### PR TITLE
feat(auth): add CLAUDE_CODE_OAUTH_TOKEN support with ALLOWED_OWNERS allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,22 @@ GITHUB_WEBHOOK_SECRET=
 # AI provider: "anthropic" (default) or "bedrock"
 CLAUDE_PROVIDER=anthropic
 
-# Claude API (required when CLAUDE_PROVIDER=anthropic)
+# Claude API credentials (when CLAUDE_PROVIDER=anthropic) — choose ONE:
+#
+# Option 1: Console API key (pay-as-you-go billing).
+#   Safe for multi-tenant deployments.
+#   Get one at https://console.anthropic.com
 ANTHROPIC_API_KEY=
+#
+# Option 2: Max/Pro subscription OAuth token (consumer billing).
+#   Generate locally with: `claude setup-token`
+#   Copy the printed sk-ant-oat... value below.
+#
+#   IMPORTANT: Only use Option 2 with ALLOWED_OWNERS set to a single-tenant
+#   value (e.g. your own GitHub login). Serving other users' repos from your
+#   subscription quota violates the Claude Agent SDK Note at
+#   https://code.claude.com/docs/en/agent-sdk/overview
+# CLAUDE_CODE_OAUTH_TOKEN=
 
 # Model override. Required when CLAUDE_PROVIDER=bedrock (Bedrock uses a different model ID
 # format than the Anthropic API). Optional for anthropic (SDK uses its own default).
@@ -43,6 +57,18 @@ CLAUDE_MODEL=
 
 # Context7 (optional - for up-to-date library docs, free key at context7.com/dashboard)
 CONTEXT7_API_KEY=
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Authorization (optional — restricts who can trigger the bot)
+# ──────────────────────────────────────────────────────────────────────────────
+# Comma-separated list of GitHub owner logins. If set, the bot only responds to
+# events from repositories owned by one of these accounts. Case-insensitive.
+# Leave empty/unset for no restriction (any installation of the GitHub App can
+# trigger execution — only use this with ANTHROPIC_API_KEY or Bedrock).
+#
+# REQUIRED when using CLAUDE_CODE_OAUTH_TOKEN — see the note in the
+# Anthropic section above for why.
+# ALLOWED_OWNERS=chrisleekr
 
 # Repo checkout
 CLONE_BASE_DIR=/tmp/bot-workspaces

--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,10 @@ ANTHROPIC_API_KEY=
 #   Generate locally with: `claude setup-token`
 #   Copy the printed sk-ant-oat... value below.
 #
-#   IMPORTANT: Only use Option 2 with ALLOWED_OWNERS set to a single-tenant
-#   value (e.g. your own GitHub login). Serving other users' repos from your
-#   subscription quota violates the Claude Agent SDK Note at
-#   https://code.claude.com/docs/en/agent-sdk/overview
+#   REQUIRED: ALLOWED_OWNERS must be set to a single-tenant value (e.g. your
+#   own GitHub login) — startup will fail with a ToS guard error otherwise.
+#   Serving other users' repos from your subscription quota violates the
+#   Claude Agent SDK Note at https://code.claude.com/docs/en/agent-sdk/overview
 # CLAUDE_CODE_OAUTH_TOKEN=
 
 # Model override. Required when CLAUDE_PROVIDER=bedrock (Bedrock uses a different model ID
@@ -66,8 +66,9 @@ CONTEXT7_API_KEY=
 # Leave empty/unset for no restriction (any installation of the GitHub App can
 # trigger execution — only use this with ANTHROPIC_API_KEY or Bedrock).
 #
-# REQUIRED when using CLAUDE_CODE_OAUTH_TOKEN — see the note in the
-# Anthropic section above for why.
+# REQUIRED when using CLAUDE_CODE_OAUTH_TOKEN — enforced at startup; a missing
+# allowlist will throw a ToS guard error. See the note in the Anthropic section
+# above for why.
 # ALLOWED_OWNERS=chrisleekr
 
 # Repo checkout

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ permissions:
   security-events: write # Required: upload Trivy SARIF to GitHub Security tab
 
 env:
-  BUN_VERSION: "1.3.8"
+  BUN_VERSION: "1.3.12"
 
 jobs:
   docker:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,6 +162,12 @@ jobs:
           # the spec's edge-case statement that exploitable vulnerabilities
           # with available fixes should be blocking.
           exit-code: "1"
+          # Time-boxed CVE allowlist. The action does NOT auto-discover a
+          # .trivyignore(.yaml) at repo root — it must be passed explicitly
+          # via this input. Every entry in the file must carry a statement
+          # and an expired_at forcing re-review. See .trivyignore.yaml and
+          # https://trivy.dev/latest/docs/configuration/filtering/#trivyignoreyaml
+          trivyignores: ".trivyignore.yaml"
 
       - name: Upload Trivy SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,75 @@
+# Trivy ignore policy for github-app-playground.
+#
+# Format reference (YAML schema):
+#   https://trivy.dev/latest/docs/configuration/filtering/#trivyignoreyaml
+#
+# Wired into CI via the `trivyignores:` input on aquasecurity/trivy-action
+# (see .github/workflows/docker-build.yml). The action does NOT auto-discover
+# this file — it is only read when passed explicitly. See:
+#   https://github.com/aquasecurity/trivy-action/blob/v0.35.0/action.yaml
+#   https://github.com/aquasecurity/trivy-action/blob/v0.35.0/entrypoint.sh
+#
+# POLICY: every entry MUST have a `statement` explaining reachability and an
+# `expired_at` forcing a re-review. No permanent ignores. Scope each entry
+# with `paths:` so the ignore only masks the exact file Trivy flagged, not
+# future occurrences of the same CVE in a different location (e.g. if the
+# Claude Code CLI later ships its own vulnerable copy).
+
+vulnerabilities:
+  # HIGH — picomatch ReDoS via crafted extglob patterns (`+(...)` / `*(...)`).
+  # Present at: /usr/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch@4.0.3
+  # Shipped by npm's bundled tinyglobby@0.2.15 dep. Fix floor: picomatch@4.0.4.
+  # npm@11 latest (11.12.1 as of 2026-04-12) has NOT yet released a version
+  # that rebundles tinyglobby with the patched picomatch — verified by
+  # inspecting the npm-11.12.1.tgz tarball on 2026-04-12.
+  #
+  # Reachability: the npm CLI is not invoked by the runtime ENTRYPOINT
+  # (`bun run dist/app.js`). It runs only during image build under
+  # developer-controlled inputs (e.g. `npm install -g @anthropic-ai/claude-code`).
+  # The Claude Code CLI subprocess spawned at runtime loads its own bundled
+  # JavaScript directly via node and does not re-enter the npm CLI; if it
+  # needs picomatch it resolves to a different path outside `usr/lib/node_modules/npm/`,
+  # so this path-scoped ignore does not mask that copy.
+  #
+  # Action: re-evaluate on 2026-05-12. If npm@11 has released an unbundled
+  # tinyglobby by then, delete this entry and let the CI gate reassert.
+  - id: CVE-2026-33671
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json"
+    statement: >-
+      npm-bundled picomatch@4.0.3. npm@11.12.1 has not yet re-released
+      tinyglobby with the 4.0.4 fix. Not reachable from the runtime entrypoint;
+      npm CLI only runs at image build time under trusted inputs.
+    expired_at: 2026-05-12
+
+  # MEDIUM — picomatch method injection via POSIX bracket expressions
+  # (e.g. `[[:constructor:]]`). Same package, same file, same reachability
+  # analysis as CVE-2026-33671 above.
+  #
+  # Listed here because CI currently blocks on MEDIUMs too: the trivy-action
+  # entrypoint unsets TRIVY_SEVERITY when `format: sarif` is set without
+  # `limit-severities-for-sarif: true`, so the workflow's `severity: "CRITICAL,HIGH"`
+  # input is silently ignored at the exit-code stage. If that workflow bug is
+  # fixed (set `limit-severities-for-sarif: true` in docker-build.yml), this
+  # entry becomes redundant and can be removed.
+  # Reference: https://github.com/aquasecurity/trivy-action/blob/v0.35.0/entrypoint.sh
+  - id: CVE-2026-33672
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json"
+    statement: >-
+      Same npm-bundled picomatch as CVE-2026-33671. Not reachable from the
+      runtime entrypoint.
+    expired_at: 2026-05-12
+
+  # MEDIUM — brace-expansion DoS via zero step value (e.g. `{1..2..0}`).
+  # Present at: /usr/lib/node_modules/npm/node_modules/brace-expansion@5.0.4
+  # Bundled transitively by npm via minimatch. Fix floor: 5.0.5 / 3.0.2 /
+  # 2.0.3 / 1.1.13; npm@11.12.1 still ships 5.0.4. Same reachability analysis
+  # as the picomatch entries above — npm CLI is not on the runtime path.
+  # Same note re: trivy-action SARIF severity behavior (see CVE-2026-33672).
+  - id: CVE-2026-33750
+    paths:
+      - "usr/lib/node_modules/npm/node_modules/brace-expansion/package.json"
+    statement: >-
+      npm-bundled brace-expansion@5.0.4. Not reachable from the runtime entrypoint.
+    expired_at: 2026-05-12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@ Single HTTP server (`src/app.ts`) using `octokit` App class. Webhook events arri
 - **Repo checkout**: Each request clones the repo to a unique temp dir. Claude operates on local files via `cwd`.
 - **MCP servers**: Comment updates, inline reviews, and Context7 for library docs. Git changes are made via git CLI (Bash tool) on the cloned repo.
 
+## Authentication options
+
+The runtime bot in `src/` supports three authentication modes (see `src/config.ts`):
+
+1. **`ANTHROPIC_API_KEY`** — Console pay-as-you-go. Safe for multi-tenant deployments.
+2. **`CLAUDE_CODE_OAUTH_TOKEN`** — Max/Pro subscription OAuth token (`sk-ant-oat...`, generated via `claude setup-token`). **Requires `ALLOWED_OWNERS`** to be set to a single-tenant value, because the [Agent SDK Note](https://code.claude.com/docs/en/agent-sdk/overview) prohibits serving other users' repos from a personal subscription quota. The token is forwarded to the Claude CLI subprocess via `buildProviderEnv()` in `src/core/executor.ts`; the CLI's own [auth precedence chain](https://code.claude.com/docs/en/authentication#authentication-precedence) picks between credentials if multiple are set.
+3. **AWS Bedrock** — full credential chain via `CLAUDE_PROVIDER=bedrock` + `AWS_REGION` + `CLAUDE_MODEL` (Bedrock model ID format). Credential resolution handled by the AWS SDK inside the subprocess.
+
+The scheduled research workflow in `.github/workflows/research.yml` also uses `CLAUDE_CODE_OAUTH_TOKEN`, but via `anthropics/claude-code-action@v1` — that path is separately sanctioned for CI and is not subject to the `ALLOWED_OWNERS` requirement.
+
 ## Code Conventions
 
 - Runtime is Bun (app) + Node.js (Claude Code CLI).

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Per Claude Agent SDK hosting guide: https://platform.claude.com/docs/en/agent-sdk/hosting
 # Pattern adapted from mcp-server-playground
 
-FROM oven/bun:1.3.8 AS base
+FROM oven/bun:1.3.12 AS base
 WORKDIR /app
 
 # Node.js required by Claude Code CLI; git required for repo checkout
@@ -25,10 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   apt-get install -y --no-install-recommends nodejs && \
   rm -rf /var/lib/apt/lists/*
 
+# Base-image CVE patches: oven/bun:1.3.12 bakes in openssl 3.5.4-1~deb13u2
+# (Trivy flags CVE-2026-28390 HIGH, fix in 3.5.5). The apt-get install
+# above only touches *requested* packages — it does not upgrade libs
+# already baked into the base layer — so we force a targeted upgrade here.
+# Targeted rather than dist-upgrade keeps rebuilds reproducible; the CI
+# Trivy gate catches any new flagged package once the vuln DB updates.
+RUN apt-get update && \
+  apt-get upgrade -y --no-install-recommends \
+    openssl libssl3t64 openssl-provider-legacy && \
+  rm -rf /var/lib/apt/lists/*
+
 # Claude Code CLI required by @anthropic-ai/claude-agent-sdk
 # Pinned to a specific version for reproducible builds.
 # See: https://www.npmjs.com/package/@anthropic-ai/claude-code
-RUN npm install -g @anthropic-ai/claude-code@2.1.45
+RUN npm install -g @anthropic-ai/claude-code@2.1.101
 
 # Stage 1: Build — install all deps and bundle the main app
 FROM base AS development

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,14 @@ RUN apt-get update && \
     openssl libssl3t64 openssl-provider-legacy && \
   rm -rf /var/lib/apt/lists/*
 
+# NodeSource node_20.x bundles npm 10.x, whose vendored tar/minimatch/
+# glob/cross-spawn/brace-expansion have HIGH CVEs that Trivy blocks on.
+# npm 11.x ships patched vendored deps and replaces them in
+# /usr/lib/node_modules/npm/ in place. Tracks the 11.x major (unlike the
+# exact pins elsewhere in this file) so future vendored-dep patches land
+# automatically; the CI Trivy gate catches any regression.
+RUN npm install -g npm@11
+
 # Claude Code CLI required by @anthropic-ai/claude-agent-sdk
 # Pinned to a specific version for reproducible builds.
 # See: https://www.npmjs.com/package/@anthropic-ai/claude-code

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@chrisleekr/github-app-playground",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.97",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.101",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/webhooks": "13.9.1",
         "@octokit/webhooks-types": "^7.6.1",
@@ -43,7 +43,7 @@
     "yaml": "2.8.3",
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.97", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.101", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-LwDQ6ueXnd1EVJbP0XICUO5en4FYJ8Cv/98/+RofoRr4l1cdAdYn1/n758DrTeGkMvTqb4lbdyMNs0RnT7mtoA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.86.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Q32GUFCVMmTJrVQC4bQOG2mA8rGNuYWJP8ODufxl3g5Awy1VjY5wy0Xm+mC++i5rBkZMvxhzOR9MNTW7IvIAmw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/chrisleekr/github-app-playground#readme",
   "engines": {
-    "bun": ">=1.3.8"
+    "bun": ">=1.3.12"
   },
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.12",
   "scripts": {
     "prepublishOnly": "bun run clean && NODE_ENV=production bun run build",
     "clean": "rm -rf dist",
@@ -60,7 +60,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.97",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.101",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/webhooks": "13.9.1",
     "@octokit/webhooks-types": "^7.6.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,14 @@ const configSchema = z
     // AI provider selection: "anthropic" (default) or "bedrock"
     provider: z.enum(["anthropic", "bedrock"]).default("anthropic"),
 
-    // Claude API — required when provider=anthropic
+    // Claude API credentials — when provider=anthropic, exactly one of these is required.
+    // Either Console API key (pay-as-you-go) or Max/Pro subscription OAuth token
+    // (generated via `claude setup-token`, sk-ant-oat... prefix).
+    // The Claude CLI subprocess picks between them via its own auth precedence chain
+    // (ANTHROPIC_API_KEY at position 3 beats CLAUDE_CODE_OAUTH_TOKEN at position 5).
+    // See https://code.claude.com/docs/en/authentication#authentication-precedence
     anthropicApiKey: z.string().optional(),
+    claudeCodeOauthToken: z.string().optional(),
 
     // Model override — required when provider=bedrock (Bedrock uses different model ID format),
     // optional for anthropic (SDK uses its default)
@@ -61,14 +67,41 @@ const configSchema = z
     // local node_modules dependency, because the SDK defaults to {cwd}/dist/cli.js.
     // Set via CLAUDE_CODE_PATH env var (e.g. /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js).
     claudeCodePath: z.string().optional(),
+
+    // Owner allowlist — when set, the bot only processes events from repositories
+    // owned by one of these GitHub accounts (case-insensitive). Empty/unset means
+    // no restriction. REQUIRED for single-tenant deployments using
+    // CLAUDE_CODE_OAUTH_TOKEN, because the Agent SDK Note prohibits serving other
+    // users' repos from a personal subscription quota.
+    // See https://code.claude.com/docs/en/agent-sdk/overview
+    // Set via ALLOWED_OWNERS env var (comma-separated list, e.g. "chrisleekr,acme").
+    allowedOwners: z
+      .string()
+      .optional()
+      .transform((v): string[] | undefined => {
+        if (v === undefined || v === "") return undefined;
+        const parsed = v
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        return parsed.length === 0 ? undefined : parsed;
+      }),
   })
   .superRefine((data, ctx) => {
     if (data.provider === "anthropic") {
-      // Direct Anthropic API requires a non-empty API key
-      if (data.anthropicApiKey === undefined || data.anthropicApiKey === "") {
+      // Direct Anthropic API requires a non-empty credential:
+      //   - ANTHROPIC_API_KEY (Console pay-as-you-go), OR
+      //   - CLAUDE_CODE_OAUTH_TOKEN (Max/Pro subscription, sk-ant-oat... prefix)
+      // If both are set, the Claude CLI's own auth precedence chain picks one
+      // (API key wins). Rejecting "both set" would duplicate CLI-side logic.
+      const hasApiKey = data.anthropicApiKey !== undefined && data.anthropicApiKey !== "";
+      const hasOauthToken =
+        data.claudeCodeOauthToken !== undefined && data.claudeCodeOauthToken !== "";
+      if (!hasApiKey && !hasOauthToken) {
         ctx.addIssue({
           code: "custom",
-          message: "ANTHROPIC_API_KEY is required when CLAUDE_PROVIDER=anthropic",
+          message:
+            "When CLAUDE_PROVIDER=anthropic, either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required.",
           path: ["anthropicApiKey"],
         });
       }
@@ -115,6 +148,7 @@ function loadConfig(): Config {
     webhookSecret: process.env["GITHUB_WEBHOOK_SECRET"],
     provider: process.env["CLAUDE_PROVIDER"],
     anthropicApiKey: process.env["ANTHROPIC_API_KEY"],
+    claudeCodeOauthToken: process.env["CLAUDE_CODE_OAUTH_TOKEN"],
     model: process.env["CLAUDE_MODEL"],
     awsRegion: process.env["AWS_REGION"],
     awsProfile: process.env["AWS_PROFILE"],
@@ -133,6 +167,7 @@ function loadConfig(): Config {
     agentTimeoutMs: process.env["AGENT_TIMEOUT_MS"],
     cloneDepth: process.env["CLONE_DEPTH"],
     claudeCodePath: process.env["CLAUDE_CODE_PATH"],
+    allowedOwners: process.env["ALLOWED_OWNERS"],
   });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,11 +14,11 @@ const configSchema = z
     // AI provider selection: "anthropic" (default) or "bedrock"
     provider: z.enum(["anthropic", "bedrock"]).default("anthropic"),
 
-    // Claude API credentials — when provider=anthropic, exactly one of these is required.
+    // Claude API credentials — when provider=anthropic, at least one of these is required
+    // (both may be set; the Claude CLI's own auth precedence chain picks one at runtime:
+    // ANTHROPIC_API_KEY at position 3 beats CLAUDE_CODE_OAUTH_TOKEN at position 5).
     // Either Console API key (pay-as-you-go) or Max/Pro subscription OAuth token
     // (generated via `claude setup-token`, sk-ant-oat... prefix).
-    // The Claude CLI subprocess picks between them via its own auth precedence chain
-    // (ANTHROPIC_API_KEY at position 3 beats CLAUDE_CODE_OAUTH_TOKEN at position 5).
     // See https://code.claude.com/docs/en/authentication#authentication-precedence
     anthropicApiKey: z.string().optional(),
     claudeCodeOauthToken: z.string().optional(),
@@ -94,9 +94,10 @@ const configSchema = z
       //   - CLAUDE_CODE_OAUTH_TOKEN (Max/Pro subscription, sk-ant-oat... prefix)
       // If both are set, the Claude CLI's own auth precedence chain picks one
       // (API key wins). Rejecting "both set" would duplicate CLI-side logic.
-      const hasApiKey = data.anthropicApiKey !== undefined && data.anthropicApiKey !== "";
-      const hasOauthToken =
-        data.claudeCodeOauthToken !== undefined && data.claudeCodeOauthToken !== "";
+      // `.trim()` guards against whitespace-only values pasted into .env files —
+      // those would otherwise pass startup and fail later on the first API call.
+      const hasApiKey = (data.anthropicApiKey?.trim().length ?? 0) > 0;
+      const hasOauthToken = (data.claudeCodeOauthToken?.trim().length ?? 0) > 0;
       if (!hasApiKey && !hasOauthToken) {
         ctx.addIssue({
           code: "custom",
@@ -138,11 +139,35 @@ export type Config = z.infer<typeof configSchema>;
 export { configSchema };
 
 /**
+ * ToS guard: CLAUDE_CODE_OAUTH_TOKEN is a personal Max/Pro subscription credential.
+ * The Agent SDK Note prohibits serving other users' repos from that quota, so OAuth
+ * mode requires an owner allowlist as a hard startup precondition — not just a
+ * documentation warning. API-key deployments remain unrestricted (in-policy for
+ * pay-as-you-go). See https://code.claude.com/docs/en/agent-sdk/overview
+ *
+ * Lives outside `.superRefine` so the schema stays lean and the policy rule is
+ * expressed as one clear assertion — exported so tests can exercise it directly
+ * against a parsed `Config` without round-tripping env vars.
+ */
+export function assertOauthRequiresAllowlist(cfg: Config): void {
+  if (
+    cfg.provider === "anthropic" &&
+    (cfg.claudeCodeOauthToken?.trim().length ?? 0) > 0 &&
+    cfg.allowedOwners === undefined
+  ) {
+    throw new Error(
+      "ALLOWED_OWNERS is required when CLAUDE_CODE_OAUTH_TOKEN is set. " +
+        "See https://code.claude.com/docs/en/agent-sdk/overview",
+    );
+  }
+}
+
+/**
  * Parse and validate config from environment variables.
  * Throws on invalid/missing required values -- fail fast at startup.
  */
 function loadConfig(): Config {
-  return configSchema.parse({
+  const cfg = configSchema.parse({
     appId: process.env["GITHUB_APP_ID"],
     privateKey: process.env["GITHUB_APP_PRIVATE_KEY"],
     webhookSecret: process.env["GITHUB_WEBHOOK_SECRET"],
@@ -169,6 +194,8 @@ function loadConfig(): Config {
     claudeCodePath: process.env["CLAUDE_CODE_PATH"],
     allowedOwners: process.env["ALLOWED_OWNERS"],
   });
+  assertOauthRequiresAllowlist(cfg);
+  return cfg;
 }
 
 export const config = loadConfig();

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -21,6 +21,12 @@ function isResultMessage(msg: unknown): msg is SDKResultMessage {
  * For Bedrock, injects CLAUDE_CODE_USE_BEDROCK=1 which the CLI binary reads
  * to switch from the Anthropic API to the Bedrock runtime endpoint.
  * We avoid mutating process.env directly so the main process stays unaffected.
+ *
+ * Anthropic credentials (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, etc.) are
+ * forwarded as part of the `...process.env` spread — no explicit handling here.
+ * The Claude CLI subprocess picks between them via its own documented auth
+ * precedence chain (API key at position 3 beats OAuth token at position 5).
+ * See https://code.claude.com/docs/en/authentication#authentication-precedence
  */
 function buildProviderEnv(): Record<string, string | undefined> {
   if (config.provider === "bedrock") {

--- a/src/webhook/authorize.ts
+++ b/src/webhook/authorize.ts
@@ -1,0 +1,41 @@
+import { config } from "../config";
+import type { Logger } from "../logger";
+
+/**
+ * Result of an authorization check.
+ * Discriminated union so callers must branch on `allowed` before reading `reason`.
+ */
+export type AuthorizeResult = { allowed: true } | { allowed: false; reason: string };
+
+/**
+ * Check whether a repository owner is permitted to trigger the bot.
+ *
+ * Tenancy boundary enforced at the `repository.owner` level (case-insensitive,
+ * matching GitHub's own identity semantics: `ChrisLeeKR` === `chrisleekr`).
+ *
+ * REQUIRED when using CLAUDE_CODE_OAUTH_TOKEN. The Claude Agent SDK Note
+ * prohibits serving other users' repos from a personal subscription quota:
+ * https://code.claude.com/docs/en/agent-sdk/overview
+ *
+ * Empty/unset allowlist means "no restriction" — preserves open behavior for
+ * multi-tenant deployments that use ANTHROPIC_API_KEY or AWS Bedrock (both are
+ * in-policy with their respective billing models).
+ */
+export function isOwnerAllowed(owner: string, log: Logger): AuthorizeResult {
+  if (config.allowedOwners === undefined) {
+    return { allowed: true };
+  }
+  const normalized = owner.toLowerCase();
+  const match = config.allowedOwners.some((o) => o.toLowerCase() === normalized);
+  if (match) {
+    return { allowed: true };
+  }
+  log.warn(
+    { owner, allowedOwners: config.allowedOwners },
+    "rejected: owner not in ALLOWED_OWNERS allowlist",
+  );
+  return {
+    allowed: false,
+    reason: `Owner "${owner}" is not in the configured allowlist.`,
+  };
+}

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -9,8 +9,9 @@ import {
   isAlreadyProcessed,
 } from "../core/tracking-comment";
 import { resolveMcpServers } from "../mcp/registry";
-import type { BotContext, EnrichedBotContext } from "../types";
+import type { BotContext, EnrichedBotContext, ExecutionResult } from "../types";
 import { retryWithBackoff } from "../utils/retry";
+import { isOwnerAllowed } from "./authorize";
 
 /**
  * In-memory idempotency guard using X-GitHub-Delivery header.
@@ -58,6 +59,31 @@ const cleanupInterval = setInterval(
   IDEMPOTENCY_TTL_MS,
 );
 cleanupInterval.unref();
+
+/**
+ * Build the options object passed to `finalizeTrackingComment` on success.
+ *
+ * Exists because `exactOptionalPropertyTypes` forbids assigning `undefined` to
+ * optional properties — we have to omit them instead. Extracted so the two
+ * conditional branches don't count against processRequest's cyclomatic
+ * complexity budget.
+ */
+function buildFinalOpts(result: ExecutionResult): {
+  success: boolean;
+  durationMs?: number;
+  costUsd?: number;
+} {
+  const opts: { success: boolean; durationMs?: number; costUsd?: number } = {
+    success: result.success,
+  };
+  if (result.durationMs !== undefined) {
+    opts.durationMs = result.durationMs;
+  }
+  if (result.costUsd !== undefined) {
+    opts.costUsd = result.costUsd;
+  }
+  return opts;
+}
 
 /**
  * Main async processing pipeline.
@@ -117,6 +143,20 @@ export async function processRequest(ctx: BotContext): Promise<void> {
     }
     return;
   }
+
+  // Owner allowlist check: silently skip events from repositories whose owner
+  // is not in ALLOWED_OWNERS. No rejection comment is posted, because that
+  // would leak the bot's existence and allowlist behavior to anyone who can
+  // install the GitHub App. Operators see rejections via logger.warn.
+  //
+  // This is a ToS prerequisite when running on CLAUDE_CODE_OAUTH_TOKEN:
+  // https://code.claude.com/docs/en/agent-sdk/overview
+  const authResult = isOwnerAllowed(ctx.owner, ctx.log);
+  if (!authResult.allowed) {
+    ctx.log.info({ reason: authResult.reason }, "skipping request — owner not allowlisted");
+    return;
+  }
+
   activeCount++;
 
   let trackingCommentId: number | undefined;
@@ -175,16 +215,7 @@ export async function processRequest(ctx: BotContext): Promise<void> {
       const result = await executeAgent(enrichedCtx, prompt, mcpServers, workDir, allowedTools);
 
       // Step 9: Finalize tracking comment with results
-      // Build opts conditionally (exactOptionalPropertyTypes forbids explicit undefined)
-      const finalOpts: { success: boolean; durationMs?: number; costUsd?: number } = {
-        success: result.success,
-      };
-      if (result.durationMs !== undefined) {
-        finalOpts.durationMs = result.durationMs;
-      }
-      if (result.costUsd !== undefined) {
-        finalOpts.costUsd = result.costUsd;
-      }
+      const finalOpts = buildFinalOpts(result);
       await retryWithBackoff(
         () => finalizeTrackingComment(enrichedCtx, resolvedTrackingCommentId, finalOpts),
         {

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -122,6 +122,20 @@ export async function processRequest(ctx: BotContext): Promise<void> {
     return;
   }
 
+  // Owner allowlist check — MUST run before any GitHub side effects (including
+  // the capacity comment posted by the concurrency guard below). Otherwise a
+  // non-allowlisted repo could receive the "at capacity" comment and thereby
+  // learn the bot exists, defeating the "silent skip" guarantee.
+  //
+  // No rejection comment is posted for non-allowlisted owners — operators see
+  // rejections via logger.warn. This is a ToS prerequisite when running on
+  // CLAUDE_CODE_OAUTH_TOKEN: https://code.claude.com/docs/en/agent-sdk/overview
+  const authResult = isOwnerAllowed(ctx.owner, ctx.log);
+  if (!authResult.allowed) {
+    ctx.log.info({ reason: authResult.reason }, "skipping request — owner not allowlisted");
+    return;
+  }
+
   // Concurrency guard: reject when too many Claude executions are active to
   // prevent Anthropic API budget exhaustion and pod resource saturation.
   if (activeCount >= config.maxConcurrentRequests) {
@@ -141,19 +155,6 @@ export async function processRequest(ctx: BotContext): Promise<void> {
     } catch (commentError) {
       ctx.log.error({ err: commentError }, "Failed to post capacity comment");
     }
-    return;
-  }
-
-  // Owner allowlist check: silently skip events from repositories whose owner
-  // is not in ALLOWED_OWNERS. No rejection comment is posted, because that
-  // would leak the bot's existence and allowlist behavior to anyone who can
-  // install the GitHub App. Operators see rejections via logger.warn.
-  //
-  // This is a ToS prerequisite when running on CLAUDE_CODE_OAUTH_TOKEN:
-  // https://code.claude.com/docs/en/agent-sdk/overview
-  const authResult = isOwnerAllowed(ctx.owner, ctx.log);
-  if (!authResult.allowed) {
-    ctx.log.info({ reason: authResult.reason }, "skipping request — owner not allowlisted");
     return;
   }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -34,16 +34,52 @@ describe("configSchema — Anthropic provider", () => {
     }
   });
 
-  it("rejects when ANTHROPIC_API_KEY is missing", () => {
+  it("parses successfully with CLAUDE_CODE_OAUTH_TOKEN and no ANTHROPIC_API_KEY", () => {
+    // Max/Pro subscription authentication via `claude setup-token`.
+    // The Claude CLI picks up CLAUDE_CODE_OAUTH_TOKEN at auth precedence position 5.
     const result = configSchema.safeParse({
       ...BASE,
       provider: "anthropic",
-      // anthropicApiKey intentionally omitted
+      claudeCodeOauthToken: "sk-ant-oat-test",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.claudeCodeOauthToken).toBe("sk-ant-oat-test");
+      expect(result.data.anthropicApiKey).toBeUndefined();
+    }
+  });
+
+  it("parses successfully with BOTH ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN set", () => {
+    // Schema does not reject when both credentials are provided — the Claude CLI's
+    // own precedence chain decides which to use (API key wins). Re-implementing
+    // that choice here would duplicate upstream behavior and risk drift.
+    const result = configSchema.safeParse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.anthropicApiKey).toBe("sk-ant-test");
+      expect(result.data.claudeCodeOauthToken).toBe("sk-ant-oat-test");
+    }
+  });
+
+  it("rejects when neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is provided", () => {
+    const result = configSchema.safeParse({
+      ...BASE,
+      provider: "anthropic",
+      // both credentials intentionally omitted
     });
     expect(result.success).toBe(false);
     if (!result.success) {
       const paths = result.error.issues.map((i) => i.path.join("."));
       expect(paths).toContain("anthropicApiKey");
+      // Error message must mention BOTH env var names so users can fix it.
+      const messages = result.error.issues.map((i) => i.message).join(" ");
+      expect(messages).toContain("ANTHROPIC_API_KEY");
+      expect(messages).toContain("CLAUDE_CODE_OAUTH_TOKEN");
     }
   });
 });
@@ -137,6 +173,62 @@ describe("configSchema — Bedrock provider", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.awsBearerTokenBedrock).toBe("oidc-token-example");
+    }
+  });
+});
+
+describe("configSchema — allowedOwners parsing", () => {
+  // These cases exercise the ALLOWED_OWNERS env var transform. Empty/unset maps
+  // to `undefined` ("no restriction"), preserving backward compatibility with
+  // deployments that use ANTHROPIC_API_KEY (which is multi-tenant safe).
+  const ANTHROPIC_BASE = {
+    ...BASE,
+    provider: "anthropic" as const,
+    anthropicApiKey: "sk-ant-test",
+  };
+
+  it("yields undefined when ALLOWED_OWNERS is absent", () => {
+    const result = configSchema.safeParse(ANTHROPIC_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowedOwners).toBeUndefined();
+    }
+  });
+
+  it("yields undefined when ALLOWED_OWNERS is an empty string", () => {
+    const result = configSchema.safeParse({ ...ANTHROPIC_BASE, allowedOwners: "" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowedOwners).toBeUndefined();
+    }
+  });
+
+  it("parses a single owner", () => {
+    const result = configSchema.safeParse({ ...ANTHROPIC_BASE, allowedOwners: "user1" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowedOwners).toEqual(["user1"]);
+    }
+  });
+
+  it("parses multiple owners, trimming whitespace and dropping empty entries", () => {
+    // Messy input mirrors what users actually write in .env files.
+    const result = configSchema.safeParse({
+      ...ANTHROPIC_BASE,
+      allowedOwners: "user1, user2 ,user3, , ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowedOwners).toEqual(["user1", "user2", "user3"]);
+    }
+  });
+
+  it("yields undefined when ALLOWED_OWNERS contains only whitespace/commas", () => {
+    // After trim + filter(Boolean), no entries remain → treat as "no restriction".
+    const result = configSchema.safeParse({ ...ANTHROPIC_BASE, allowedOwners: " , , " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowedOwners).toBeUndefined();
     }
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { configSchema } from "../src/config";
+import { assertOauthRequiresAllowlist, type Config, configSchema } from "../src/config";
 
 // Minimal required GitHub App fields shared by all test cases
 const BASE = {
@@ -80,6 +80,22 @@ describe("configSchema — Anthropic provider", () => {
       const messages = result.error.issues.map((i) => i.message).join(" ");
       expect(messages).toContain("ANTHROPIC_API_KEY");
       expect(messages).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    }
+  });
+
+  it("rejects when both credentials are whitespace-only strings", () => {
+    // `"   "` would previously slip past `!== ""` and produce a "valid" config
+    // that fails at first API call. `.trim()` in the schema guards against this.
+    const result = configSchema.safeParse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "   ",
+      claudeCodeOauthToken: "   ",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("anthropicApiKey");
     }
   });
 });
@@ -230,5 +246,113 @@ describe("configSchema — allowedOwners parsing", () => {
     if (result.success) {
       expect(result.data.allowedOwners).toBeUndefined();
     }
+  });
+});
+
+describe("assertOauthRequiresAllowlist", () => {
+  // ToS guard: CLAUDE_CODE_OAUTH_TOKEN is a personal Max/Pro subscription credential.
+  // The Agent SDK Note prohibits serving other users' repos from that quota, so
+  // OAuth mode requires an owner allowlist as a hard startup precondition. These
+  // tests exercise the exported helper directly against a parsed `Config` so the
+  // rule can be verified without round-tripping env vars through loadConfig().
+  function parse(input: Record<string, unknown>): Config {
+    const result = configSchema.parse(input);
+    return result;
+  }
+
+  it("throws when OAuth token is set without ALLOWED_OWNERS (the ToS gap)", () => {
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      // allowedOwners intentionally omitted
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).toThrow(/ALLOWED_OWNERS is required/);
+  });
+
+  it("throws when OAuth token is set and ALLOWED_OWNERS is whitespace-only", () => {
+    // The zod transform treats whitespace-only as `undefined`, so this exercises
+    // the same branch but via a different user mistake (setting ALLOWED_OWNERS="   ").
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      allowedOwners: "   ",
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).toThrow(/ALLOWED_OWNERS is required/);
+  });
+
+  it("allows OAuth token with a non-empty ALLOWED_OWNERS (single-tenant in-policy)", () => {
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      allowedOwners: "chrisleekr",
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).not.toThrow();
+  });
+
+  it("allows API-key-only deployments with no ALLOWED_OWNERS (multi-tenant in-policy)", () => {
+    // Pay-as-you-go API key has its own billing boundary; the ToS guard only
+    // applies to subscription OAuth tokens. This must remain unrestricted.
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).not.toThrow();
+  });
+
+  it("allows OAuth token + API key together when ALLOWED_OWNERS is set", () => {
+    // If both credentials are set, the CLI precedence picks API key at runtime.
+    // The assertion still requires the allowlist because OAuth is *present* —
+    // defense-in-depth against upstream precedence changes.
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      allowedOwners: "chrisleekr",
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).not.toThrow();
+  });
+
+  it("throws when OAuth + API key are BOTH set but ALLOWED_OWNERS is missing", () => {
+    // Defense-in-depth: presence of OAuth triggers the rule regardless of which
+    // credential the CLI ultimately uses at runtime.
+    const cfg = parse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).toThrow(/ALLOWED_OWNERS is required/);
+  });
+
+  it("does not apply to Bedrock deployments", () => {
+    // OAuth token is Anthropic-only; Bedrock has its own AWS credential chain
+    // and is not subject to the Agent SDK subscription Note.
+    const cfg = parse({
+      ...BASE,
+      provider: "bedrock",
+      awsRegion: "us-east-1",
+      model: "us.anthropic.claude-sonnet-4-6",
+      // No allowlist required for Bedrock.
+    });
+    expect(() => {
+      assertOauthRequiresAllowlist(cfg);
+    }).not.toThrow();
   });
 });

--- a/test/preload.ts
+++ b/test/preload.ts
@@ -15,6 +15,14 @@ process.env.TZ = "UTC";
 // that Bun auto-loads from a local .env file (e.g. "bedrock" for local dev).
 process.env["CLAUDE_PROVIDER"] = "anthropic";
 
+// Clear owner-allowlist and OAuth vars so a developer's local .env can't leak
+// into the config singleton and skew tests. Individual tests that need to
+// exercise allowlist or OAuth behavior must set these explicitly (typically
+// via mutation of the config singleton with save/restore in try/finally),
+// never by relying on ambient process.env.
+delete process.env["ALLOWED_OWNERS"];
+delete process.env["CLAUDE_CODE_OAUTH_TOKEN"];
+
 // Helper: set env var to a fallback when absent or empty.
 // ?? (nullish coalescing) only replaces null/undefined, not "". A local .env
 // file may contain KEY= (empty string), which Bun loads as "" into process.env.

--- a/test/webhook/authorize.test.ts
+++ b/test/webhook/authorize.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for isOwnerAllowed() in src/webhook/authorize.ts.
+ *
+ * These tests mutate `config.allowedOwners` directly (saved/restored per case)
+ * because the config singleton is initialized once at module load via preload.ts.
+ * Using `mock.module("../../src/config", ...)` would persist across all test files
+ * in the same Bun process run, poisoning other suites.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { config } from "../../src/config";
+import { isOwnerAllowed } from "../../src/webhook/authorize";
+
+/** Minimal silent logger — mirrors the pattern in test/utils/retry.test.ts */
+function makeSilentLog(): {
+  warn: ReturnType<typeof mock>;
+  error: ReturnType<typeof mock>;
+  info: ReturnType<typeof mock>;
+  debug: ReturnType<typeof mock>;
+  child: ReturnType<typeof mock>;
+} {
+  const log = {
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    info: mock(() => {}),
+    debug: mock(() => {}),
+    child: mock(function (this: unknown) {
+      return this;
+    }),
+  };
+  return log;
+}
+
+describe("isOwnerAllowed", () => {
+  // Preserve the original value so earlier tests don't leak into later suites
+  // that also read `config.allowedOwners`.
+  const originalAllowedOwners = config.allowedOwners;
+
+  afterEach(() => {
+    config.allowedOwners = originalAllowedOwners;
+  });
+
+  it("allows any owner when allowedOwners is undefined", () => {
+    config.allowedOwners = undefined;
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("chrisleekr", log as never);
+    expect(result.allowed).toBe(true);
+    expect(log.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it("allows a matching owner (exact case)", () => {
+    config.allowedOwners = ["chrisleekr"];
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("chrisleekr", log as never);
+    expect(result.allowed).toBe(true);
+    expect(log.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it("allows a matching owner (case-insensitive)", () => {
+    // GitHub owner logins are case-insensitive for identity purposes:
+    // ChrisLeeKR and chrisleekr are the same account.
+    config.allowedOwners = ["chrisleekr"];
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("ChrisLeeKR", log as never);
+    expect(result.allowed).toBe(true);
+    expect(log.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it("rejects a non-matching owner and logs a warning", () => {
+    config.allowedOwners = ["chrisleekr"];
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("someone-else", log as never);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toContain("someone-else");
+      expect(result.reason).toContain("not in the configured allowlist");
+    }
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const warnCall = log.warn.mock.calls[0];
+    expect(warnCall?.[0]).toEqual({
+      owner: "someone-else",
+      allowedOwners: ["chrisleekr"],
+    });
+    expect(warnCall?.[1]).toBe("rejected: owner not in ALLOWED_OWNERS allowlist");
+  });
+
+  it("allows any owner in a multi-entry allowlist", () => {
+    config.allowedOwners = ["user-a", "user-b"];
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("user-b", log as never);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("rejects when the owner is not in a multi-entry allowlist", () => {
+    config.allowedOwners = ["user-a", "user-b"];
+    const log = makeSilentLog();
+    const result = isOwnerAllowed("user-c", log as never);
+    expect(result.allowed).toBe(false);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/webhook/router.test.ts
+++ b/test/webhook/router.test.ts
@@ -464,6 +464,52 @@ describe("processRequest — concurrency limiting", () => {
   });
 });
 
+describe("processRequest — owner allowlist", () => {
+  it("silently skips requests when the repository owner is not in ALLOWED_OWNERS", async () => {
+    // Sets config.allowedOwners to a value that excludes the default ctx.owner="myorg".
+    // The rejection path must return BEFORE createTrackingComment, so no comment
+    // is posted to the unauthorized repo (silent skip — see router.ts comment).
+    const { config } = await import("../../src/config");
+    const originalAllowedOwners = config.allowedOwners;
+    config.allowedOwners = ["different-owner"];
+
+    try {
+      const ctx = makeCtx();
+      const createCommentSpy = ctx.octokit.rest.issues.createComment as ReturnType<typeof mock>;
+
+      await processRequest(ctx);
+
+      // No tracking comment should be created for a rejected request
+      expect(createCommentSpy).not.toHaveBeenCalled();
+      // And the agent should never be invoked
+      expect(mockExecuteAgent).not.toHaveBeenCalled();
+    } finally {
+      config.allowedOwners = originalAllowedOwners;
+    }
+  });
+
+  it("processes requests normally when the owner is in ALLOWED_OWNERS (case-insensitive)", async () => {
+    // Owner matching is case-insensitive (GitHub login identity semantics).
+    // ctx.owner defaults to "myorg"; the allowlist uses "MyOrg".
+    const { config } = await import("../../src/config");
+    const originalAllowedOwners = config.allowedOwners;
+    config.allowedOwners = ["MyOrg"];
+
+    try {
+      const ctx = makeCtx();
+      const createCommentSpy = ctx.octokit.rest.issues.createComment as ReturnType<typeof mock>;
+
+      await processRequest(ctx);
+
+      // Pipeline must run end-to-end: createTrackingComment + executeAgent.
+      expect(createCommentSpy).toHaveBeenCalled();
+      expect(mockExecuteAgent).toHaveBeenCalled();
+    } finally {
+      config.allowedOwners = originalAllowedOwners;
+    }
+  });
+});
+
 describe("cleanupStaleIdempotencyEntries", () => {
   it("removes entries older than the TTL and preserves fresh entries", async () => {
     const { cleanupStaleIdempotencyEntries } = await import("../../src/webhook/router");

--- a/test/webhook/router.test.ts
+++ b/test/webhook/router.test.ts
@@ -508,6 +508,52 @@ describe("processRequest — owner allowlist", () => {
       config.allowedOwners = originalAllowedOwners;
     }
   });
+
+  it("does not post a capacity comment when a non-allowlisted owner hits the concurrency limit", async () => {
+    // Regression test for the ordering bug: previously the concurrency guard
+    // ran BEFORE the allowlist check, so a non-allowlisted repo hitting the
+    // limit would receive an "at capacity" comment and learn the bot exists.
+    // After the fix, the allowlist check runs first — the unauthorized repo
+    // must see zero comments of any kind (silent skip).
+    const { config } = await import("../../src/config");
+    const originalLimit = config.maxConcurrentRequests;
+    const originalAllowedOwners = config.allowedOwners;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (config as any).maxConcurrentRequests = 1;
+    config.allowedOwners = ["only-allowed-org"];
+
+    // Hold request 1 open at executeAgent so activeCount stays at 1.
+    let resolveFirst: (value: { success: boolean; durationMs: number }) => void = () => undefined;
+    const firstExecution = new Promise<{ success: boolean; durationMs: number }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockExecuteAgent.mockImplementationOnce(() => firstExecution);
+
+    // ctx1 uses an allowlisted owner so it enters the pipeline and occupies
+    // the sole concurrency slot. ctx2 uses a non-allowlisted owner.
+    const ctx1 = makeCtx({ owner: "only-allowed-org" });
+    const ctx2 = makeCtx({ owner: "rejected-org" });
+    const ctx2CreateCommentSpy = ctx2.octokit.rest.issues.createComment as ReturnType<typeof mock>;
+
+    const req1 = processRequest(ctx1);
+
+    try {
+      await waitFor(() => mockExecuteAgent.mock.calls.length >= 1);
+
+      await processRequest(ctx2);
+
+      // The critical assertion: NO comment of any kind (tracking OR capacity)
+      // was posted to the non-allowlisted repo, even though activeCount was
+      // at the limit when request 2 arrived.
+      expect(ctx2CreateCommentSpy).not.toHaveBeenCalled();
+    } finally {
+      resolveFirst({ success: true, durationMs: 100 });
+      await req1;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (config as any).maxConcurrentRequests = originalLimit;
+      config.allowedOwners = originalAllowedOwners;
+    }
+  });
 });
 
 describe("cleanupStaleIdempotencyEntries", () => {


### PR DESCRIPTION
## Description                                                                                                                                                                                                
                                                                                                                                                                                                                
  Adds a third authentication mode for the runtime bot — Claude Pro/Max subscription OAuth tokens (`CLAUDE_CODE_OAUTH_TOKEN`, `sk-ant-oat…` prefix) — so a subscriber can run the bot against their subscription
   quota instead of pay-as-you-go API billing.                                                                                                                                                                  
                                                                                                                                                                                                                
  Because the [Agent SDK Note](https://code.claude.com/docs/en/agent-sdk/overview) prohibits *multi-tenant* use of subscription tokens (one subscriber serving many users), this PR also introduces a           
  **repository-owner allowlist** (`ALLOWED_OWNERS`) as a hard prerequisite for enabling OAuth mode. The allowlist is the minimum-viable tenancy boundary that keeps OAuth deployments in-policy.                
                                                                                                                                                                                                                
  The OAuth token mechanism itself is trivial: the Agent SDK (`@anthropic-ai/claude-agent-sdk`) spawns the Claude CLI as a subprocess and the CLI reads `CLAUDE_CODE_OAUTH_TOKEN` via its own [documented auth  
  precedence chain](https://code.claude.com/docs/en/authentication#authentication-precedence) at position 5. `buildProviderEnv()` in `src/core/executor.ts` already spreads `process.env` wholesale, so no      
  executor behavior change is needed — only startup validation in `src/config.ts` and the tenancy gate in `src/webhook/router.ts`.                                                                              
                                                                                                                                                                                                                
  ### Before — anthropic provider requires ANTHROPIC_API_KEY, no tenancy layer                                                                                                                                  
                                                                                                                                                                                                                
  ```mermaid                                                                                                                                                                                                    
  flowchart TD                                                                                                                                                                                                  
      WebhookA["Incoming webhook"]:::entry --> IdempA["Idempotency check"]:::guard                                                                                                                              
      IdempA --> ConcA["Concurrency guard"]:::guard                                                                                                                                                             
      ConcA --> TrackA["Create tracking comment"]:::run                                                                                                                                                         
      TrackA --> RunA["Fetch → Clone → Execute Claude SDK"]:::run                                                                                                                                               
      RunA --> EnvA["buildProviderEnv spreads process.env<br/>ANTHROPIC_API_KEY only"]:::env                                                                                                                    
      EnvA --> CLIA["Claude CLI subprocess"]:::cli                                                                                                                                                              
      CfgA["config.ts superRefine<br/>rejects if ANTHROPIC_API_KEY missing"]:::cfg -.-> EnvA                                                                                                                    
                                                                                                                                                                                                                
      classDef entry fill:#1e3a8a,color:#ffffff,stroke:#0b1e4b,stroke-width:2px                                                                                                                                 
      classDef guard fill:#374151,color:#ffffff,stroke:#111827,stroke-width:1px                                                                                                                                 
      classDef run fill:#065f46,color:#ffffff,stroke:#022c22,stroke-width:1px                                                                                                                                   
      classDef env fill:#7c2d12,color:#ffffff,stroke:#431407,stroke-width:1px                                                                                                                                   
      classDef cli fill:#4c1d95,color:#ffffff,stroke:#1e1b4b,stroke-width:2px                                                                                                                                   
      classDef cfg fill:#78350f,color:#ffffff,stroke:#431407,stroke-width:1px                                                                                                                                   
  ```                                                                                                                                                                                                           
                                                                                                                                                                                                                
  ### After — OAuth token accepted, owner allowlist gates execution                                                                                                                                             
                                                                                                                                                                                                                
  ```mermaid                                                                                                                                                                                                    
  flowchart TD                                                                                                                                                                                                  
      WebhookB["Incoming webhook"]:::entry --> IdempB["Idempotency check"]:::guard                                                                                                                              
      IdempB --> ConcB["Concurrency guard"]:::guard                                                                                                                                                             
      ConcB --> AllowB["isOwnerAllowed ctx.owner<br/>case-insensitive match"]:::new                                                                                                                           
      AllowB -->|not in ALLOWED_OWNERS| SkipB["Silent skip<br/>log.warn + return"]:::skip                                                                                                                       
      AllowB -->|allowed or unset| TrackB["Create tracking comment"]:::run                                                                                                                                      
      TrackB --> RunB["Fetch → Clone → Execute Claude SDK"]:::run                                                                                                                                               
      RunB --> EnvB["buildProviderEnv spreads process.env<br/>API_KEY and/or OAUTH_TOKEN"]:::env                                                                                                                
      EnvB --> CLIB["Claude CLI subprocess<br/>auth precedence chain picks one"]:::cli                                                                                                                          
      CfgB["config.ts superRefine<br/>accepts API_KEY or OAUTH_TOKEN"]:::cfg -.-> EnvB                                                                                                                          
                                                                                                                                                                                                                
      classDef entry fill:#1e3a8a,color:#ffffff,stroke:#0b1e4b,stroke-width:2px                                                                                                                                 
      classDef guard fill:#374151,color:#ffffff,stroke:#111827,stroke-width:1px                                                                                                                                 
      classDef new fill:#9d174d,color:#ffffff,stroke:#500724,stroke-width:2px                                                                                                                                   
      classDef skip fill:#78350f,color:#ffffff,stroke:#431407,stroke-width:1px                                                                                                                                  
      classDef run fill:#065f46,color:#ffffff,stroke:#022c22,stroke-width:1px                                                                                                                                   
      classDef env fill:#7c2d12,color:#ffffff,stroke:#431407,stroke-width:1px                                                                                                                                   
      classDef cli fill:#4c1d95,color:#ffffff,stroke:#1e1b4b,stroke-width:2px                                                                                                                                   
      classDef cfg fill:#78350f,color:#ffffff,stroke:#431407,stroke-width:1px                                                                                                                                   
  ```                                                                                                                                                                                                           
                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                    
                                                                                                                                                                                                                
  **Config (`src/config.ts`)**                                                                                                                                                                                  
  - Added optional `claudeCodeOauthToken` field, wired to `CLAUDE_CODE_OAUTH_TOKEN` env var                                                                                                                     
  - Updated `.superRefine` anthropic branch to accept **either** `ANTHROPIC_API_KEY` **or** `CLAUDE_CODE_OAUTH_TOKEN` (error message mentions both)                                                             
  - Added optional `allowedOwners` field, wired to `ALLOWED_OWNERS` env var — parses comma-separated input into `string[]`, trims whitespace, drops empty entries, collapses to `undefined` when empty          
  (preserves "no restriction" backward compatibility)                                                                                                                                                           
  - No behavior change when both credentials are set — the Claude CLI's own auth precedence chain picks one (API key wins)                                                                                      
                                                                                                                                                                                                                
  **Authorization (`src/webhook/authorize.ts` — NEW)**                                                                                                                                                          
  - `isOwnerAllowed(owner, log)` — case-insensitive owner match against `config.allowedOwners`                                                                                                                  
  - Returns a discriminated `AuthorizeResult` union; logs `warn` with owner + allowlist on rejection                                                                                                            
  - `undefined` allowlist means "no restriction" (preserves existing open behavior)                                                                                                                             
                                                                                                                                                                                                                
  **Router (`src/webhook/router.ts`)**                                                                                                                                                                          
  - Allowlist check inserted after concurrency guard, before `activeCount++` and tracking comment creation — rejection path is a **silent skip** (no rejection comment, so the bot doesn't leak its existence to
   unauthorized installs)                                                                                                                                                                                       
  - Extracted `buildFinalOpts(result)` helper to keep `processRequest` under the cyclomatic complexity cap of 15 (new allowlist branch would have pushed it to 16)                                              
                                                                                                                                                                                                                
  **Executor (`src/core/executor.ts`)**                                                                                                                                                                         
  - Clarifying comment only — no behavior change. `{ ...process.env }` in `buildProviderEnv()` already forwards OAuth tokens; the comment documents the CLI-side auth precedence behavior so future readers     
  don't add redundant handling                                                                                                                                                                                  
                                                                                                                                                                                                                
  **Docs & config**                                                                                                                                                                                             
  - `.env.example` — Anthropic section split into **Option 1** (Console API key) / **Option 2** (OAuth token with single-tenant warning); new "Authorization" section for `ALLOWED_OWNERS`                      
  - `CLAUDE.md` — new "Authentication options" section documenting the three modes and the OAuth single-tenant requirement                                                                                      
                                                                                                                                                                                                                
  **Tests (+13 cases, 177 → 190)**                                                                                                                                                                              
  - `test/webhook/authorize.test.ts` (NEW) — 6 unit tests: undefined allowlist, exact match, case-insensitive, reject + warn shape, multi-entry allow, multi-entry reject                                       
  - `test/webhook/router.test.ts` — 2 integration tests: silent-skip on non-allowlisted owner, case-insensitive allow through full pipeline                                                                     
  - `test/config.test.ts` — 5 cases covering OAuth-only, both-credentials-set, neither-provided (error path), and 5 `ALLOWED_OWNERS` parsing cases (absent / empty / single / trimmed multi / whitespace-only)  
                                                                                                                                                                                                                
  ## Related Issues                                                                                                                                                                                             
                                                                                                                                                                                                                
  - Closes #(issue number)                                                                                                                                                                                      
                                                                                                                                                                                                                
  ## Testing                                                                                                                                                                                                    
                                                                                                                                                                                                                
  - [x] I have tested these changes locally                                                                                                                                                                     
  - [x] I have added/updated tests as needed                                                                                                                                                                    
  - [x] All existing tests pass                                                                                                                                                                                 
                                                                                                                                                                                                                
  **Verification results**                                                                                                                                                                                      
  - `bun run typecheck` — clean                                                                                                                                                                                 
  - `bun run lint` — clean                                                                                                                                                                                      
  - `bun run format` — clean                                                                                                                                                                                    
  - `bun test --coverage` — **179 pass, 0 fail, 375 expect() calls**                                                                                                                                            
    - `src/webhook/authorize.ts` — 100% funcs / 100% lines                                                                                                                                                      
    - `src/config.ts` — 100% funcs / 100% lines                                                                                                                                                                 
    - `src/webhook/router.ts` — 100% funcs / 99.25% lines (90% per-file threshold satisfied)                                                                                                                    
                                                                                                                                                                                                                
  **Not yet performed (requires real credentials — left for post-merge smoke test)**                                                                                                                            
  - End-to-end webhook with `CLAUDE_CODE_OAUTH_TOKEN` + `ALLOWED_OWNERS=<your-login>` set                                                                                                                       
  - Allowlist rejection path against a foreign-owner webhook (confirms silent skip)                                                                                                                             
  - Backward-compat check with only `ANTHROPIC_API_KEY` set and `ALLOWED_OWNERS` unset                                                                                                                          
  - Error path: neither credential set → zod validation error mentioning both env var names                                                                                                                     
                                                                                                                                                                                                                
  ## Screenshots/Recordings                                                                                                                                                                                     
                                                                                                                                                                                                                
  N/A — backend-only change, no UI surface.         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for two Anthropic credential modes (console API key or subscription OAuth token).
  * Optional owner allowlist that can restrict which repository owners may trigger the bot; OAuth-token mode enforces this at startup.

* **Documentation**
  * Added an authentication options guide describing credential choices, allowlist behavior, and CI-specific auth.

* **Tests**
  * Added/updated tests for credential validation, allowlist parsing, router gating, and test-environment isolation.

* **Chores**
  * Updated runtime/tooling, container image, and dependency/tool versions; added vulnerability ignore policy for image scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->