### PR TITLE
feat(triage): Slice E (part 1) — isolated-job capacity gate + pending queue + drainer (T040/T041/T043/T044/T045)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { App } from "octokit";
 import { config } from "./config";
 import { closeDb, getDb } from "./db";
 import { runMigrations } from "./db/migrate";
+import { startPendingQueueDrainer, stopPendingQueueDrainer } from "./k8s/pending-queue-drainer";
 import { logger } from "./logger";
 import { recoverStaleExecutions } from "./orchestrator/history";
 import { closeValkey, getValkeyClient, isValkeyHealthy } from "./orchestrator/valkey";
@@ -305,6 +306,15 @@ async function runStartupChecks(): Promise<void> {
     logger.info({ wsPort: config.wsPort }, "Orchestrator WebSocket server started");
   }
 
+  // US3 T044: drain the pending isolated-job queue whenever in-flight
+  // capacity frees up. Only relevant when the isolated-job target is
+  // reachable — inline + daemon + shared-runner deployments never queue
+  // isolated-job requests, so spinning up the interval would just waste
+  // Valkey round-trips.
+  if (config.agentJobMode === "isolated-job" || config.agentJobMode === "auto") {
+    startPendingQueueDrainer(app);
+  }
+
   isReady = true;
   logger.info("Startup checks passed, server is ready");
 }
@@ -326,6 +336,9 @@ function shutdown(signal: string): void {
   server.close(() => {
     void (async (): Promise<void> => {
       try {
+        // Stop the isolated-job queue drainer before Valkey closes so any
+        // in-flight drain tick doesn't race with client teardown.
+        stopPendingQueueDrainer();
         // Drain the WebSocket server first so daemon disconnect cleanup
         // (which still uses the Valkey client) finishes before we close Valkey.
         await stopWebSocketServer();

--- a/src/core/tracking-comment.ts
+++ b/src/core/tracking-comment.ts
@@ -74,6 +74,25 @@ function escapeHtml(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * FR-018 / US3: when the isolated-job pool is at capacity, the request is
+ * enqueued and the tracking comment surfaces its position. `position` is
+ * 1-indexed (the head of the queue is 1); `max` is the configured
+ * `MAX_CONCURRENT_ISOLATED_JOBS`. Kept as a pure helper so US3 integration
+ * tests can assert the exact string without mounting the entire comment
+ * pipeline.
+ *
+ * The inputs are integers from trusted config + Valkey RPUSH return, so no
+ * escaping is required — unlike `renderTriageSection.rationale` which is
+ * model-generated. Coerced to integer via `Math.trunc` as a defensive check
+ * against a future caller passing a float.
+ */
+export function renderQueuePosition(position: number, max: number): string {
+  const p = Math.trunc(position);
+  const m = Math.trunc(max);
+  return `⏳ Queued (position ${String(p)} of ${String(m)} on isolated-job pool). Waiting for capacity…`;
+}
+
 export function renderTriageSection(triage: TriageCommentSection): string {
   const confidencePct = (triage.confidence * 100).toFixed(0);
   const costFmt = triage.costUsd < 0.001 ? "<US$0.001" : `US$${triage.costUsd.toFixed(4)}`;

--- a/src/k8s/pending-queue-drainer.ts
+++ b/src/k8s/pending-queue-drainer.ts
@@ -18,6 +18,8 @@
 import type { App } from "octokit";
 
 import { config } from "../config";
+// Avoid pulling in the full tracking-comment module (and therefore octokit
+// typing) — the drainer only needs a single rejection comment shape.
 import { createChildLogger, logger } from "../logger";
 import type { SerializableBotContext } from "../shared/daemon-types";
 import type { BotContext } from "../types";
@@ -152,13 +154,22 @@ async function drainLoop(app: App): Promise<void> {
       ctx.log.info({ deliveryId: ctx.deliveryId }, "drained queued isolated-job — Job spawned");
     } catch (err) {
       // FR-021: no retry on mid-run failure. Just release any slot and log.
-      // infra-absent here is unusual (we only queued because capacity was
-      // full, implying prior spawns worked) but handle it defensively.
+      //
+      // Copilot PR #21 review: a queued request whose drain trips
+      // `infra-absent` (K8s went away between enqueue and drain) used to
+      // be silently dropped. Surface it to the requester with the same
+      // rejection comment the router would have posted on a direct-spawn
+      // infra-absent, so the user isn't left with a dangling "⏳ Queued"
+      // with no resolution.
       const kind = err instanceof JobSpawnerError ? err.kind : "unknown";
       ctx.log.error(
         { err, deliveryId: ctx.deliveryId, kind },
         "drainer spawn failed — dropping entry (FR-021 no retry)",
       );
+      if (err instanceof JobSpawnerError && err.kind === "infra-absent") {
+        // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+        await postInfraAbsentDrainRejection(ctx);
+      }
       // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
       await releaseInFlight(ctx.deliveryId);
     }
@@ -192,4 +203,28 @@ async function reconstructBotContext(
     octokit: octokit as unknown as BotContext["octokit"],
     log,
   };
+}
+
+/**
+ * Post a rejection comment to the issue/PR when the drainer trips an
+ * `infra-absent` on a previously-queued request. Mirrors the wording used
+ * by `recordInfraAbsentRejection` in the router's direct-spawn path so a
+ * user sees the same explanation regardless of whether they hit the
+ * capacity gate first.
+ */
+async function postInfraAbsentDrainRejection(ctx: BotContext): Promise<void> {
+  try {
+    await ctx.octokit.rest.issues.createComment({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issue_number: ctx.entityNumber,
+      body:
+        `**${config.triggerPhrase}** cannot complete this queued request: the isolated-job target ` +
+        `requires Kubernetes infrastructure that is no longer reachable. The platform will not ` +
+        `silently downgrade to a different target — please re-trigger once infrastructure is ` +
+        `restored, or without the \`bot:job\` label / docker keyword if shared-runner is acceptable.`,
+    });
+  } catch (commentError) {
+    ctx.log.error({ err: commentError }, "Failed to post drainer infra-absent rejection comment");
+  }
 }

--- a/src/k8s/pending-queue-drainer.ts
+++ b/src/k8s/pending-queue-drainer.ts
@@ -1,0 +1,195 @@
+/**
+ * Background drainer for the isolated-job pending queue (T044, US3).
+ *
+ * Runs as a single `setInterval` inside the webhook server process. Each
+ * tick: while `inFlightCount()` is under capacity AND the queue has entries,
+ * pop one, reconstruct a BotContext from the stored serialized form, and
+ * call `spawnIsolatedJob`. On spawn success, register the delivery in the
+ * in-flight set; on spawn failure, release any slot we might have grabbed
+ * and drop the entry (FR-021: no mid-run retry, and a queue re-add would
+ * re-enter the same failing state).
+ *
+ * Idempotency: `dequeuePending` is the only consumer of the pending list,
+ * and the drainer is the only caller of `dequeuePending` at runtime. The
+ * `draining` guard serialises tick handlers so a slow spawn cannot overlap
+ * with the next interval firing.
+ */
+
+import type { App } from "octokit";
+
+import { config } from "../config";
+import { createChildLogger, logger } from "../logger";
+import type { SerializableBotContext } from "../shared/daemon-types";
+import type { BotContext } from "../types";
+import type { DispatchDecision } from "../webhook/router";
+import { JobSpawnerError, spawnIsolatedJob } from "./job-spawner";
+import {
+  dequeuePending,
+  inFlightCount,
+  type PendingIsolatedJobEntry,
+  registerInFlight,
+  releaseInFlight,
+} from "./pending-queue";
+
+/** Default drainer poll interval in milliseconds. */
+export const DEFAULT_DRAIN_INTERVAL_MS = 5_000;
+
+let drainerInterval: ReturnType<typeof setInterval> | undefined;
+// Mutex as an in-flight promise rather than a boolean flag. Using a boolean
+// across `await` points trips `@typescript-eslint/require-atomic-updates`
+// and, more fundamentally, wouldn't prevent two concurrent callers from
+// both observing `draining=false` simultaneously before either reassigns.
+// A promise captured synchronously at the start of the tick cannot race.
+let activeDrain: Promise<void> | undefined;
+
+/**
+ * Start the drainer. Idempotent — repeated calls are no-ops. Returns the
+ * interval handle for test-only shutdown. `app` is the `octokit` App
+ * instance; the drainer uses it to mint a fresh installation token for the
+ * dequeued event's repo (the token stored at enqueue time is
+ * short-lived and likely expired by the time the pool frees).
+ */
+export function startPendingQueueDrainer(
+  app: App,
+  intervalMs: number = DEFAULT_DRAIN_INTERVAL_MS,
+): ReturnType<typeof setInterval> {
+  if (drainerInterval !== undefined) return drainerInterval;
+  drainerInterval = setInterval(() => {
+    void drainPendingOnce(app);
+  }, intervalMs);
+  drainerInterval.unref();
+  logger.info({ intervalMs }, "pending-queue drainer started");
+  return drainerInterval;
+}
+
+export function stopPendingQueueDrainer(): void {
+  if (drainerInterval !== undefined) {
+    clearInterval(drainerInterval);
+    drainerInterval = undefined;
+    logger.info("pending-queue drainer stopped");
+  }
+}
+
+/**
+ * Exported for tests. Runs one tick of the drain loop: pop + spawn until
+ * capacity is reached, the queue drains, or an unrecoverable error occurs.
+ * Never throws — all errors are logged.
+ */
+export function drainPendingOnce(app: App): Promise<void> {
+  // Synchronous fast-path: return the in-flight tick's promise so both
+  // overlapping callers await the same work rather than starting a second
+  // tick. The assignment of `activeDrain` is synchronous with the IIFE
+  // so no `await` can interleave between check and set.
+  if (activeDrain !== undefined) return activeDrain;
+  const run = (async (): Promise<void> => {
+    try {
+      await drainLoop(app);
+    } catch (err) {
+      logger.error({ err }, "pending-queue drainer tick failed");
+    } finally {
+      activeDrain = undefined;
+    }
+  })();
+  activeDrain = run;
+  return run;
+}
+
+async function drainLoop(app: App): Promise<void> {
+  // Bounded by queue length + capacity; `maxIterations` is a defence against
+  // a pathological Valkey that keeps returning dequeued entries with the
+  // same delivery id after the spawn path fails to register in-flight.
+  const maxIterations = Math.max(config.pendingIsolatedJobQueueMax, 20);
+  for (let i = 0; i < maxIterations; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+    const inFlight = await inFlightCount();
+    if (inFlight >= config.maxConcurrentIsolatedJobs) return;
+
+    // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+    const result = await dequeuePending();
+    if (result.outcome === "empty") return;
+    if (result.outcome === "context-missing") {
+      logger.warn(
+        { deliveryId: result.entry.deliveryId },
+        "dropped queued isolated-job — bot-context TTL expired before drain",
+      );
+      continue;
+    }
+    if (result.outcome === "corrupt") {
+      logger.error(
+        { rawPreview: result.raw.slice(0, 200), error: result.error },
+        "dropped corrupt pending-queue entry",
+      );
+      continue;
+    }
+
+    // `dequeued` — reconstruct a BotContext and spawn.
+    let ctx: BotContext;
+    try {
+      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+      ctx = await reconstructBotContext(app, result.entry, result.context);
+    } catch (err) {
+      logger.error(
+        { err, deliveryId: result.entry.deliveryId },
+        "failed to reconstruct BotContext for queued isolated-job — dropping",
+      );
+      continue;
+    }
+
+    const decision: DispatchDecision = {
+      target: "isolated-job",
+      reason: result.entry.dispatchReason,
+      maxTurns: result.entry.maxTurns,
+      ...(result.entry.triageResult !== null && {
+        complexity: result.entry.triageResult.complexity,
+      }),
+    };
+
+    try {
+      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+      await spawnIsolatedJob(ctx, decision);
+      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+      await registerInFlight(ctx.deliveryId);
+      ctx.log.info({ deliveryId: ctx.deliveryId }, "drained queued isolated-job — Job spawned");
+    } catch (err) {
+      // FR-021: no retry on mid-run failure. Just release any slot and log.
+      // infra-absent here is unusual (we only queued because capacity was
+      // full, implying prior spawns worked) but handle it defensively.
+      const kind = err instanceof JobSpawnerError ? err.kind : "unknown";
+      ctx.log.error(
+        { err, deliveryId: ctx.deliveryId, kind },
+        "drainer spawn failed — dropping entry (FR-021 no retry)",
+      );
+      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+      await releaseInFlight(ctx.deliveryId);
+    }
+  }
+}
+
+/**
+ * Rebuild a `BotContext` from the stored `SerializableBotContext`. The
+ * stored form lacks an `octokit` instance (class) and `log` (pino Logger
+ * with streams); this helper mints a fresh installation octokit from the
+ * App JWT and a child logger keyed on the original delivery id.
+ */
+async function reconstructBotContext(
+  app: App,
+  entry: PendingIsolatedJobEntry,
+  context: SerializableBotContext,
+): Promise<BotContext> {
+  const install = await app.octokit.rest.apps.getRepoInstallation({
+    owner: entry.source.owner,
+    repo: entry.source.repo,
+  });
+  const octokit = await app.getInstallationOctokit(install.data.id);
+  const log = createChildLogger({
+    deliveryId: context.deliveryId,
+    owner: context.owner,
+    repo: context.repo,
+    entityNumber: context.entityNumber,
+  });
+  return {
+    ...context,
+    octokit: octokit as unknown as BotContext["octokit"],
+    log,
+  };
+}

--- a/src/k8s/pending-queue.ts
+++ b/src/k8s/pending-queue.ts
@@ -1,0 +1,236 @@
+/**
+ * Valkey-backed pending queue + in-flight tracker for the isolated-job
+ * dispatch target (T043, US3). Implements data-model.md §6 and research.md
+ * R4: a single FIFO Redis list `dispatch:isolated-job:pending` bounded by
+ * `PENDING_ISOLATED_JOB_QUEUE_MAX`, paired with a set
+ * `dispatch:isolated-job:in-flight` bounded by `MAX_CONCURRENT_ISOLATED_JOBS`.
+ *
+ * BotContext is stored in a separate key (`bot-context:<deliveryId>`) with a
+ * 1-hour TTL so list entries stay small. Values are gzipped JSON — the raw
+ * BotContext can contain large PR bodies / diffs; the TTL covers the worst
+ * case of a queue entry outliving a pod restart by more than the reasonable
+ * recovery window.
+ *
+ * All operations are non-transactional; the spec explicitly accepts that an
+ * event whose queue entry was never dequeued before a restart is lost (the
+ * outer idempotency layer prevents duplicate processing on redelivery).
+ */
+
+import { z } from "zod";
+
+import { logger } from "../logger";
+import { TriageResponseSchema } from "../orchestrator/triage";
+import { requireValkeyClient } from "../orchestrator/valkey";
+import type { SerializableBotContext } from "../shared/daemon-types";
+
+/** Redis key names — centralised so tests can assert against them. */
+export const PENDING_LIST_KEY = "dispatch:isolated-job:pending";
+export const IN_FLIGHT_SET_KEY = "dispatch:isolated-job:in-flight";
+export const BOT_CONTEXT_TTL_SECONDS = 3600;
+
+function botContextKey(deliveryId: string): string {
+  return `bot-context:${deliveryId}`;
+}
+
+/**
+ * JSON schema for a pending queue entry. Mirrors
+ * `PendingIsolatedJobEntrySchema` in data-model.md §6. Validated on both
+ * enqueue (to reject programming errors fast) and dequeue (to reject
+ * corrupted or schema-drifted entries).
+ */
+export const PendingIsolatedJobEntrySchema = z.object({
+  deliveryId: z.string().min(1),
+  enqueuedAt: z.iso.datetime(),
+  botContextKey: z.string().min(1),
+  triageResult: TriageResponseSchema.nullable(),
+  source: z.object({
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    issueOrPrNumber: z.number().int().positive(),
+  }),
+});
+export type PendingIsolatedJobEntry = z.infer<typeof PendingIsolatedJobEntrySchema>;
+
+/** Outcome of an enqueue attempt. Never throws on a full queue. */
+export type EnqueueOutcome =
+  | { readonly outcome: "enqueued"; readonly position: number }
+  | { readonly outcome: "rejected-full"; readonly currentLength: number };
+
+/**
+ * Enqueue a pending isolated-job request. Caller is responsible for having
+ * already checked `inFlightCount()` against the capacity ceiling — this
+ * function only guards the queue length against
+ * `PENDING_ISOLATED_JOB_QUEUE_MAX`.
+ *
+ * Write order matters: `SETEX` the BotContext key FIRST so a racing dequeue
+ * after `RPUSH` cannot observe a list entry whose context key is missing.
+ *
+ * Position is 1-indexed and reflects queue length AFTER this entry lands.
+ */
+export async function enqueuePending(
+  entry: PendingIsolatedJobEntry,
+  serializedContext: SerializableBotContext,
+  opts: { maxQueueLength: number },
+): Promise<EnqueueOutcome> {
+  const valkey = requireValkeyClient();
+  const validated = PendingIsolatedJobEntrySchema.parse(entry);
+
+  const currentLength = await llen(valkey, PENDING_LIST_KEY);
+  if (currentLength >= opts.maxQueueLength) {
+    return { outcome: "rejected-full", currentLength };
+  }
+
+  await storeBotContext(validated.deliveryId, serializedContext);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey RPUSH returns the new list length
+  const newLength: number = await valkey.send("RPUSH", [
+    PENDING_LIST_KEY,
+    JSON.stringify(validated),
+  ]);
+  return { outcome: "enqueued", position: newLength };
+}
+
+/** Outcome of a dequeue attempt. */
+export type DequeueOutcome =
+  | {
+      readonly outcome: "dequeued";
+      readonly entry: PendingIsolatedJobEntry;
+      readonly context: SerializableBotContext;
+    }
+  | { readonly outcome: "empty" }
+  | { readonly outcome: "context-missing"; readonly entry: PendingIsolatedJobEntry }
+  | { readonly outcome: "corrupt"; readonly raw: string; readonly error: string };
+
+/**
+ * Pop the head of the pending queue. Returns the parsed entry plus its
+ * BotContext. Callers transition the request to running by invoking
+ * `registerInFlight(deliveryId)` after successful spawn.
+ *
+ * `corrupt` indicates a schema-invalid list entry — the entry is consumed
+ * (not requeued) so a poison message cannot block the pool forever; the
+ * caller is expected to log and move on.
+ */
+export async function dequeuePending(): Promise<DequeueOutcome> {
+  const valkey = requireValkeyClient();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey LPOP returns string | null
+  const raw: string | null = await valkey.send("LPOP", [PENDING_LIST_KEY]);
+  if (raw === null) return { outcome: "empty" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { outcome: "corrupt", raw, error: err instanceof Error ? err.message : String(err) };
+  }
+  const result = PendingIsolatedJobEntrySchema.safeParse(parsed);
+  if (!result.success) {
+    return { outcome: "corrupt", raw, error: result.error.message };
+  }
+  const entry = result.data;
+
+  const context = await loadBotContext(entry.deliveryId);
+  if (context === null) {
+    // TTL expired or bot-context was never written; caller should skip
+    // this entry without re-queuing — the upstream idempotency layer will
+    // not re-trigger it, and keeping it would block the pool.
+    return { outcome: "context-missing", entry };
+  }
+  return { outcome: "dequeued", entry, context };
+}
+
+/**
+ * Returns the 1-indexed position of `deliveryId` in the pending queue,
+ * or null when the entry is not found. Used by the tracking-comment
+ * renderer to show "position N of M". O(N) in queue length — queue max
+ * is 20 by default so this is cheap.
+ */
+export async function getPosition(deliveryId: string): Promise<number | null> {
+  const valkey = requireValkeyClient();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey LRANGE returns string[]
+  const entries: string[] = await valkey.send("LRANGE", [PENDING_LIST_KEY, "0", "-1"]);
+  for (let i = 0; i < entries.length; i++) {
+    const raw = entries[i];
+    if (raw === undefined) continue;
+    try {
+      const parsed = JSON.parse(raw) as { deliveryId?: unknown };
+      if (parsed.deliveryId === deliveryId) return i + 1;
+    } catch {
+      // Skip unparsable entries — dequeuePending will collect them later.
+    }
+  }
+  return null;
+}
+
+/** Current queue length. Cheap — single `LLEN`. */
+export async function pendingLength(): Promise<number> {
+  const valkey = requireValkeyClient();
+  return await llen(valkey, PENDING_LIST_KEY);
+}
+
+/** Current in-flight count. Single `SCARD`. */
+export async function inFlightCount(): Promise<number> {
+  const valkey = requireValkeyClient();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey SCARD returns number
+  const count: number = await valkey.send("SCARD", [IN_FLIGHT_SET_KEY]);
+  return count;
+}
+
+/**
+ * Mark a delivery as in-flight (post-spawn). Idempotent via `SADD`.
+ * Returns the new cardinality so the router can log "pool at N/M".
+ */
+export async function registerInFlight(deliveryId: string): Promise<number> {
+  const valkey = requireValkeyClient();
+  await valkey.send("SADD", [IN_FLIGHT_SET_KEY, deliveryId]);
+  return await inFlightCount();
+}
+
+/**
+ * Release an in-flight slot (on success, failure, OR timeout). Idempotent
+ * via `SREM`. Also deletes the BotContext key — keeping it past completion
+ * would leak memory and risk stale re-reads from a misbehaving operator
+ * script.
+ */
+export async function releaseInFlight(deliveryId: string): Promise<void> {
+  const valkey = requireValkeyClient();
+  await valkey.send("SREM", [IN_FLIGHT_SET_KEY, deliveryId]);
+  await deleteBotContext(deliveryId);
+}
+
+/** Persist the BotContext blob with the standard 1h TTL. */
+export async function storeBotContext(
+  deliveryId: string,
+  context: SerializableBotContext,
+): Promise<void> {
+  const valkey = requireValkeyClient();
+  const payload = JSON.stringify(context);
+  await valkey.send("SETEX", [botContextKey(deliveryId), String(BOT_CONTEXT_TTL_SECONDS), payload]);
+}
+
+export async function loadBotContext(deliveryId: string): Promise<SerializableBotContext | null> {
+  const valkey = requireValkeyClient();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey GET returns string | null
+  const payload: string | null = await valkey.send("GET", [botContextKey(deliveryId)]);
+  if (payload === null) return null;
+  try {
+    return JSON.parse(payload) as SerializableBotContext;
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), deliveryId },
+      "Failed to parse stored bot-context; treating as missing",
+    );
+    return null;
+  }
+}
+
+export async function deleteBotContext(deliveryId: string): Promise<void> {
+  const valkey = requireValkeyClient();
+  await valkey.send("DEL", [botContextKey(deliveryId)]);
+}
+
+async function llen(
+  valkey: { send: (cmd: string, args: string[]) => Promise<unknown> },
+  key: string,
+): Promise<number> {
+  const result = (await valkey.send("LLEN", [key])) as number;
+  return result;
+}

--- a/src/k8s/pending-queue.ts
+++ b/src/k8s/pending-queue.ts
@@ -22,6 +22,7 @@ import { logger } from "../logger";
 import { TriageResponseSchema } from "../orchestrator/triage";
 import { requireValkeyClient } from "../orchestrator/valkey";
 import type { SerializableBotContext } from "../shared/daemon-types";
+import { DispatchReasonSchema } from "../shared/dispatch-types";
 
 /** Redis key names — centralised so tests can assert against them. */
 export const PENDING_LIST_KEY = "dispatch:isolated-job:pending";
@@ -43,6 +44,14 @@ export const PendingIsolatedJobEntrySchema = z.object({
   enqueuedAt: z.iso.datetime(),
   botContextKey: z.string().min(1),
   triageResult: TriageResponseSchema.nullable(),
+  /**
+   * Carried so the drainer can rebuild a DispatchDecision without re-running
+   * the classifier / triage cascade. `dispatchReason` is the original
+   * router-chosen reason (label / keyword / triage / …); `maxTurns` is the
+   * complexity-resolved turn budget from `resolveMaxTurnsForComplexity`.
+   */
+  dispatchReason: DispatchReasonSchema,
+  maxTurns: z.number().int().positive(),
   source: z.object({
     owner: z.string().min(1),
     repo: z.string().min(1),

--- a/src/k8s/pending-queue.ts
+++ b/src/k8s/pending-queue.ts
@@ -6,8 +6,10 @@
  * `dispatch:isolated-job:in-flight` bounded by `MAX_CONCURRENT_ISOLATED_JOBS`.
  *
  * BotContext is stored in a separate key (`bot-context:<deliveryId>`) with a
- * 1-hour TTL so list entries stay small. Values are gzipped JSON — the raw
- * BotContext can contain large PR bodies / diffs; the TTL covers the worst
+ * 1-hour TTL so list entries stay small. Values are plain JSON today — if
+ * profiling shows large PR bodies / diffs pushing Valkey memory, wrap the
+ * `storeBotContext` / `loadBotContext` pair in gzip (data-model.md §6 lists
+ * compression as reserved-but-not-required). The 1-hour TTL covers the worst
  * case of a queue entry outliving a pod restart by more than the reasonable
  * recovery window.
  *
@@ -66,13 +68,44 @@ export type EnqueueOutcome =
   | { readonly outcome: "rejected-full"; readonly currentLength: number };
 
 /**
+ * Lua script that atomically (a) checks `LLEN` against `max`, (b) `SETEX`es
+ * the BotContext key, and (c) `RPUSH`es the entry. Returns `{1, newLen}` on
+ * success or `{-1, currentLen}` on reject-full. Atomicity matters because a
+ * naive `LLEN → RPUSH` check-then-act lets concurrent enqueues each observe
+ * `LLEN < max` and collectively push past the ceiling (Copilot PR #21
+ * review). EVAL runs on a single Redis thread, so the LLEN + RPUSH pair is
+ * serialised with respect to all other Valkey writers.
+ *
+ * KEYS:
+ *   1: pending list key
+ *   2: bot-context:<deliveryId> key
+ * ARGV:
+ *   1: max queue length (integer as string)
+ *   2: entry JSON
+ *   3: BotContext JSON
+ *   4: BotContext TTL seconds (integer as string)
+ */
+const ENQUEUE_PENDING_LUA = `
+local len = redis.call("LLEN", KEYS[1])
+local max = tonumber(ARGV[1])
+if len >= max then
+  return {-1, len}
+end
+redis.call("SETEX", KEYS[2], ARGV[4], ARGV[3])
+local newlen = redis.call("RPUSH", KEYS[1], ARGV[2])
+return {1, newlen}
+`.trim();
+
+/**
  * Enqueue a pending isolated-job request. Caller is responsible for having
  * already checked `inFlightCount()` against the capacity ceiling — this
  * function only guards the queue length against
  * `PENDING_ISOLATED_JOB_QUEUE_MAX`.
  *
- * Write order matters: `SETEX` the BotContext key FIRST so a racing dequeue
- * after `RPUSH` cannot observe a list entry whose context key is missing.
+ * Atomic via a single Lua EVAL: LLEN + (SETEX bot-context) + RPUSH run as
+ * one Redis command. Two parallel enqueues can no longer both observe
+ * `LLEN < max` and push past the ceiling, and the BotContext key is never
+ * written for an entry that failed the length check.
  *
  * Position is 1-indexed and reflects queue length AFTER this entry lands.
  */
@@ -84,18 +117,23 @@ export async function enqueuePending(
   const valkey = requireValkeyClient();
   const validated = PendingIsolatedJobEntrySchema.parse(entry);
 
-  const currentLength = await llen(valkey, PENDING_LIST_KEY);
-  if (currentLength >= opts.maxQueueLength) {
-    return { outcome: "rejected-full", currentLength };
-  }
-
-  await storeBotContext(validated.deliveryId, serializedContext);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey RPUSH returns the new list length
-  const newLength: number = await valkey.send("RPUSH", [
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Valkey EVAL returns [status, length] per the script contract above
+  const result: [number, number] = await valkey.send("EVAL", [
+    ENQUEUE_PENDING_LUA,
+    "2",
     PENDING_LIST_KEY,
+    botContextKey(validated.deliveryId),
+    String(opts.maxQueueLength),
     JSON.stringify(validated),
+    JSON.stringify(serializedContext),
+    String(BOT_CONTEXT_TTL_SECONDS),
   ]);
-  return { outcome: "enqueued", position: newLength };
+  const status = result[0];
+  const length = result[1];
+  if (status === -1) {
+    return { outcome: "rejected-full", currentLength: length };
+  }
+  return { outcome: "enqueued", position: length };
 }
 
 /** Outcome of a dequeue attempt. */

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -393,12 +393,15 @@ export async function dispatch(ctx: BotContext, decision: DispatchDecision): Pro
  *   3. At capacity AND queue full  → `capacity-rejected` execution row +
  *      tracking-comment rejection (FR-018: no silent downgrade).
  *
- * `infra-absent` still short-circuits before capacity is consulted because
- * `spawnIsolatedJob` only throws it once `loadKubernetesClient()` runs. That
- * happens AFTER the capacity gate here: an infra-absent deployment at
- * capacity still surfaces as infra-absent (the correct behaviour — queueing
- * forever on an infrastructure that cannot honour the request makes no
- * sense). The queue pre-check is still cheap (single Valkey `SCARD`).
+ * Ordering with `infra-absent`: `spawnIsolatedJob` detects missing K8s auth
+ * via `loadKubernetesClient()`, which runs AFTER this function's capacity
+ * gate. That means on an infra-absent deployment, the FIRST request still
+ * hits capacity=0, takes the direct-spawn branch, and fails fast with an
+ * infra-absent rejection comment. But once capacity is saturated (e.g. K8s
+ * went away AFTER some Jobs were spawned), subsequent requests take the
+ * enqueue path and sit in the queue; the drainer later trips the same
+ * `infra-absent` and surfaces it on the drained request (see
+ * `pending-queue-drainer.ts`). The `SCARD` pre-check here is cheap.
  */
 async function dispatchIsolatedJob(ctx: BotContext, decision: DispatchDecision): Promise<void> {
   const inFlight = await inFlightCount();

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -1,9 +1,15 @@
 import { config } from "../config";
 import { runInlinePipeline } from "../core/inline-pipeline";
-import { isAlreadyProcessed } from "../core/tracking-comment";
+import { isAlreadyProcessed, renderQueuePosition } from "../core/tracking-comment";
 import { getDb } from "../db";
 import { classifyStatic } from "../k8s/classifier";
 import { JobSpawnerError, spawnIsolatedJob } from "../k8s/job-spawner";
+import {
+  enqueuePending,
+  inFlightCount,
+  type PendingIsolatedJobEntry,
+  registerInFlight,
+} from "../k8s/pending-queue";
 import { dispatchToSharedRunner } from "../k8s/shared-runner-dispatcher";
 import {
   decrementActiveCount,
@@ -372,21 +378,179 @@ export async function dispatch(ctx: BotContext, decision: DispatchDecision): Pro
       return;
     }
     case "isolated-job":
-      try {
-        await spawnIsolatedJob(ctx, decision);
-      } catch (err) {
-        // FR-018 graceful rejection (T025): infra-absent → write a rejection
-        // execution row + post a tracking-comment update, do NOT downgrade
-        // to a different target. Other JobSpawnerError kinds (auth-load,
-        // api-rejected, api-unavailable) bubble to the processRequest
-        // catch where they're logged as runtime failures.
-        if (err instanceof JobSpawnerError && err.kind === "infra-absent") {
-          await recordInfraAbsentRejection(ctx, decision, err.message);
-          return;
-        }
-        throw err;
-      }
+      await dispatchIsolatedJob(ctx, decision);
       return;
+  }
+}
+
+/**
+ * T044 (US3): wire the Valkey pending queue + in-flight cap into the
+ * isolated-job path. Three mutually exclusive outcomes:
+ *
+ *   1. Under capacity      → `spawnIsolatedJob` + `registerInFlight` (direct).
+ *   2. At capacity, queue has room → `enqueuePending`; the drainer picks
+ *      the entry up and spawns later. Tracking comment shows "position N of M".
+ *   3. At capacity AND queue full  → `capacity-rejected` execution row +
+ *      tracking-comment rejection (FR-018: no silent downgrade).
+ *
+ * `infra-absent` still short-circuits before capacity is consulted because
+ * `spawnIsolatedJob` only throws it once `loadKubernetesClient()` runs. That
+ * happens AFTER the capacity gate here: an infra-absent deployment at
+ * capacity still surfaces as infra-absent (the correct behaviour — queueing
+ * forever on an infrastructure that cannot honour the request makes no
+ * sense). The queue pre-check is still cheap (single Valkey `SCARD`).
+ */
+async function dispatchIsolatedJob(ctx: BotContext, decision: DispatchDecision): Promise<void> {
+  const inFlight = await inFlightCount();
+  if (inFlight >= config.maxConcurrentIsolatedJobs) {
+    const entry: PendingIsolatedJobEntry = {
+      deliveryId: ctx.deliveryId,
+      enqueuedAt: new Date().toISOString(),
+      botContextKey: `bot-context:${ctx.deliveryId}`,
+      triageResult: decision.triage ?? null,
+      dispatchReason: decision.reason,
+      maxTurns: decision.maxTurns,
+      source: { owner: ctx.owner, repo: ctx.repo, issueOrPrNumber: ctx.entityNumber },
+    };
+    const outcome = await enqueuePending(entry, serializeBotContext(ctx), {
+      maxQueueLength: config.pendingIsolatedJobQueueMax,
+    });
+    if (outcome.outcome === "rejected-full") {
+      await recordCapacityRejection(ctx, decision, outcome.currentLength);
+      return;
+    }
+    await postQueuedTrackingComment(ctx, outcome.position);
+    ctx.log.info(
+      {
+        deliveryId: ctx.deliveryId,
+        position: outcome.position,
+        inFlight,
+        max: config.maxConcurrentIsolatedJobs,
+      },
+      "isolated-job at capacity — enqueued",
+    );
+    return;
+  }
+
+  try {
+    await spawnIsolatedJob(ctx, decision);
+  } catch (err) {
+    // FR-018 graceful rejection (T025): infra-absent → write a rejection
+    // execution row + post a tracking-comment update, do NOT downgrade
+    // to a different target. Other JobSpawnerError kinds (auth-load,
+    // api-rejected, api-unavailable) bubble to the processRequest
+    // catch where they're logged as runtime failures.
+    if (err instanceof JobSpawnerError && err.kind === "infra-absent") {
+      await recordInfraAbsentRejection(ctx, decision, err.message);
+      return;
+    }
+    throw err;
+  }
+
+  // Register AFTER spawn to avoid occupying a slot for a never-created Job.
+  // Non-fatal on failure: the Job is running; the in-flight set is a
+  // best-effort capacity counter, not a liveness source of truth.
+  try {
+    await registerInFlight(ctx.deliveryId);
+  } catch (err) {
+    ctx.log.warn(
+      { err, deliveryId: ctx.deliveryId },
+      "isolated-job registerInFlight failed — slot accounting may drift",
+    );
+  }
+}
+
+/**
+ * US3 queue-full write-path. Persists an execution row with
+ * `dispatch_reason="capacity-rejected"` and posts a tracking comment that
+ * tells the requester the pool is saturated beyond the queue ceiling. Spec
+ * (FR-018) is explicit: NO silent downgrade to shared-runner or daemon.
+ */
+async function recordCapacityRejection(
+  ctx: BotContext,
+  decision: DispatchDecision,
+  queueLength: number,
+): Promise<void> {
+  ctx.log.warn(
+    {
+      deliveryId: ctx.deliveryId,
+      target: decision.target,
+      queueLength,
+      max: config.pendingIsolatedJobQueueMax,
+    },
+    "isolated-job dispatch rejected — pool at capacity and pending queue full",
+  );
+
+  const db = getDb();
+  if (db !== null) {
+    try {
+      await createExecution({
+        deliveryId: ctx.deliveryId,
+        repoOwner: ctx.owner,
+        repoName: ctx.repo,
+        entityNumber: ctx.entityNumber,
+        entityType: ctx.isPR ? "pull_request" : "issue",
+        eventName: ctx.eventName,
+        triggerUsername: ctx.triggerUsername,
+        dispatchMode: decision.target,
+        dispatchReason: "capacity-rejected",
+        ...(decision.triage !== undefined && {
+          triageConfidence: decision.triage.confidence,
+          triageCostUsd: decision.triage.costUsd,
+          triageComplexity: decision.triage.complexity,
+        }),
+        contextJson: serializeBotContext(ctx),
+      });
+    } catch (recordErr) {
+      ctx.log.error(
+        { err: recordErr },
+        "Failed to write capacity-rejected execution row (non-fatal)",
+      );
+    }
+  }
+
+  try {
+    await ctx.octokit.rest.issues.createComment({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issue_number: ctx.entityNumber,
+      body:
+        `**${config.triggerPhrase}** cannot dispatch this request: the \`isolated-job\` pool is at capacity ` +
+        `(${String(config.maxConcurrentIsolatedJobs)} in-flight) and the pending queue is full ` +
+        `(${String(queueLength)} of ${String(config.pendingIsolatedJobQueueMax)} waiting). ` +
+        `The platform will not silently downgrade to a different target — please re-trigger in a few minutes.`,
+    });
+  } catch (commentError) {
+    ctx.log.error({ err: commentError }, "Failed to post capacity-rejected rejection comment");
+  }
+}
+
+/**
+ * Post the initial "⏳ Queued (position N of M)" tracking comment for a
+ * pending isolated-job request. The body embeds the delivery marker so the
+ * durable idempotency check (`isAlreadyProcessed`) picks it up on a webhook
+ * retry while the event is still queued — preventing a second enqueue for
+ * the same delivery.
+ *
+ * The queued comment is deliberately a separate comment from the one the
+ * Job entrypoint later posts ("Working…"): the Job's `createTrackingComment`
+ * runs inside the isolated pod with a fresh octokit instance, and trying
+ * to thread a comment id through the Valkey queue would require extending
+ * `SerializableBotContext`. The UX cost is one extra comment in the thread;
+ * the engineering cost of threading a mutable id across processes isn't
+ * worth paying.
+ */
+async function postQueuedTrackingComment(ctx: BotContext, position: number): Promise<void> {
+  try {
+    const body = `<!-- delivery:${ctx.deliveryId} -->\n${renderQueuePosition(position, config.maxConcurrentIsolatedJobs)}`;
+    await ctx.octokit.rest.issues.createComment({
+      owner: ctx.owner,
+      repo: ctx.repo,
+      issue_number: ctx.entityNumber,
+      body,
+    });
+  } catch (commentError) {
+    ctx.log.error({ err: commentError }, "Failed to post queued tracking comment");
   }
 }
 

--- a/test/core/tracking-comment.test.ts
+++ b/test/core/tracking-comment.test.ts
@@ -7,6 +7,7 @@ import {
   finalizeTrackingComment,
   isAlreadyProcessed,
   renderDispatchReasonLine,
+  renderQueuePosition,
   renderTriageSection,
   type TriageCommentSection,
   updateTrackingComment,
@@ -376,5 +377,26 @@ describe("renderTriageSection (T037)", () => {
     const lines = renderTriageSection(base).split("\n");
     const summaryIdx = lines.findIndex((l) => l.startsWith("<summary>"));
     expect(lines[summaryIdx + 1]).toBe("");
+  });
+});
+
+describe("renderQueuePosition (US3 T045)", () => {
+  it("formats a 1-indexed position alongside the capacity ceiling", () => {
+    expect(renderQueuePosition(1, 3)).toBe(
+      "⏳ Queued (position 1 of 3 on isolated-job pool). Waiting for capacity…",
+    );
+    expect(renderQueuePosition(15, 20)).toBe(
+      "⏳ Queued (position 15 of 20 on isolated-job pool). Waiting for capacity…",
+    );
+  });
+
+  it("truncates non-integer inputs defensively (position and max)", () => {
+    expect(renderQueuePosition(3.9, 5.2)).toContain("position 3 of 5");
+  });
+
+  it("produces a single-line body (no newlines, no HTML)", () => {
+    const body = renderQueuePosition(2, 3);
+    expect(body).not.toContain("\n");
+    expect(body).not.toContain("<");
   });
 });

--- a/test/k8s/pending-queue-drainer.test.ts
+++ b/test/k8s/pending-queue-drainer.test.ts
@@ -332,6 +332,94 @@ describe("drainPendingOnce — spawn failure (FR-021 no retry)", () => {
     expect(mockReleaseInFlight).toHaveBeenCalledTimes(1);
     expect(mockReleaseInFlight.mock.calls[0]?.[0]).toBe(entry.deliveryId);
   });
+
+  it("posts an infra-absent rejection comment when the drained spawn trips infra-absent (Copilot PR #21)", async () => {
+    // Import the mocked JobSpawnerError so `instanceof` matches the class
+    // the drainer sees after module mocking resolves.
+    const { JobSpawnerError } = await import("../../src/k8s/job-spawner");
+
+    const entry = makeEntry();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+    mockSpawnIsolatedJob.mockImplementation(() =>
+      Promise.reject(
+        new (JobSpawnerError as unknown as new (k: string, m: string) => Error)(
+          "infra-absent",
+          "k8s removed",
+        ),
+      ),
+    );
+
+    // Upgrade app.getInstallationOctokit so the reconstructed BotContext
+    // has a real-looking `octokit.rest.issues.createComment` — that's what
+    // the new postInfraAbsentDrainRejection helper calls.
+    const createComment = mock(() => Promise.resolve({ data: { id: 77 } }));
+    const app = makeApp();
+    app.getInstallationOctokit = mock(() =>
+      Promise.resolve({
+        rest: { issues: { createComment } },
+      } as unknown),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await drainPendingOnce(app as any);
+
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+    expect(mockReleaseInFlight).toHaveBeenCalledTimes(1);
+    // The key assertion: drainer surfaced infra-absent to the user instead
+    // of silently dropping.
+    expect(createComment).toHaveBeenCalledTimes(1);
+    const callArgs = (createComment as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    if (callArgs !== undefined) {
+      const [arg] = callArgs as [{ body: string }];
+      expect(arg.body.toLowerCase()).toContain("kubernetes");
+      expect(arg.body.toLowerCase()).toContain("no longer reachable");
+    }
+  });
+
+  it("does NOT post an infra-absent comment for non-infra-absent spawn failures", async () => {
+    const entry = makeEntry();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+    mockSpawnIsolatedJob.mockImplementation(() =>
+      Promise.reject(new Error("500 Internal Server Error")),
+    );
+
+    const createComment = mock(() => Promise.resolve({ data: { id: 1 } }));
+    const app = makeApp();
+    app.getInstallationOctokit = mock(() =>
+      Promise.resolve({
+        rest: { issues: { createComment } },
+      } as unknown),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await drainPendingOnce(app as any);
+
+    expect(createComment).not.toHaveBeenCalled();
+    expect(mockReleaseInFlight).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("drainPendingOnce — overlap guard", () => {

--- a/test/k8s/pending-queue-drainer.test.ts
+++ b/test/k8s/pending-queue-drainer.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Tests for src/k8s/pending-queue-drainer.ts — background drain of the
+ * isolated-job pending queue (T044, US3).
+ *
+ * Exercises all four dequeue outcomes (empty / dequeued / context-missing /
+ * corrupt) plus the in-flight capacity gate, the overlap-guard (two
+ * concurrent ticks share a single promise), and the spawn-failure no-retry
+ * invariant (FR-021).
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { PendingIsolatedJobEntry } from "../../src/k8s/pending-queue";
+import type { SerializableBotContext } from "../../src/shared/daemon-types";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up BEFORE importing the subject module so dynamic mocks take
+// effect on first import.
+// ---------------------------------------------------------------------------
+
+const mockInFlightCount = mock(() => Promise.resolve(0));
+const mockDequeuePending = mock(() =>
+  Promise.resolve({ outcome: "empty" } as unknown as DequeueResult),
+);
+const mockRegisterInFlight = mock(() => Promise.resolve(1));
+const mockReleaseInFlight = mock(() => Promise.resolve());
+const mockSpawnIsolatedJob = mock(() => Promise.resolve({ success: true, durationMs: 0 }));
+
+type DequeueResult =
+  | { outcome: "empty" }
+  | { outcome: "dequeued"; entry: PendingIsolatedJobEntry; context: SerializableBotContext }
+  | { outcome: "context-missing"; entry: PendingIsolatedJobEntry }
+  | { outcome: "corrupt"; raw: string; error: string };
+
+void mock.module("../../src/k8s/pending-queue", () => ({
+  inFlightCount: mockInFlightCount,
+  dequeuePending: mockDequeuePending,
+  registerInFlight: mockRegisterInFlight,
+  releaseInFlight: mockReleaseInFlight,
+}));
+
+void mock.module("../../src/k8s/job-spawner", () => ({
+  spawnIsolatedJob: mockSpawnIsolatedJob,
+  JobSpawnerError: class JobSpawnerError extends Error {
+    constructor(
+      readonly kind: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+// Silence logger + avoid pulling real pino streams into the mock.
+void mock.module("../../src/logger", () => ({
+  logger: {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  },
+  createChildLogger: (): Record<string, (..._args: unknown[]) => void> => ({
+    info: (): void => {},
+    warn: (): void => {},
+    error: (): void => {},
+    debug: (): void => {},
+  }),
+}));
+
+const { drainPendingOnce } = await import("../../src/k8s/pending-queue-drainer");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<PendingIsolatedJobEntry> = {}): PendingIsolatedJobEntry {
+  return {
+    deliveryId: "d-drain-1",
+    enqueuedAt: "2026-04-15T10:00:00.000Z",
+    botContextKey: "bot-context:d-drain-1",
+    triageResult: null,
+    dispatchReason: "label",
+    maxTurns: 30,
+    source: { owner: "o", repo: "r", issueOrPrNumber: 42 },
+    ...overrides,
+  };
+}
+
+function makeContext(deliveryId = "d-drain-1"): SerializableBotContext {
+  return {
+    deliveryId,
+    owner: "o",
+    repo: "r",
+    entityNumber: 42,
+    isPR: true,
+    eventName: "issue_comment",
+    triggerUsername: "u",
+    triggerBody: "hi",
+    labels: [],
+    defaultBranch: "main",
+    triggerTimestamp: "2026-04-15T10:00:00.000Z",
+    commentId: 1,
+  } as unknown as SerializableBotContext;
+}
+
+/**
+ * Fake `App` — only the surfaces the drainer actually uses
+ * (`octokit.rest.apps.getRepoInstallation` + `getInstallationOctokit`).
+ */
+function makeApp(): {
+  octokit: { rest: { apps: { getRepoInstallation: ReturnType<typeof mock> } } };
+  getInstallationOctokit: ReturnType<typeof mock>;
+} {
+  return {
+    octokit: {
+      rest: {
+        apps: {
+          getRepoInstallation: mock(() => Promise.resolve({ data: { id: 123 } })),
+        },
+      },
+    },
+    getInstallationOctokit: mock(() => Promise.resolve({} as unknown)),
+  };
+}
+
+beforeEach(() => {
+  mockInFlightCount.mockClear();
+  mockDequeuePending.mockClear();
+  mockRegisterInFlight.mockClear();
+  mockReleaseInFlight.mockClear();
+  mockSpawnIsolatedJob.mockClear();
+  mockInFlightCount.mockImplementation(() => Promise.resolve(0));
+  mockDequeuePending.mockImplementation(() =>
+    Promise.resolve({ outcome: "empty" } as unknown as DequeueResult),
+  );
+  mockRegisterInFlight.mockImplementation(() => Promise.resolve(1));
+  mockReleaseInFlight.mockImplementation(() => Promise.resolve());
+  mockSpawnIsolatedJob.mockImplementation(() => Promise.resolve({ success: true, durationMs: 0 }));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("drainPendingOnce — empty queue", () => {
+  it("returns immediately when the queue is empty", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+    expect(mockInFlightCount).toHaveBeenCalledTimes(1);
+    expect(mockDequeuePending).toHaveBeenCalledTimes(1);
+    expect(mockSpawnIsolatedJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("drainPendingOnce — capacity gate", () => {
+  it("returns without dequeuing when in-flight is at max", async () => {
+    mockInFlightCount.mockImplementation(() => Promise.resolve(3)); // == config.maxConcurrentIsolatedJobs default
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+    expect(mockInFlightCount).toHaveBeenCalledTimes(1);
+    expect(mockDequeuePending).not.toHaveBeenCalled();
+  });
+});
+
+describe("drainPendingOnce — dequeued path", () => {
+  it("spawns and registers in-flight on a clean dequeue", async () => {
+    const entry = makeEntry();
+    const ctx = makeContext();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({ outcome: "dequeued", entry, context: ctx } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight.mock.calls[0]?.[0]).toBe(entry.deliveryId);
+    expect(mockReleaseInFlight).not.toHaveBeenCalled();
+  });
+
+  it("carries dispatchReason + maxTurns + triage complexity into the decision passed to spawn", async () => {
+    const entry = makeEntry({
+      dispatchReason: "triage",
+      maxTurns: 50,
+      triageResult: {
+        mode: "isolated-job",
+        confidence: 1,
+        complexity: "complex",
+        rationale: "big change",
+      },
+    });
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    const decisionArg = mockSpawnIsolatedJob.mock.calls[0]?.[1] as {
+      target: string;
+      reason: string;
+      maxTurns: number;
+      complexity?: string;
+    };
+    expect(decisionArg.target).toBe("isolated-job");
+    expect(decisionArg.reason).toBe("triage");
+    expect(decisionArg.maxTurns).toBe(50);
+    expect(decisionArg.complexity).toBe("complex");
+  });
+
+  it("does NOT set complexity on the decision when the queue entry has no triageResult", async () => {
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry: makeEntry({ triageResult: null }),
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    const decisionArg = mockSpawnIsolatedJob.mock.calls[0]?.[1] as {
+      complexity?: string;
+    };
+    expect(decisionArg.complexity).toBeUndefined();
+  });
+});
+
+describe("drainPendingOnce — context-missing path", () => {
+  it("logs and skips without spawning", async () => {
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "context-missing",
+          entry: makeEntry(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    expect(mockSpawnIsolatedJob).not.toHaveBeenCalled();
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+  });
+});
+
+describe("drainPendingOnce — corrupt path", () => {
+  it("logs and skips without spawning; subsequent clean dequeue still runs", async () => {
+    const entry = makeEntry({ deliveryId: "d-clean" });
+    const ctx = makeContext("d-clean");
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "corrupt",
+          raw: "not{json",
+          error: "unexpected",
+        } as DequeueResult);
+      }
+      if (calls === 2) {
+        return Promise.resolve({ outcome: "dequeued", entry, context: ctx } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight.mock.calls[0]?.[0]).toBe("d-clean");
+  });
+});
+
+describe("drainPendingOnce — spawn failure (FR-021 no retry)", () => {
+  it("releases the in-flight slot and drops the entry on spawn failure", async () => {
+    const entry = makeEntry();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+    mockSpawnIsolatedJob.mockImplementation(() => Promise.reject(new Error("k8s API unreachable")));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    await drainPendingOnce(app);
+
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+    expect(mockReleaseInFlight).toHaveBeenCalledTimes(1);
+    expect(mockReleaseInFlight.mock.calls[0]?.[0]).toBe(entry.deliveryId);
+  });
+});
+
+describe("drainPendingOnce — overlap guard", () => {
+  it("two concurrent calls share one tick (single inFlightCount sequence)", async () => {
+    // Make dequeue slow so the second call arrives while the first is
+    // still in the tick; both should await the same promise.
+    let resolved = false;
+    const slowDequeue = (): Promise<DequeueResult> =>
+      new Promise((resolve) => {
+        const done = (): void => {
+          resolved = true;
+          resolve({ outcome: "empty" } as DequeueResult);
+        };
+        setTimeout(done, 25);
+      });
+    mockDequeuePending.mockImplementation(slowDequeue);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = makeApp() as any;
+    const p1 = drainPendingOnce(app);
+    const p2 = drainPendingOnce(app);
+    await Promise.all([p1, p2]);
+
+    expect(resolved).toBe(true);
+    // Only one tick happened: inFlightCount called once, dequeuePending once.
+    expect(mockInFlightCount).toHaveBeenCalledTimes(1);
+    expect(mockDequeuePending).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("drainPendingOnce — context reconstruction", () => {
+  it("mints a fresh installation octokit via app.getInstallationOctokit", async () => {
+    const entry = makeEntry();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    const app = makeApp();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await drainPendingOnce(app as any);
+
+    expect(app.octokit.rest.apps.getRepoInstallation).toHaveBeenCalledTimes(1);
+    expect(app.getInstallationOctokit).toHaveBeenCalledTimes(1);
+    expect(app.getInstallationOctokit.mock.calls[0]?.[0]).toBe(123);
+  });
+
+  it("drops the entry when installation resolution fails", async () => {
+    const entry = makeEntry();
+    let calls = 0;
+    mockDequeuePending.mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve({
+          outcome: "dequeued",
+          entry,
+          context: makeContext(),
+        } as DequeueResult);
+      }
+      return Promise.resolve({ outcome: "empty" } as DequeueResult);
+    });
+
+    const app = makeApp();
+    app.octokit.rest.apps.getRepoInstallation = mock(() =>
+      Promise.reject(new Error("installation not found")),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await drainPendingOnce(app as any);
+
+    expect(mockSpawnIsolatedJob).not.toHaveBeenCalled();
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+  });
+});

--- a/test/k8s/pending-queue.test.ts
+++ b/test/k8s/pending-queue.test.ts
@@ -126,33 +126,37 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("enqueuePending", () => {
-  it("stores bot-context via SETEX with the documented TTL", async () => {
-    scriptSend({ LLEN: 0, RPUSH: 1 });
+describe("enqueuePending (atomic EVAL)", () => {
+  // After Copilot PR #21 review: the check-then-act LLEN+RPUSH was replaced
+  // with a single Lua EVAL that returns [status, length]. These tests mock
+  // the EVAL response directly.
 
-    const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
-
-    expect(r.outcome).toBe("enqueued");
-    const setexCall = mockSend.mock.calls.find((c) => c[0] === "SETEX");
-    expect(setexCall).toBeDefined();
-    expect(setexCall?.[1][0]).toBe("bot-context:d-001");
-    expect(setexCall?.[1][1]).toBe(String(BOT_CONTEXT_TTL_SECONDS));
-  });
-
-  it("RPUSHes the entry to the pending list", async () => {
-    scriptSend({ LLEN: 0, RPUSH: 1 });
+  it("passes the pending list, bot-context key, max, entry JSON, context JSON, and TTL as EVAL args", async () => {
+    mockSend.mockImplementation((cmd: string) => {
+      if (cmd === "EVAL") return Promise.resolve([1, 1]);
+      return Promise.resolve(null);
+    });
 
     await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
 
-    const rpushCall = mockSend.mock.calls.find((c) => c[0] === "RPUSH");
-    expect(rpushCall).toBeDefined();
-    expect(rpushCall?.[1][0]).toBe(PENDING_LIST_KEY);
-    const payload = JSON.parse(rpushCall?.[1][1] ?? "null") as PendingIsolatedJobEntry;
-    expect(payload.deliveryId).toBe("d-001");
+    const evalCall = mockSend.mock.calls.find((c) => c[0] === "EVAL");
+    expect(evalCall).toBeDefined();
+    const args = evalCall?.[1] ?? [];
+    // [script, numKeys, key1, key2, max, entryJson, contextJson, ttl]
+    expect(args[1]).toBe("2");
+    expect(args[2]).toBe(PENDING_LIST_KEY);
+    expect(args[3]).toBe("bot-context:d-001");
+    expect(args[4]).toBe("20");
+    const entryPayload = JSON.parse(args[5] ?? "null") as PendingIsolatedJobEntry;
+    expect(entryPayload.deliveryId).toBe("d-001");
+    expect(args[7]).toBe(String(BOT_CONTEXT_TTL_SECONDS));
   });
 
-  it("returns 1-indexed position from RPUSH result", async () => {
-    scriptSend({ LLEN: 2, RPUSH: 3 });
+  it("returns 1-indexed position from the EVAL success tuple", async () => {
+    mockSend.mockImplementation((cmd: string) => {
+      if (cmd === "EVAL") return Promise.resolve([1, 3]);
+      return Promise.resolve(null);
+    });
 
     const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
 
@@ -160,19 +164,35 @@ describe("enqueuePending", () => {
     if (r.outcome === "enqueued") expect(r.position).toBe(3);
   });
 
-  it("returns rejected-full when LLEN >= maxQueueLength; does NOT RPUSH or SETEX", async () => {
-    scriptSend({ LLEN: 20 });
+  it("returns rejected-full when the EVAL reject tuple fires; carries currentLength", async () => {
+    mockSend.mockImplementation((cmd: string) => {
+      if (cmd === "EVAL") return Promise.resolve([-1, 20]);
+      return Promise.resolve(null);
+    });
 
     const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
 
     expect(r.outcome).toBe("rejected-full");
     if (r.outcome === "rejected-full") expect(r.currentLength).toBe(20);
-    expect(mockSend.mock.calls.find((c) => c[0] === "RPUSH")).toBeUndefined();
+  });
+
+  it("makes exactly one Valkey round-trip (atomicity guarantee, not two check-then-acts)", async () => {
+    mockSend.mockImplementation((cmd: string) => {
+      if (cmd === "EVAL") return Promise.resolve([1, 1]);
+      return Promise.resolve(null);
+    });
+
+    await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
+
+    // Exactly one EVAL, zero standalone LLEN / SETEX / RPUSH.
+    expect(mockSend.mock.calls.filter((c) => c[0] === "EVAL")).toHaveLength(1);
+    expect(mockSend.mock.calls.find((c) => c[0] === "LLEN")).toBeUndefined();
     expect(mockSend.mock.calls.find((c) => c[0] === "SETEX")).toBeUndefined();
+    expect(mockSend.mock.calls.find((c) => c[0] === "RPUSH")).toBeUndefined();
   });
 
   it("throws on schema-invalid entries (programming error, not queue-full)", async () => {
-    scriptSend({ LLEN: 0 });
+    mockSend.mockImplementation(() => Promise.resolve(null));
 
     let threw = false;
     try {
@@ -185,6 +205,9 @@ describe("enqueuePending", () => {
       threw = true;
     }
     expect(threw).toBe(true);
+    // Schema validation short-circuits BEFORE EVAL fires — nothing should
+    // have been written to Valkey on a programming error.
+    expect(mockSend.mock.calls.find((c) => c[0] === "EVAL")).toBeUndefined();
   });
 });
 

--- a/test/k8s/pending-queue.test.ts
+++ b/test/k8s/pending-queue.test.ts
@@ -81,6 +81,8 @@ function makeEntry(overrides: Partial<PendingIsolatedJobEntry> = {}): PendingIso
     enqueuedAt: "2026-04-15T10:00:00.000Z",
     botContextKey: "bot-context:d-001",
     triageResult: null,
+    dispatchReason: "label",
+    maxTurns: 30,
     source: { owner: "o", repo: "r", issueOrPrNumber: 42 },
     ...overrides,
   };

--- a/test/k8s/pending-queue.test.ts
+++ b/test/k8s/pending-queue.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for src/k8s/pending-queue.ts — Valkey-backed FIFO pending queue +
+ * in-flight tracker for the isolated-job dispatch target (T040 + T041).
+ *
+ * Covers:
+ *   - enqueue below max → RPUSH + bot-context SETEX, returns position
+ *   - enqueue at max → rejected-full, no RPUSH, no SETEX
+ *   - FIFO ordering of dequeue (RPUSH / LPOP)
+ *   - getPosition returns 1-indexed position, null when absent
+ *   - dequeue returns context-missing when bot-context TTL expired
+ *   - dequeue returns corrupt on schema-invalid or non-JSON entries
+ *   - SADD / SREM / SCARD semantics for the in-flight tracker
+ *   - releaseInFlight deletes bot-context (SREM + DEL pairing)
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { PendingIsolatedJobEntry } from "../../src/k8s/pending-queue";
+import type { SerializableBotContext } from "../../src/shared/daemon-types";
+
+// ---------------------------------------------------------------------------
+// Mock Valkey client
+// ---------------------------------------------------------------------------
+
+interface MockSend {
+  (cmd: string, args: string[]): Promise<unknown>;
+  mock: { calls: [string, string[]][] };
+  mockClear(): void;
+  mockImplementation(fn: (cmd: string, args: string[]) => Promise<unknown>): void;
+}
+
+const mockSend = mock((_cmd: string, _args: string[]) =>
+  Promise.resolve(null as unknown),
+) as unknown as MockSend;
+
+void mock.module("../../src/orchestrator/valkey", () => ({
+  requireValkeyClient: (): { send: typeof mockSend } => ({ send: mockSend }),
+  getValkeyClient: (): { send: typeof mockSend } => ({ send: mockSend }),
+  isValkeyHealthy: (): boolean => true,
+  closeValkey: (): void => {},
+}));
+
+// Silence logger
+void mock.module("../../src/logger", () => ({
+  logger: {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    child: mock(() => ({
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    })),
+  },
+}));
+
+const {
+  BOT_CONTEXT_TTL_SECONDS,
+  IN_FLIGHT_SET_KEY,
+  PENDING_LIST_KEY,
+  dequeuePending,
+  enqueuePending,
+  getPosition,
+  inFlightCount,
+  loadBotContext,
+  pendingLength,
+  registerInFlight,
+  releaseInFlight,
+  storeBotContext,
+} = await import("../../src/k8s/pending-queue");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<PendingIsolatedJobEntry> = {}): PendingIsolatedJobEntry {
+  return {
+    deliveryId: "d-001",
+    enqueuedAt: "2026-04-15T10:00:00.000Z",
+    botContextKey: "bot-context:d-001",
+    triageResult: null,
+    source: { owner: "o", repo: "r", issueOrPrNumber: 42 },
+    ...overrides,
+  };
+}
+
+function makeContext(deliveryId = "d-001"): SerializableBotContext {
+  return {
+    deliveryId,
+    owner: "o",
+    repo: "r",
+    entityNumber: 42,
+    isPR: true,
+    eventName: "issue_comment",
+    triggerUsername: "u",
+    triggerBody: "hi",
+    labels: [],
+  } as unknown as SerializableBotContext;
+}
+
+/**
+ * Install a script that returns responses for (cmd, key) lookups. Any
+ * unregistered (cmd, key) pair resolves to `null`.
+ */
+function scriptSend(entries: Record<string, unknown>): void {
+  mockSend.mockImplementation((cmd: string, args: string[]) => {
+    const key = args[0] ?? "";
+    const full = `${cmd} ${key}`;
+    const cmdOnly = cmd;
+    if (full in entries) return Promise.resolve(entries[full]);
+    if (cmdOnly in entries) return Promise.resolve(entries[cmdOnly]);
+    return Promise.resolve(null);
+  });
+}
+
+beforeEach(() => {
+  mockSend.mockClear();
+  mockSend.mockImplementation(() => Promise.resolve(null));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("enqueuePending", () => {
+  it("stores bot-context via SETEX with the documented TTL", async () => {
+    scriptSend({ LLEN: 0, RPUSH: 1 });
+
+    const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
+
+    expect(r.outcome).toBe("enqueued");
+    const setexCall = mockSend.mock.calls.find((c) => c[0] === "SETEX");
+    expect(setexCall).toBeDefined();
+    expect(setexCall?.[1][0]).toBe("bot-context:d-001");
+    expect(setexCall?.[1][1]).toBe(String(BOT_CONTEXT_TTL_SECONDS));
+  });
+
+  it("RPUSHes the entry to the pending list", async () => {
+    scriptSend({ LLEN: 0, RPUSH: 1 });
+
+    await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
+
+    const rpushCall = mockSend.mock.calls.find((c) => c[0] === "RPUSH");
+    expect(rpushCall).toBeDefined();
+    expect(rpushCall?.[1][0]).toBe(PENDING_LIST_KEY);
+    const payload = JSON.parse(rpushCall?.[1][1] ?? "null") as PendingIsolatedJobEntry;
+    expect(payload.deliveryId).toBe("d-001");
+  });
+
+  it("returns 1-indexed position from RPUSH result", async () => {
+    scriptSend({ LLEN: 2, RPUSH: 3 });
+
+    const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
+
+    expect(r.outcome).toBe("enqueued");
+    if (r.outcome === "enqueued") expect(r.position).toBe(3);
+  });
+
+  it("returns rejected-full when LLEN >= maxQueueLength; does NOT RPUSH or SETEX", async () => {
+    scriptSend({ LLEN: 20 });
+
+    const r = await enqueuePending(makeEntry(), makeContext(), { maxQueueLength: 20 });
+
+    expect(r.outcome).toBe("rejected-full");
+    if (r.outcome === "rejected-full") expect(r.currentLength).toBe(20);
+    expect(mockSend.mock.calls.find((c) => c[0] === "RPUSH")).toBeUndefined();
+    expect(mockSend.mock.calls.find((c) => c[0] === "SETEX")).toBeUndefined();
+  });
+
+  it("throws on schema-invalid entries (programming error, not queue-full)", async () => {
+    scriptSend({ LLEN: 0 });
+
+    let threw = false;
+    try {
+      await enqueuePending(
+        { ...makeEntry(), deliveryId: "" } as PendingIsolatedJobEntry,
+        makeContext(),
+        { maxQueueLength: 20 },
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+});
+
+describe("dequeuePending", () => {
+  it("returns empty when the list is empty (LPOP null)", async () => {
+    scriptSend({ LPOP: null });
+
+    const r = await dequeuePending();
+
+    expect(r.outcome).toBe("empty");
+  });
+
+  it("returns parsed entry + bot-context on a clean LPOP", async () => {
+    const entry = makeEntry();
+    const ctx = makeContext();
+    scriptSend({
+      LPOP: JSON.stringify(entry),
+      [`GET ${entry.botContextKey}`]: JSON.stringify(ctx),
+    });
+
+    const r = await dequeuePending();
+
+    expect(r.outcome).toBe("dequeued");
+    if (r.outcome === "dequeued") {
+      expect(r.entry.deliveryId).toBe(entry.deliveryId);
+      expect(r.context.deliveryId).toBe(entry.deliveryId);
+    }
+  });
+
+  it("returns context-missing when bot-context TTL has expired (GET null)", async () => {
+    const entry = makeEntry();
+    scriptSend({
+      LPOP: JSON.stringify(entry),
+      [`GET ${entry.botContextKey}`]: null,
+    });
+
+    const r = await dequeuePending();
+
+    expect(r.outcome).toBe("context-missing");
+    if (r.outcome === "context-missing") expect(r.entry.deliveryId).toBe(entry.deliveryId);
+  });
+
+  it("returns corrupt on non-JSON payload (consumes the entry, does not requeue)", async () => {
+    scriptSend({ LPOP: "not{json" });
+
+    const r = await dequeuePending();
+
+    expect(r.outcome).toBe("corrupt");
+    // No RPUSH to the pending list to re-add the poisoned entry.
+    expect(mockSend.mock.calls.find((c) => c[0] === "RPUSH")).toBeUndefined();
+  });
+
+  it("returns corrupt on schema-invalid payload", async () => {
+    scriptSend({ LPOP: JSON.stringify({ wrong: "shape" }) });
+
+    const r = await dequeuePending();
+
+    expect(r.outcome).toBe("corrupt");
+  });
+});
+
+describe("getPosition", () => {
+  it("returns 1-indexed position when the delivery is queued", async () => {
+    const a = makeEntry({ deliveryId: "a" });
+    const b = makeEntry({ deliveryId: "b", botContextKey: "bot-context:b" });
+    const c = makeEntry({ deliveryId: "c", botContextKey: "bot-context:c" });
+    scriptSend({ LRANGE: [JSON.stringify(a), JSON.stringify(b), JSON.stringify(c)] });
+
+    expect(await getPosition("a")).toBe(1);
+    expect(await getPosition("b")).toBe(2);
+    expect(await getPosition("c")).toBe(3);
+  });
+
+  it("returns null when the delivery is not in the queue", async () => {
+    scriptSend({ LRANGE: [JSON.stringify(makeEntry())] });
+
+    expect(await getPosition("missing")).toBeNull();
+  });
+
+  it("skips unparsable entries without throwing", async () => {
+    const good = makeEntry({ deliveryId: "good" });
+    scriptSend({ LRANGE: ["not{json", JSON.stringify(good)] });
+
+    expect(await getPosition("good")).toBe(2);
+  });
+});
+
+describe("in-flight tracker", () => {
+  it("inFlightCount returns the SCARD result", async () => {
+    scriptSend({ SCARD: 2 });
+    expect(await inFlightCount()).toBe(2);
+  });
+
+  it("registerInFlight SADDs and returns the new count", async () => {
+    let sadds = 0;
+    mockSend.mockImplementation((cmd: string) => {
+      if (cmd === "SADD") {
+        sadds++;
+        return Promise.resolve(1);
+      }
+      if (cmd === "SCARD") return Promise.resolve(sadds);
+      return Promise.resolve(null);
+    });
+
+    const count = await registerInFlight("d-x");
+    expect(count).toBe(1);
+    const saddCall = mockSend.mock.calls.find((c) => c[0] === "SADD");
+    expect(saddCall?.[1]).toEqual([IN_FLIGHT_SET_KEY, "d-x"]);
+  });
+
+  it("releaseInFlight SREMs AND deletes bot-context (pairing invariant)", async () => {
+    scriptSend({});
+
+    await releaseInFlight("d-y");
+
+    const sremCall = mockSend.mock.calls.find((c) => c[0] === "SREM");
+    const delCall = mockSend.mock.calls.find((c) => c[0] === "DEL");
+    expect(sremCall?.[1]).toEqual([IN_FLIGHT_SET_KEY, "d-y"]);
+    expect(delCall?.[1]).toEqual(["bot-context:d-y"]);
+  });
+});
+
+describe("bot-context storage", () => {
+  it("storeBotContext SETEXes with TTL", async () => {
+    scriptSend({});
+    await storeBotContext("d-z", makeContext("d-z"));
+    const setex = mockSend.mock.calls.find((c) => c[0] === "SETEX");
+    expect(setex?.[1][0]).toBe("bot-context:d-z");
+    expect(setex?.[1][1]).toBe(String(BOT_CONTEXT_TTL_SECONDS));
+  });
+
+  it("loadBotContext returns null when the key is absent", async () => {
+    scriptSend({ GET: null });
+    expect(await loadBotContext("d-missing")).toBeNull();
+  });
+
+  it("loadBotContext returns null (non-fatal) on malformed JSON", async () => {
+    scriptSend({ GET: "not{json" });
+    expect(await loadBotContext("d-bad")).toBeNull();
+  });
+
+  it("loadBotContext returns the parsed context on success", async () => {
+    const ctx = makeContext("d-ok");
+    scriptSend({ GET: JSON.stringify(ctx) });
+    const loaded = await loadBotContext("d-ok");
+    expect(loaded?.deliveryId).toBe("d-ok");
+  });
+});
+
+describe("pendingLength", () => {
+  it("returns the LLEN result", async () => {
+    scriptSend({ LLEN: 7 });
+    expect(await pendingLength()).toBe(7);
+  });
+});

--- a/test/webhook/router.test.ts
+++ b/test/webhook/router.test.ts
@@ -91,6 +91,26 @@ void mock.module("../../src/db", () => ({
   getDb: mockGetDb,
 }));
 
+// US3 (T044): isolated-job dispatch now consults the Valkey-backed pending
+// queue + in-flight tracker. Mock both so tests don't need a live Valkey.
+// By default the queue is empty and in-flight is under capacity, so the
+// isolated-job branch takes its "direct spawn" path — the same behaviour
+// pre-T044 tests assumed.
+const mockInFlightCount = mock(() => Promise.resolve(0));
+const mockEnqueuePending = mock(() =>
+  Promise.resolve({ outcome: "enqueued", position: 1 } as const),
+);
+const mockRegisterInFlight = mock(() => Promise.resolve(1));
+
+void mock.module("../../src/k8s/pending-queue", () => ({
+  inFlightCount: mockInFlightCount,
+  enqueuePending: mockEnqueuePending,
+  registerInFlight: mockRegisterInFlight,
+  PENDING_LIST_KEY: "dispatch:isolated-job:pending",
+  IN_FLIGHT_SET_KEY: "dispatch:isolated-job:in-flight",
+  BOT_CONTEXT_TTL_SECONDS: 3600,
+}));
+
 // Import router AFTER mocks are set up
 const { processRequest, decideDispatch, dispatch, NotImplementedError } =
   await import("../../src/webhook/router");
@@ -1012,5 +1032,127 @@ describe("processRequest (T013) — dispatch-decision log", () => {
       // Slice B: triage never runs. US2 T036 extends with triage* fields.
       expect(payload["triageInvoked"]).toBe(false);
     }
+  });
+});
+
+// ─── US3 T044 — isolated-job capacity gating ─────────────────────────────────
+
+describe("dispatch (T044, FR-018) — isolated-job capacity gating", () => {
+  // Each test resets the queue mocks so the outer describe's defaults
+  // (in-flight=0, enqueue=enqueued) don't bleed across cases.
+
+  it("under capacity: takes the direct spawn path; does NOT call enqueuePending", async () => {
+    mockInFlightCount.mockClear();
+    mockEnqueuePending.mockClear();
+    mockRegisterInFlight.mockClear();
+    mockInFlightCount.mockImplementation(() => Promise.resolve(0));
+
+    const createComment = mock(() => Promise.resolve({ data: { id: 1 } }));
+    const ctx = makeCtx({
+      octokitOpts: {
+        createCommentFn: createComment as unknown as () => Promise<{ data: { id: number } }>,
+      },
+    });
+    const decision = {
+      target: "isolated-job" as const,
+      reason: "label" as const,
+      maxTurns: 30,
+    };
+
+    // spawnIsolatedJob throws infra-absent in the test env; that's the
+    // FR-018 rejection path which ALSO bypasses registerInFlight. The test
+    // asserts the queue gate was consulted first and rejected the
+    // enqueue path (not at capacity).
+    await dispatch(ctx, decision);
+
+    expect(mockInFlightCount).toHaveBeenCalledTimes(1);
+    expect(mockEnqueuePending).not.toHaveBeenCalled();
+  });
+
+  it("at capacity: enqueues and posts a 'Queued' tracking comment (no spawn)", async () => {
+    mockInFlightCount.mockClear();
+    mockEnqueuePending.mockClear();
+    mockRegisterInFlight.mockClear();
+    mockInFlightCount.mockImplementation(() => Promise.resolve(3)); // ≥ max default
+    mockEnqueuePending.mockImplementation(() =>
+      Promise.resolve({ outcome: "enqueued", position: 2 } as const),
+    );
+
+    const createComment = mock(() => Promise.resolve({ data: { id: 42 } }));
+    const ctx = makeCtx({
+      octokitOpts: {
+        createCommentFn: createComment as unknown as () => Promise<{ data: { id: number } }>,
+      },
+    });
+    const decision = {
+      target: "isolated-job" as const,
+      reason: "label" as const,
+      maxTurns: 30,
+    };
+
+    await dispatch(ctx, decision);
+
+    expect(mockEnqueuePending).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+    expect(createComment).toHaveBeenCalled();
+    const commentCall = (createComment as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0];
+    if (commentCall !== undefined) {
+      const [arg] = commentCall as [{ body: string }];
+      expect(arg.body).toContain("⏳ Queued");
+      expect(arg.body).toContain("position 2");
+    }
+  });
+
+  it("queue full: records capacity-rejected execution row + posts rejection comment; NO silent downgrade", async () => {
+    mockInFlightCount.mockClear();
+    mockEnqueuePending.mockClear();
+    mockRegisterInFlight.mockClear();
+    mockCreateExecution.mockClear();
+    mockGetDb.mockClear();
+    mockInFlightCount.mockImplementation(() => Promise.resolve(3));
+    mockEnqueuePending.mockImplementation(() =>
+      Promise.resolve({ outcome: "rejected-full", currentLength: 20 } as const),
+    );
+    // Provide a truthy db handle so `getDb() !== null` and the rejection
+    // write path runs. The mock doesn't speak SQL — createExecution is
+    // itself mocked; we just need getDb to return non-null.
+    mockGetDb.mockImplementation(() => ({}) as unknown);
+
+    const createComment = mock(() => Promise.resolve({ data: { id: 99 } }));
+    const ctx = makeCtx({
+      octokitOpts: {
+        createCommentFn: createComment as unknown as () => Promise<{ data: { id: number } }>,
+      },
+    });
+    const decision = {
+      target: "isolated-job" as const,
+      reason: "label" as const,
+      maxTurns: 30,
+    };
+
+    await dispatch(ctx, decision);
+
+    // Tracking comment surfaced the queue-full rejection.
+    expect(createComment).toHaveBeenCalled();
+    const commentCall = (createComment as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0];
+    if (commentCall !== undefined) {
+      const [arg] = commentCall as [{ body: string }];
+      expect(arg.body.toLowerCase()).toContain("pool is at capacity");
+      expect(arg.body.toLowerCase()).toContain("will not silently downgrade");
+    }
+
+    // Execution row recorded with dispatch_reason="capacity-rejected".
+    expect(mockCreateExecution).toHaveBeenCalled();
+    const execCall = mockCreateExecution.mock.calls[0];
+    if (execCall !== undefined) {
+      const [arg] = execCall as [{ dispatchMode: string; dispatchReason: string }];
+      expect(arg.dispatchMode).toBe("isolated-job");
+      expect(arg.dispatchReason).toBe("capacity-rejected");
+    }
+
+    // Restore the default for subsequent tests.
+    mockGetDb.mockImplementation(() => null as unknown);
   });
 });


### PR DESCRIPTION
## Description

Slice E of the triage-dispatch-modes feature (spec `20260415-000159-triage-dispatch-modes`) — **part 1** of US3 capacity back-pressure. Introduces the Valkey-backed pending queue, in-flight capacity tracker, router-level capacity gate, and the background drainer that completes the flow when capacity frees.

**Scope intentionally split**: tasks T046 (wall-clock timeout), T047 (cleanup `finally`), T048 (no-retry integration test), T042 (US3 integration test), and T049 (JSDoc pass) will land in a follow-up PR on the same branch or successor. This PR is self-contained and green on its own — the capacity gate + drainer work end-to-end against the current spawner; the follow-up is purely about hardening the spawner's completion watch.

### Before (Slice D merged)

```mermaid
flowchart LR
    WH["Webhook<br/>`@chrisleekr-bot`"]:::entry --> RT["router.dispatch<br/>isolated-job branch"]:::hot
    RT --> SPN["spawnIsolatedJob<br/>K8s Job"]:::ok
    SPN --> POD["Isolated Pod<br/>runs inline pipeline"]:::ok
    RT -.no-backpressure.-> RT
    classDef entry fill:#0a4b78,stroke:#0a3552,color:#ffffff
    classDef hot fill:#cc4125,stroke:#7a2814,color:#ffffff
    classDef ok fill:#2e7d32,stroke:#1b4d20,color:#ffffff
```

### After (this PR)

```mermaid
flowchart LR
    WH["Webhook"]:::entry --> RT["router.dispatchIsolatedJob"]:::hot
    RT --> GATE{"inFlightCount<br/>&ge; MAX_CONCURRENT?"}:::gate
    GATE -- no --> SPN["spawnIsolatedJob<br/>+ registerInFlight"]:::ok
    GATE -- yes --> Q{"queue full?"}:::gate
    Q -- no --> EQ["enqueuePending<br/>post 'Queued' comment"]:::queue
    Q -- yes --> REJ["capacity-rejected row<br/>+ rejection comment"]:::reject
    SPN --> POD["Isolated Pod"]:::ok
    EQ -.-> DRN["Drainer tick<br/>5s interval"]:::drainer
    DRN --> GATE2{"capacity free?"}:::gate
    GATE2 -- yes --> DQ["dequeuePending<br/>rebuild ctx<br/>spawn + register"]:::drainer
    DQ --> POD
    classDef entry fill:#0a4b78,stroke:#0a3552,color:#ffffff
    classDef hot fill:#cc4125,stroke:#7a2814,color:#ffffff
    classDef ok fill:#2e7d32,stroke:#1b4d20,color:#ffffff
    classDef gate fill:#f9a825,stroke:#7a5000,color:#000000
    classDef queue fill:#5e35b1,stroke:#311b92,color:#ffffff
    classDef reject fill:#880e4f,stroke:#4a0028,color:#ffffff
    classDef drainer fill:#0277bd,stroke:#013f68,color:#ffffff
```

## Changes

### `src/k8s/pending-queue.ts` (new — T043)

- Valkey-backed FIFO list `dispatch:isolated-job:pending` + set `dispatch:isolated-job:in-flight`.
- Public API: `enqueuePending`, `dequeuePending`, `getPosition`, `pendingLength`, `inFlightCount`, `registerInFlight`, `releaseInFlight`, `storeBotContext`, `loadBotContext`, `deleteBotContext`.
- Zod-validated on BOTH enqueue (programming-error fast-fail) and dequeue (schema-drift tolerance). Corrupt entries are consumed, not requeued — a poison message cannot block the pool.
- Write order in `enqueuePending`: `SETEX bot-context:<id>` FIRST, then `RPUSH` — a racing dequeue cannot observe a list entry without its context.
- `releaseInFlight` pairs `SREM` with `DEL bot-context:<id>` (cleanup invariant for the follow-up T047).

### `src/k8s/pending-queue-drainer.ts` (new — T044 drainer)

- Single `setInterval` tick (5s default, `unref`'d). Overlap-guarded via shared promise so concurrent callers await the same tick.
- On each tick: while capacity free AND queue non-empty, pop + spawn.
- Context reconstruction: mints a fresh installation octokit via `App.octokit.rest.apps.getRepoInstallation` + `App.getInstallationOctokit` (the stored token at enqueue time is likely expired by drain time).
- FR-021: on spawn failure, `releaseInFlight` + drop entry (no mid-run retry).

### `src/webhook/router.ts` (T044 wiring)

- New `dispatchIsolatedJob` function replaces the direct-spawn isolated-job branch.
- Three outcomes: direct spawn + `registerInFlight`, at-capacity enqueue + "Queued" comment, rejected-full + `capacity-rejected` executions row + rejection comment.
- FR-018: no silent downgrade to shared-runner/daemon on queue-full.
- `registerInFlight` is wrapped in `try/catch` — slot accounting is best-effort, not a liveness source.

### `src/core/tracking-comment.ts` (T045)

- `renderQueuePosition(position, max)` — pure helper producing `"⏳ Queued (position N of M on isolated-job pool). Waiting for capacity…"`. Defensively `Math.trunc`'s both inputs against future float callers.

### `src/app.ts`

- Starts drainer at startup when `agentJobMode` is `isolated-job` or `auto`.
- Stops drainer before Valkey teardown in the shutdown handler.

### Tests

- `test/k8s/pending-queue.test.ts` — 21 tests (100% coverage): enqueue under/at max, schema-invalid rejection, dequeue 4 outcomes, FIFO, `getPosition` 1-indexing + skip-unparsable, in-flight SADD/SREM/SCARD, release pairs with DEL, bot-context malformed-JSON tolerance.
- `test/k8s/pending-queue-drainer.test.ts` — 11 tests: empty/capacity-gated/dequeued/context-missing/corrupt paths, `dispatchReason` + `maxTurns` + triage complexity threading, spawn-failure no-retry, overlap guard (two concurrent ticks share one promise), context reconstruction.
- `test/webhook/router.test.ts` — 3 new US3 capacity tests (under/at/full).
- `test/core/tracking-comment.test.ts` — 3 new `renderQueuePosition` tests.

## Related Issues

- Spec: `specs/20260415-000159-triage-dispatch-modes/` (US3).
- Follow-up work on same feature branch: T042, T046, T047, T048, T049.

## Testing

- [x] I have tested these changes locally (`bun run typecheck`, `bun run lint` → 0 errors, `bash scripts/test-isolated.sh` → 30/30 files green).
- [x] I have added/updated tests as needed (38 new tests; 100% coverage on `pending-queue.ts`, 84% on `pending-queue-drainer.ts`).
- [x] All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)