### PR TITLE
chore(constitution): bump to v1.2.1 for AI orchestration carve-out

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,12 +1,14 @@
 <!-- Sync Impact Report
   Version change: 1.2.0 → 1.2.1
   Modified sections:
-    - Technology Constraints > AI orchestration: added a one-line
-      carve-out permitting non-agent single-turn inference
-      (classification, embedding, summarisation) through the
-      `src/ai/llm-client.ts` adaptor using the raw Anthropic or
-      Bedrock SDKs. Multi-turn tool-using flows remain exclusively
-      on `@anthropic-ai/claude-agent-sdk`.
+    - Technology Constraints > AI orchestration: added a carve-out
+      permitting non-agent single-turn inference (classification,
+      embedding, summarisation) through a dedicated client adaptor
+      under `src/ai/` using the raw Anthropic or Bedrock SDKs.
+      Multi-turn tool-using flows remain exclusively on
+      `@anthropic-ai/claude-agent-sdk`. Enforcement is triple-gated:
+      spec contract, runtime guards in the adaptor, and fail-fast
+      config validation.
   Rationale: unblocks the dispatch-triage feature
     (specs/20260415-000159-triage-dispatch-modes). The triage call
     is a single-turn, no-tool classification; the prior blanket ban
@@ -267,12 +269,14 @@ documentation drift from becoming systemic.
 - **AI orchestration**: `@anthropic-ai/claude-agent-sdk` for all
   multi-turn, tool-using agent flows. Non-agent single-turn
   inference (classification, embedding, summarisation) MAY use the
-  raw Anthropic or Bedrock SDKs via the `src/ai/llm-client.ts`
-  adaptor, provided the calling feature spec enforces a
-  circuit-breaker, latency cap, and cost budget (see
-  `specs/20260415-000159-triage-dispatch-modes` FR-020 / SC-003 /
-  SC-005 for the reference pattern). Multi-turn tool-using flows
-  MUST continue to use `@anthropic-ai/claude-agent-sdk`.
+  raw Anthropic or Bedrock SDKs via a dedicated client adaptor
+  module under `src/ai/`, provided **all three** of the following
+  hold: (a) the calling feature's spec documents the circuit-breaker,
+  latency cap, and cost-budget requirements; (b) the adaptor or call
+  site enforces those guards at runtime (not merely at review time);
+  and (c) any credentials, model IDs, and budget / timeout knobs are
+  validated fail-fast at startup via the Zod config schema. Multi-turn
+  tool-using flows MUST continue to use `@anthropic-ai/claude-agent-sdk`.
 - **MCP**: `@modelcontextprotocol/sdk` for tool server
   implementations.
 - **Git hooks**: Husky + lint-staged. Lefthook or other hook managers

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,4 +1,30 @@
 <!-- Sync Impact Report
+  Version change: 1.2.0 → 1.2.1
+  Modified sections:
+    - Technology Constraints > AI orchestration: added a one-line
+      carve-out permitting non-agent single-turn inference
+      (classification, embedding, summarisation) through the
+      `src/ai/llm-client.ts` adaptor using the raw Anthropic or
+      Bedrock SDKs. Multi-turn tool-using flows remain exclusively
+      on `@anthropic-ai/claude-agent-sdk`.
+  Rationale: unblocks the dispatch-triage feature
+    (specs/20260415-000159-triage-dispatch-modes). The triage call
+    is a single-turn, no-tool classification; the prior blanket ban
+    was intended to prevent agent-loop bypasses, not pure
+    inference. The carve-out is guarded by the circuit-breaker,
+    latency, and cost requirements in FR-020, SC-003, and SC-005
+    of that spec. PATCH-level per §Amendment Procedure — existing
+    guidance is clarified, no principle removed or redefined.
+  Added sections: None
+  Removed sections: None
+  Templates requiring updates:
+    - .specify/templates/plan-template.md ✅ no changes needed
+    - .specify/templates/spec-template.md ✅ no changes needed
+    - .specify/templates/tasks-template.md ✅ no changes needed
+  Follow-up TODOs: None
+-->
+
+<!-- Sync Impact Report (historical)
   Version change: 1.1.0 → 1.2.0
   Modified sections:
     - Architecture Constraints > Single Server Model: added daemon
@@ -238,8 +264,15 @@ documentation drift from becoming systemic.
 - **HTTP framework**: `octokit` App class for webhook handling. No
   additional HTTP frameworks (Express, Fastify, Hono) MUST be added
   without a constitution amendment.
-- **AI orchestration**: `@anthropic-ai/claude-agent-sdk`. Direct LLM
-  API calls outside the agent SDK are forbidden.
+- **AI orchestration**: `@anthropic-ai/claude-agent-sdk` for all
+  multi-turn, tool-using agent flows. Non-agent single-turn
+  inference (classification, embedding, summarisation) MAY use the
+  raw Anthropic or Bedrock SDKs via the `src/ai/llm-client.ts`
+  adaptor, provided the calling feature spec enforces a
+  circuit-breaker, latency cap, and cost budget (see
+  `specs/20260415-000159-triage-dispatch-modes` FR-020 / SC-003 /
+  SC-005 for the reference pattern). Multi-turn tool-using flows
+  MUST continue to use `@anthropic-ai/claude-agent-sdk`.
 - **MCP**: `@modelcontextprotocol/sdk` for tool server
   implementations.
 - **Git hooks**: Husky + lint-staged. Lefthook or other hook managers
@@ -377,4 +410,4 @@ If a spec, plan, or task contradicts this constitution, the
 constitution takes precedence. The conflicting artifact MUST be
 amended to align.
 
-**Version**: 1.2.0 | **Ratified**: 2026-04-09 | **Last Amended**: 2026-04-13
+**Version**: 1.2.1 | **Ratified**: 2026-04-09 | **Last Amended**: 2026-04-15


### PR DESCRIPTION
## Summary

- PATCH-level amendment (v1.2.0 → v1.2.1) adding a one-line carve-out under **Technology Constraints > AI orchestration** that permits non-agent single-turn inference (classification, embedding, summarisation) via a forthcoming `src/ai/llm-client.ts` adaptor using the raw Anthropic or Bedrock SDKs.
- Multi-turn tool-using flows remain exclusively on `@anthropic-ai/claude-agent-sdk`.
- Sync Impact Report appended at the top; previous 1.2.0 block moved to historical. Version footer bumped.

## Why this is a standalone PR

Per §Amendment Procedure, constitution changes must land as their own PR — not bundled with feature work — so reviewers can evaluate the governance change without feature-code distraction. This unblocks Phase 4 / US2 of the [triage-dispatch-modes feature](../tree/20260415-000159-triage-dispatch-modes/specs/20260415-000159-triage-dispatch-modes), whose `src/ai/llm-client.ts` path would otherwise violate the prior blanket "direct LLM calls forbidden" rule.

The triage call is a single-turn, no-tool classification; the prior ban was intended to prevent agent-loop bypasses, not pure inference. The carve-out is guarded by the circuit-breaker, latency, and cost requirements in FR-020 / SC-003 / SC-005 of the feature spec — referenced inline in the amended bullet so future readers can see the reference pattern.

## Test plan

- [x] `git diff --stat main...HEAD` — exactly 1 file changed (`.specify/memory/constitution.md`, +36 / -3)
- [x] Sync Impact Report at top documents 1.2.0 → 1.2.1 with rationale, modified sections, template-update audit
- [x] Previous 1.2.0 → 1.1.0 and 1.1.0 → 1.0.0 report blocks preserved as historical
- [x] Version footer reads `**Version**: 1.2.1 | **Ratified**: 2026-04-09 | **Last Amended**: 2026-04-15`
- [ ] CI (lint / format / typecheck / test) passes
- [ ] No feature code shipped in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI orchestration policy governance to allow greater flexibility in single-turn inference operations when proper safeguards are in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->