### PR TITLE
feat(triage): slice E part 2 — isolated-job completion watcher (T042/T046–T049)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ ANTHROPIC_API_KEY=
 # format than the Anthropic API). Optional for anthropic (SDK uses its own default).
 # Bedrock example:  us.anthropic.claude-sonnet-4-6
 # Anthropic example: claude-opus-4-5
-CLAUDE_MODEL=
+CLAUDE_MODEL=claude-opus-4-5
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Amazon Bedrock (when CLAUDE_PROVIDER=bedrock)
@@ -107,6 +107,16 @@ AGENT_JOB_MODE=inline
 
 # TTL for completed job pods (seconds)
 # JOB_TTL_SECONDS=300
+
+# Hard wall-clock ceiling on an isolated-job run (seconds). K8s enforces
+# server-side via Job.spec.activeDeadlineSeconds; the app-side watcher also
+# enforces this and, on timeout, deletes the Job, writes a
+# status="timeout" execution row, and releases the in-flight slot. Keep
+# strictly below the installation-token TTL (GitHub: 3600s).
+# JOB_ACTIVE_DEADLINE_SECONDS=1800
+
+# Poll interval for the server-side isolated-job completion watcher.
+# JOB_WATCH_POLL_INTERVAL_MS=5000
 
 # ClusterIP URL of the shared runner Service
 # INTERNAL_RUNNER_URL=

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,16 @@ const configSchema = z
     jobNamespace: z.string().default("github-app"),
     jobImage: z.string().optional(),
     jobTtlSeconds: z.coerce.number().int().positive().default(300),
+    // K8s `activeDeadlineSeconds` — hard wall-clock ceiling on an isolated-
+    // job run. K8s enforces server-side; the app-side watcher polls status
+    // and, on timeout, deletes the Job, writes a `status="timeout"`
+    // execution row, and releases the in-flight slot. Keep strictly below
+    // the installation-token TTL (GitHub: 3600s).
+    jobActiveDeadlineSeconds: z.coerce.number().int().positive().max(3500).default(1800),
+    // Client-side poll interval used by `watchJobCompletion`. Too-frequent
+    // polling burns K8s API budget; too-slow polling delays releaseInFlight
+    // past true completion and causes the capacity gate to under-provision.
+    jobWatchPollIntervalMs: z.coerce.number().int().positive().default(5000),
     // Internal HTTP endpoint for the shared-runner pool. Required when
     // agentJobMode is "shared-runner" or "auto" (enforced in superRefine).
     internalRunnerUrl: z.url().optional(),
@@ -480,6 +490,8 @@ function loadConfig(): Config {
     jobNamespace: process.env["JOB_NAMESPACE"],
     jobImage: process.env["JOB_IMAGE"],
     jobTtlSeconds: process.env["JOB_TTL_SECONDS"],
+    jobActiveDeadlineSeconds: process.env["JOB_ACTIVE_DEADLINE_SECONDS"],
+    jobWatchPollIntervalMs: process.env["JOB_WATCH_POLL_INTERVAL_MS"],
     internalRunnerUrl: process.env["INTERNAL_RUNNER_URL"],
 
     // Data layer

--- a/src/k8s/job-spawner.ts
+++ b/src/k8s/job-spawner.ts
@@ -1,8 +1,15 @@
-import { BatchV1Api, KubeConfig, type V1Job } from "@kubernetes/client-node";
+import { BatchV1Api, KubeConfig, type V1Job, type V1JobStatus } from "@kubernetes/client-node";
+import type { Logger } from "pino";
 
 import { config } from "../config";
+import { getDb } from "../db";
+import { logger } from "../logger";
+import { markExecutionFailed } from "../orchestrator/history";
 import { type BotContext, type ExecutionResult, serializeBotContext } from "../types";
 import type { DispatchDecision } from "../webhook/router";
+import { releaseInFlight } from "./pending-queue";
+
+type WatchLogger = Logger;
 
 /**
  * Typed errors the isolated-job spawner can throw. Distinguishing
@@ -88,21 +95,31 @@ export function _resetK8sClientForTests(): void {
  * agent starts — avoids a race where Claude tries `docker info` before the
  * sidecar has bound the socket.
  *
- * Cleanup: backoffLimit=0 (no K8s retry — idempotency belongs to the app
- * layer), ttlSecondsAfterFinished=3600 (auto-clean after 1h),
- * activeDeadlineSeconds=1800 (30-min wall clock).
+ * Cleanup: backoffLimit=0 (no K8s retry — idempotency AND FR-021 no-retry
+ * on mid-run failure both belong to the app layer, not K8s), TTL matches
+ * `config.jobTtlSeconds`, activeDeadlineSeconds matches
+ * `config.jobActiveDeadlineSeconds` (K8s enforces the hard wall clock;
+ * `watchJobCompletion` below enforces the same ceiling client-side and
+ * owns the `status="timeout"` execution row + `releaseInFlight` cleanup).
  */
+/**
+ * Stable, deterministic Job name derived from the delivery id. DNS-1123
+ * (lowercase alphanumeric + dashes, ≤63 chars). Exported so the
+ * completion watcher can reconstruct the name without threading it
+ * through every caller.
+ */
+export function jobNameForDelivery(deliveryId: string): string {
+  return `bot-${deliveryId
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "-")
+    .slice(0, 50)}`;
+}
+
 function buildJobSpec(ctx: BotContext, decision: DispatchDecision, encodedContext: string): V1Job {
   const namespace = config.jobNamespace;
   const image = config.jobImage ?? "github-app-playground:local";
   const ttlSeconds = config.jobTtlSeconds;
-  // Job names must be DNS-1123 (lowercase alphanumeric + dashes, ≤63 chars).
-  // deliveryId is a UUID; lower-case it and prefix with a stable token so the
-  // Job is greppable in `kubectl get jobs`.
-  const jobName = `bot-${ctx.deliveryId
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "-")
-    .slice(0, 50)}`;
+  const jobName = jobNameForDelivery(ctx.deliveryId);
 
   // Provider credentials forwarded to the pod. These mirror what the
   // executor injects into the Claude CLI subprocess on the inline path —
@@ -150,7 +167,7 @@ function buildJobSpec(ctx: BotContext, decision: DispatchDecision, encodedContex
     spec: {
       backoffLimit: 0,
       ttlSecondsAfterFinished: ttlSeconds,
-      activeDeadlineSeconds: 1800,
+      activeDeadlineSeconds: config.jobActiveDeadlineSeconds,
       template: {
         metadata: {
           labels: { "app.kubernetes.io/component": "isolated-job" },
@@ -245,4 +262,246 @@ export async function spawnIsolatedJob(
   }
 
   return { success: true, durationMs: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Completion watcher (T046 + T047 + T048)
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminal outcome of `watchJobCompletion`. Each outcome maps to a
+ * distinct operator story:
+ *
+ *   - `succeeded` : Job completed with at least one successful Pod. The
+ *                   entrypoint already wrote `status='completed'` and
+ *                   finalised the tracking comment; the watcher only
+ *                   releases the in-flight slot.
+ *   - `failed`    : Job reported a Pod failure that was NOT a deadline
+ *                   timeout. Entrypoint owns the row + comment; FR-021
+ *                   forbids automatic retry, so the watcher only releases.
+ *   - `timeout`   : Wall-clock ceiling reached (either K8s observed the
+ *                   `activeDeadlineSeconds` or the client-side deadline
+ *                   fires first). Watcher deletes the Job (idempotent),
+ *                   marks the execution row failed with a timeout-tagged
+ *                   error message, and releases the slot.
+ *   - `abandoned` : Job disappeared (deleted externally) or was never
+ *                   observed. Watcher releases the slot and logs; no DB
+ *                   write — the entrypoint row, if any, is left intact.
+ */
+export type JobWatchOutcome = "succeeded" | "failed" | "timeout" | "abandoned";
+
+/**
+ * Options for `watchJobCompletion`. All `inject*` callbacks exist purely
+ * for deterministic tests — production callers pass none and get the
+ * real wall clock / K8s client / bundled cleanup helpers.
+ */
+export interface WatchJobCompletionOptions {
+  /** Optional override for the wall-clock deadline (ms). Defaults to `config.jobActiveDeadlineSeconds * 1000`. */
+  deadlineMs?: number;
+  /** Optional override for the poll interval (ms). Defaults to `config.jobWatchPollIntervalMs`. */
+  pollIntervalMs?: number;
+  /** Optional namespace override. Defaults to `config.jobNamespace`. */
+  namespace?: string;
+
+  // --- test injection ---
+  /** Override the K8s BatchV1Api — tests pass a stub. */
+  injectClient?: Pick<BatchV1Api, "readNamespacedJobStatus" | "deleteNamespacedJob">;
+  /** Override `Date.now()` for deterministic timeout assertions. */
+  injectNow?: () => number;
+  /** Override `setTimeout`-based sleep to keep tests fast. */
+  injectSleep?: (ms: number) => Promise<void>;
+  /** Override the DB status writer. Tests capture calls to assert the timeout path wrote the row. */
+  injectMarkFailed?: (deliveryId: string, errorMessage: string) => Promise<void>;
+  /** Override `releaseInFlight`. Tests assert the `finally` invariant fires on every exit path. */
+  injectReleaseInFlight?: (deliveryId: string) => Promise<void>;
+}
+
+/**
+ * Watch an isolated-job to completion. Fire-and-forget from the router's
+ * perspective: intended to be invoked via `void watchJobCompletion(...)` so
+ * the webhook can return its 200 immediately and the watcher runs in the
+ * background until the Job terminates or the wall-clock deadline elapses.
+ *
+ * Invariants:
+ *
+ *   - (T047) `releaseInFlight(deliveryId)` runs in a `finally` block on
+ *     every exit path — success, failure, timeout, K8s error, unexpected
+ *     throw. Without this the in-flight capacity counter would leak slots
+ *     and the pool would eventually refuse work despite having capacity.
+ *   - (T048 / FR-021) On `failed` or `timeout`, the watcher records the
+ *     failure but does NOT re-enqueue or re-dispatch. The maintainer must
+ *     re-trigger manually.
+ *   - (T046) The watcher enforces a wall-clock ceiling independently of
+ *     `activeDeadlineSeconds`. The K8s-side deadline is authoritative for
+ *     actually killing the Pod; the client-side deadline guarantees the
+ *     row + in-flight slot are cleaned up even if the K8s API becomes
+ *     unreachable past the deadline. When the deadline fires first,
+ *     `deleteNamespacedJob` is best-effort (swallowed on failure).
+ *
+ * @returns The terminal outcome. Never throws to the caller; all failures
+ *          are converted to `abandoned` so a detached `void watchJobCompletion(...)`
+ *          call can't crash the server with an unhandled rejection.
+ */
+export async function watchJobCompletion(
+  deliveryId: string,
+  options: WatchJobCompletionOptions = {},
+): Promise<JobWatchOutcome> {
+  const namespace = options.namespace ?? config.jobNamespace;
+  const deadlineMs = options.deadlineMs ?? config.jobActiveDeadlineSeconds * 1000;
+  const pollIntervalMs = options.pollIntervalMs ?? config.jobWatchPollIntervalMs;
+  const now = options.injectNow ?? Date.now;
+  const sleep = options.injectSleep ?? defaultSleep;
+  const markFailed = options.injectMarkFailed ?? defaultMarkFailed;
+  const release = options.injectReleaseInFlight ?? releaseInFlight;
+
+  const jobName = jobNameForDelivery(deliveryId);
+  const log = logger.child({ module: "job-spawner.watch", deliveryId, jobName });
+  const startedAt = now();
+
+  let client: Pick<BatchV1Api, "readNamespacedJobStatus" | "deleteNamespacedJob">;
+  try {
+    client = options.injectClient ?? loadKubernetesClient().batch;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "watchJobCompletion could not load K8s client — releasing slot and abandoning watch",
+    );
+    await safeRelease(release, deliveryId, log);
+    return "abandoned";
+  }
+
+  try {
+    // Poll loop. `sleep` runs at the top so the first status read happens
+    // one interval after spawn — the Pod is typically still pulling images
+    // for the first few seconds and reading status that early returns nothing
+    // useful.
+
+    while (true) {
+      await sleep(pollIntervalMs);
+
+      const elapsed = now() - startedAt;
+      if (elapsed >= deadlineMs) {
+        log.warn({ elapsedMs: elapsed, deadlineMs }, "isolated-job wall-clock deadline reached");
+        await bestEffortDelete(client, namespace, jobName, log);
+        await markFailed(
+          deliveryId,
+          `isolated-job exceeded wall-clock deadline of ${Math.round(deadlineMs / 1000)}s`,
+        );
+        return "timeout";
+      }
+
+      const status = await safeReadStatus(client, namespace, jobName, log);
+      if (status === null) return "abandoned";
+
+      if ((status.succeeded ?? 0) >= 1) {
+        log.info({ elapsedMs: elapsed }, "isolated-job succeeded");
+        return "succeeded";
+      }
+
+      if ((status.failed ?? 0) >= 1) {
+        const deadlineExceeded = jobFailedForDeadline(status);
+        if (deadlineExceeded) {
+          log.warn({ elapsedMs: elapsed }, "isolated-job terminated by K8s DeadlineExceeded");
+          await bestEffortDelete(client, namespace, jobName, log);
+          await markFailed(
+            deliveryId,
+            `isolated-job terminated by Kubernetes: DeadlineExceeded after ${Math.round(
+              elapsed / 1000,
+            )}s`,
+          );
+          return "timeout";
+        }
+        log.warn({ elapsedMs: elapsed }, "isolated-job failed");
+        // Entrypoint owns the DB row + tracking comment on a graceful
+        // failure; FR-021 forbids retry. Watcher only releases (via finally).
+        return "failed";
+      }
+
+      // else: still Pending / Running — loop again.
+    }
+  } finally {
+    await safeRelease(release, deliveryId, log);
+  }
+}
+
+function jobFailedForDeadline(status: V1JobStatus): boolean {
+  const conds = status.conditions ?? [];
+  return conds.some((c) => c.type === "Failed" && c.reason === "DeadlineExceeded");
+}
+
+async function safeReadStatus(
+  client: Pick<BatchV1Api, "readNamespacedJobStatus">,
+  namespace: string,
+  jobName: string,
+  log: WatchLogger,
+): Promise<V1JobStatus | null> {
+  try {
+    const resp = await client.readNamespacedJobStatus({ namespace, name: jobName });
+    return resp.status ?? {};
+  } catch (err) {
+    const status =
+      (err as { statusCode?: number; response?: { statusCode?: number } })?.statusCode ??
+      (err as { response?: { statusCode?: number } })?.response?.statusCode;
+    if (status === 404) {
+      // Job disappeared — nothing to watch. Treat as abandoned so the
+      // caller's finally block still releases the slot.
+      log.warn({ status }, "isolated-job not found (404) — watch abandoned");
+      return null;
+    }
+    // Transient: log + keep polling. Real operator remedies (API down for
+    // > deadline) are handled by the wall-clock deadline branch.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), status },
+      "isolated-job status read failed — retrying",
+    );
+    return {};
+  }
+}
+
+async function bestEffortDelete(
+  client: Pick<BatchV1Api, "deleteNamespacedJob">,
+  namespace: string,
+  jobName: string,
+  log: WatchLogger,
+): Promise<void> {
+  try {
+    await client.deleteNamespacedJob({
+      namespace,
+      name: jobName,
+      propagationPolicy: "Background",
+    });
+  } catch (err) {
+    // Not fatal: K8s enforces activeDeadlineSeconds server-side anyway; the
+    // manual delete is only to reclaim pod/sidecar resources faster.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "best-effort delete of timed-out Job failed",
+    );
+  }
+}
+
+async function safeRelease(
+  release: (deliveryId: string) => Promise<void>,
+  deliveryId: string,
+  log: WatchLogger,
+): Promise<void> {
+  try {
+    await release(deliveryId);
+  } catch (err) {
+    // Never let a release-time Valkey outage crash the watcher — the
+    // in-flight set entry will age out with the bot-context TTL.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "releaseInFlight failed after Job completion — slot accounting may drift",
+    );
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function defaultMarkFailed(deliveryId: string, errorMessage: string): Promise<void> {
+  if (getDb() === null) return;
+  await markExecutionFailed(deliveryId, errorMessage);
 }

--- a/src/k8s/job-spawner.ts
+++ b/src/k8s/job-spawner.ts
@@ -296,7 +296,12 @@ export type JobWatchOutcome = "succeeded" | "failed" | "timeout" | "abandoned";
  * real wall clock / K8s client / bundled cleanup helpers.
  */
 export interface WatchJobCompletionOptions {
-  /** Optional override for the wall-clock deadline (ms). Defaults to `config.jobActiveDeadlineSeconds * 1000`. */
+  /**
+   * Optional override for the wall-clock deadline (ms). Defaults to
+   * `config.jobActiveDeadlineSeconds * 1000`. Capped at the default — a
+   * caller may shorten the watch but MUST NOT extend it past the
+   * server-side `activeDeadlineSeconds` used when creating the Job.
+   */
   deadlineMs?: number;
   /** Optional override for the poll interval (ms). Defaults to `config.jobWatchPollIntervalMs`. */
   pollIntervalMs?: number;
@@ -347,7 +352,16 @@ export async function watchJobCompletion(
   options: WatchJobCompletionOptions = {},
 ): Promise<JobWatchOutcome> {
   const namespace = options.namespace ?? config.jobNamespace;
-  const deadlineMs = options.deadlineMs ?? config.jobActiveDeadlineSeconds * 1000;
+  // T046: cap the wall-clock deadline at the config ceiling
+  // (`config.jobActiveDeadlineSeconds`, itself bounded at 3500s by the
+  // Zod schema so the GitHub installation-token TTL stays intact). A
+  // caller-provided `deadlineMs` may shorten the watch but MUST NOT
+  // extend it past the server-side `activeDeadlineSeconds` used when
+  // creating the Job — otherwise the watcher could linger after K8s has
+  // already killed the Pod.
+  const maxDeadlineMs = config.jobActiveDeadlineSeconds * 1000;
+  const rawDeadlineMs = options.deadlineMs ?? maxDeadlineMs;
+  const deadlineMs = Math.min(rawDeadlineMs, maxDeadlineMs);
   const pollIntervalMs = options.pollIntervalMs ?? config.jobWatchPollIntervalMs;
   const now = options.injectNow ?? Date.now;
   const sleep = options.injectSleep ?? defaultSleep;
@@ -371,13 +385,19 @@ export async function watchJobCompletion(
   }
 
   try {
-    // Poll loop. `sleep` runs at the top so the first status read happens
-    // one interval after spawn — the Pod is typically still pulling images
-    // for the first few seconds and reading status that early returns nothing
-    // useful.
-
+    // Poll loop. The entire body is wrapped so any unexpected throw from
+    // `injectSleep` / `injectMarkFailed` / `bestEffortDelete` is converted
+    // to `abandoned` rather than propagating as an unhandled rejection
+    // (the docstring's "Never throws to the caller" guarantee).
+    // The outer `finally` still fires, so the in-flight slot is always
+    // released.
     while (true) {
-      await sleep(pollIntervalMs);
+      // Cap the sleep to the remaining budget so a large `pollIntervalMs`
+      // can't overshoot the deadline by a full interval. `Math.max(1, …)`
+      // guarantees forward progress when we're right at the boundary.
+      const remaining = deadlineMs - (now() - startedAt);
+      const nextSleepMs = Math.max(1, Math.min(pollIntervalMs, remaining));
+      await sleep(nextSleepMs);
 
       const elapsed = now() - startedAt;
       if (elapsed >= deadlineMs) {
@@ -419,6 +439,17 @@ export async function watchJobCompletion(
 
       // else: still Pending / Running — loop again.
     }
+  } catch (err) {
+    // Defense-in-depth: anything thrown from inside the loop (injected
+    // sleep, markFailed, bestEffortDelete, or an unexpected
+    // non-duck-typed K8s error) is converted to `abandoned`. Without
+    // this outer catch, a `void watchJobCompletion(...)` call could
+    // surface as an unhandled rejection and crash the server.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "watchJobCompletion encountered unexpected error — abandoning watch",
+    );
+    return "abandoned";
   } finally {
     await safeRelease(release, deliveryId, log);
   }
@@ -488,17 +519,27 @@ async function safeRelease(
   try {
     await release(deliveryId);
   } catch (err) {
-    // Never let a release-time Valkey outage crash the watcher — the
-    // in-flight set entry will age out with the bot-context TTL.
+    // Never let a release-time Valkey outage crash the watcher. NOTE: the
+    // in-flight set (`dispatch:isolated-job:in-flight`) has no TTL, so a
+    // persistently failing release leaks a permanent capacity slot until
+    // an operator trims the set manually. Surfaced at ERROR level so the
+    // operator picks it up via alerting.
     log.error(
       { err: err instanceof Error ? err.message : String(err) },
-      "releaseInFlight failed after Job completion — slot accounting may drift",
+      "releaseInFlight failed after Job completion — slot LEAKED (manual cleanup required)",
     );
   }
 }
 
 function defaultSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    // `.unref()` so an in-flight watcher's poll timer does not keep the
+    // webhook server process alive for up to the job deadline (30+ min)
+    // during graceful shutdown. The watcher is best-effort; on SIGTERM the
+    // entrypoint's own handler owns the row/comment finalisation, and K8s
+    // enforces `activeDeadlineSeconds` server-side anyway.
+    setTimeout(resolve, ms).unref();
+  });
 }
 
 async function defaultMarkFailed(deliveryId: string, errorMessage: string): Promise<void> {

--- a/src/k8s/pending-queue-drainer.ts
+++ b/src/k8s/pending-queue-drainer.ts
@@ -24,7 +24,7 @@ import { createChildLogger, logger } from "../logger";
 import type { SerializableBotContext } from "../shared/daemon-types";
 import type { BotContext } from "../types";
 import type { DispatchDecision } from "../webhook/router";
-import { JobSpawnerError, spawnIsolatedJob } from "./job-spawner";
+import { JobSpawnerError, spawnIsolatedJob, watchJobCompletion } from "./job-spawner";
 import {
   dequeuePending,
   inFlightCount,
@@ -151,6 +151,15 @@ async function drainLoop(app: App): Promise<void> {
       await spawnIsolatedJob(ctx, decision);
       // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
       await registerInFlight(ctx.deliveryId);
+      // Fire-and-forget completion watcher — same invariants as the
+      // direct-spawn path (T046/T047/T048). Drainer must NOT await it;
+      // the drain loop needs to move to the next entry.
+      void watchJobCompletion(ctx.deliveryId).catch((err: unknown) => {
+        ctx.log.error(
+          { err, deliveryId: ctx.deliveryId },
+          "watchJobCompletion threw unexpectedly in drainer — in-flight slot may leak",
+        );
+      });
       ctx.log.info({ deliveryId: ctx.deliveryId }, "drained queued isolated-job — Job spawned");
     } catch (err) {
       // FR-021: no retry on mid-run failure. Just release any slot and log.

--- a/src/k8s/pending-queue-drainer.ts
+++ b/src/k8s/pending-queue-drainer.ts
@@ -146,21 +146,15 @@ async function drainLoop(app: App): Promise<void> {
       }),
     };
 
+    // Spawn is the only step whose failure means "Job never started" —
+    // only spawn failure justifies releasing the slot + posting
+    // infra-absent. Register and watch failures must NOT be treated as
+    // spawn failures: once spawn succeeds the Job is running on the
+    // cluster, and skipping `watchJobCompletion()` would lose
+    // timeout/cleanup monitoring entirely (CodeRabbit PR #22).
     try {
       // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
       await spawnIsolatedJob(ctx, decision);
-      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
-      await registerInFlight(ctx.deliveryId);
-      // Fire-and-forget completion watcher — same invariants as the
-      // direct-spawn path (T046/T047/T048). Drainer must NOT await it;
-      // the drain loop needs to move to the next entry.
-      void watchJobCompletion(ctx.deliveryId).catch((err: unknown) => {
-        ctx.log.error(
-          { err, deliveryId: ctx.deliveryId },
-          "watchJobCompletion threw unexpectedly in drainer — in-flight slot may leak",
-        );
-      });
-      ctx.log.info({ deliveryId: ctx.deliveryId }, "drained queued isolated-job — Job spawned");
     } catch (err) {
       // FR-021: no retry on mid-run failure. Just release any slot and log.
       //
@@ -181,7 +175,35 @@ async function drainLoop(app: App): Promise<void> {
       }
       // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
       await releaseInFlight(ctx.deliveryId);
+      continue;
     }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop -- drainer is sequential by design
+      await registerInFlight(ctx.deliveryId);
+    } catch (err) {
+      // Non-fatal: the Job is already running. An unregistered in-flight
+      // slot only means capacity accounting drifts low (the pool admits
+      // one fewer Job until an operator resyncs Valkey); the watcher
+      // below is still the source of truth for cleanup.
+      ctx.log.warn(
+        { err, deliveryId: ctx.deliveryId },
+        "isolated-job registerInFlight failed — slot accounting may drift",
+      );
+    }
+
+    // Fire-and-forget completion watcher — same invariants as the
+    // direct-spawn path (T046/T047/T048). Fires regardless of
+    // registerInFlight outcome because the Job itself is already running.
+    // Drainer must NOT await it; the drain loop needs to move to the
+    // next entry.
+    void watchJobCompletion(ctx.deliveryId).catch((err: unknown) => {
+      ctx.log.error(
+        { err, deliveryId: ctx.deliveryId },
+        "watchJobCompletion threw unexpectedly in drainer — in-flight slot may leak",
+      );
+    });
+    ctx.log.info({ deliveryId: ctx.deliveryId }, "drained queued isolated-job — Job spawned");
   }
 }
 

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -3,7 +3,7 @@ import { runInlinePipeline } from "../core/inline-pipeline";
 import { isAlreadyProcessed, renderQueuePosition } from "../core/tracking-comment";
 import { getDb } from "../db";
 import { classifyStatic } from "../k8s/classifier";
-import { JobSpawnerError, spawnIsolatedJob } from "../k8s/job-spawner";
+import { JobSpawnerError, spawnIsolatedJob, watchJobCompletion } from "../k8s/job-spawner";
 import {
   enqueuePending,
   inFlightCount,
@@ -461,6 +461,20 @@ async function dispatchIsolatedJob(ctx: BotContext, decision: DispatchDecision):
       "isolated-job registerInFlight failed — slot accounting may drift",
     );
   }
+
+  // Fire-and-forget completion watcher (T046/T047/T048). Runs in the
+  // background for the Job's lifetime; on termination it releases the
+  // in-flight slot, and on wall-clock timeout it also updates the
+  // executions row. `.catch` exists so a Promise rejection never
+  // surfaces as an unhandledRejection — the watcher itself already
+  // translates all internal errors to `abandoned`, but the guard is a
+  // cheap belt-and-braces against future refactors.
+  void watchJobCompletion(ctx.deliveryId).catch((err: unknown) => {
+    ctx.log.error(
+      { err, deliveryId: ctx.deliveryId },
+      "watchJobCompletion threw unexpectedly — in-flight slot may leak",
+    );
+  });
 }
 
 /**

--- a/test/k8s/job-spawner.watch.test.ts
+++ b/test/k8s/job-spawner.watch.test.ts
@@ -11,9 +11,10 @@
 
 import { describe, expect, it, mock } from "bun:test";
 
-import { watchJobCompletion } from "../../src/k8s/job-spawner";
-
-// Silence logger
+// Silence logger — mock MUST be registered before `../../src/k8s/job-spawner`
+// is imported, otherwise the real pino module is already in the module
+// cache and the mock never takes effect. `await import(...)` below defers
+// the spawner module load until after the mock is registered.
 void mock.module("../../src/logger", () => ({
   logger: {
     info: mock(() => {}),
@@ -25,6 +26,8 @@ void mock.module("../../src/logger", () => ({
     }),
   },
 }));
+
+const { watchJobCompletion } = await import("../../src/k8s/job-spawner");
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/k8s/job-spawner.watch.test.ts
+++ b/test/k8s/job-spawner.watch.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for `watchJobCompletion` in src/k8s/job-spawner.ts — the
+ * completion watcher that enforces T046 (wall-clock timeout),
+ * T047 (releaseInFlight in finally), and T048 (FR-021 no retry on
+ * mid-run failure).
+ *
+ * All tests inject the K8s client, sleep, now, markFailed, and
+ * releaseInFlight so none of them touch the real K8s API, clock, or
+ * Valkey.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+
+import { watchJobCompletion } from "../../src/k8s/job-spawner";
+
+// Silence logger
+void mock.module("../../src/logger", () => ({
+  logger: {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    child: mock(function () {
+      return this;
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface StatusResponse {
+  status?: {
+    succeeded?: number;
+    failed?: number;
+    conditions?: { type?: string; reason?: string }[];
+  };
+}
+
+function stubClient(opts: {
+  statuses: StatusResponse[];
+  throwOnRead?: () => unknown;
+  deleteImpl?: () => Promise<void>;
+}): {
+  readNamespacedJobStatus: ReturnType<typeof mock>;
+  deleteNamespacedJob: ReturnType<typeof mock>;
+} {
+  let i = 0;
+  const read = mock(() => {
+    if (opts.throwOnRead !== undefined) {
+      throw opts.throwOnRead();
+    }
+    const s = opts.statuses[Math.min(i, opts.statuses.length - 1)] ?? {};
+    i++;
+    return Promise.resolve(s);
+  });
+  const del = mock(async () => {
+    if (opts.deleteImpl !== undefined) await opts.deleteImpl();
+  });
+  return {
+    readNamespacedJobStatus: read,
+    deleteNamespacedJob: del,
+  };
+}
+
+// Fast fake clock / sleep: sleep increments a counter by the requested ms
+// and resolves immediately.
+function fakeClock(): { now: () => number; sleep: (ms: number) => Promise<void> } {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: (ms: number) => {
+      t += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("watchJobCompletion — succeeded", () => {
+  it("returns 'succeeded' when status.succeeded >= 1", async () => {
+    const client = stubClient({ statuses: [{ status: { succeeded: 1 } }] });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-1", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("succeeded");
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(client.deleteNamespacedJob).not.toHaveBeenCalled();
+    // T047 invariant: releaseInFlight fires regardless of outcome.
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith("d-1");
+  });
+});
+
+describe("watchJobCompletion — failed (T048 / FR-021)", () => {
+  it("returns 'failed' on generic Pod failure, does NOT delete or mark timeout", async () => {
+    const client = stubClient({ statuses: [{ status: { failed: 1 } }] });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-2", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("failed");
+    // FR-021: no retry, no re-dispatch. Entrypoint owns the row on a
+    // graceful failure — watcher must not stomp it with markFailed.
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(client.deleteNamespacedJob).not.toHaveBeenCalled();
+    // T047 invariant.
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 'timeout' (not 'failed') when the failure carries DeadlineExceeded", async () => {
+    const client = stubClient({
+      statuses: [
+        {
+          status: {
+            failed: 1,
+            conditions: [{ type: "Failed", reason: "DeadlineExceeded" }],
+          },
+        },
+      ],
+    });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-3", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("timeout");
+    expect(markFailed).toHaveBeenCalledTimes(1);
+    const firstMarkCall = markFailed.mock.calls[0] as [string, string];
+    expect(firstMarkCall[0]).toBe("d-3");
+    expect(firstMarkCall[1]).toContain("DeadlineExceeded");
+    expect(client.deleteNamespacedJob).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("watchJobCompletion — client-side wall-clock timeout (T046)", () => {
+  it("returns 'timeout' when the deadline is reached before K8s reports completion", async () => {
+    // Status responses all report "still running" (no succeeded, no
+    // failed). The fake sleep advances the clock by pollIntervalMs each
+    // iteration so the deadline is guaranteed to fire.
+    const client = stubClient({ statuses: [{ status: {} }] });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-4", {
+      deadlineMs: 5_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("timeout");
+    expect(markFailed).toHaveBeenCalledTimes(1);
+    const timeoutMarkCall = markFailed.mock.calls[0] as [string, string];
+    expect(timeoutMarkCall[1]).toMatch(/wall-clock deadline/);
+    // Best-effort delete of the run-away Job
+    expect(client.deleteNamespacedJob).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows errors from deleteNamespacedJob — K8s enforces the deadline anyway", async () => {
+    const client = stubClient({
+      statuses: [{ status: {} }],
+      deleteImpl: () => Promise.reject(new Error("kube api down")),
+    });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-5", {
+      deadlineMs: 2_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("timeout");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("watchJobCompletion — K8s API errors", () => {
+  it("returns 'abandoned' on 404 and still releases the slot", async () => {
+    const client = stubClient({
+      statuses: [],
+      throwOnRead: () => Object.assign(new Error("not found"), { statusCode: 404 }),
+    });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-6", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("abandoned");
+    expect(markFailed).not.toHaveBeenCalled();
+    // T047 invariant: released even on abandoned.
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient 500 and returns once the Job eventually succeeds", async () => {
+    // First read throws 500; subsequent reads return success.
+    let firstCall = true;
+    const client = {
+      readNamespacedJobStatus: mock(() => {
+        if (firstCall) {
+          firstCall = false;
+          throw Object.assign(new Error("boom"), { statusCode: 500 });
+        }
+        return Promise.resolve({ status: { succeeded: 1 } });
+      }),
+      deleteNamespacedJob: mock(() => Promise.resolve()),
+    };
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.resolve());
+
+    const outcome = await watchJobCompletion("d-7", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    expect(outcome).toBe("succeeded");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("watchJobCompletion — T047 invariant", () => {
+  it("releases the slot even when releaseInFlight itself throws (does not crash)", async () => {
+    const client = stubClient({ statuses: [{ status: { succeeded: 1 } }] });
+    const { now, sleep } = fakeClock();
+    const markFailed = mock(() => Promise.resolve());
+    const release = mock(() => Promise.reject(new Error("valkey down")));
+
+    const outcome = await watchJobCompletion("d-8", {
+      deadlineMs: 60_000,
+      pollIntervalMs: 1_000,
+      injectClient: client,
+      injectNow: now,
+      injectSleep: sleep,
+      injectMarkFailed: markFailed,
+      injectReleaseInFlight: release,
+    });
+
+    // Watcher must not propagate the release failure — the Job already
+    // terminated; surfacing the Valkey error would incorrectly mark the
+    // watch as abandoned.
+    expect(outcome).toBe("succeeded");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/k8s/pending-queue-drainer.test.ts
+++ b/test/k8s/pending-queue-drainer.test.ts
@@ -132,6 +132,7 @@ beforeEach(() => {
   mockRegisterInFlight.mockClear();
   mockReleaseInFlight.mockClear();
   mockSpawnIsolatedJob.mockClear();
+  mockWatchJobCompletion.mockClear();
   mockInFlightCount.mockImplementation(() => Promise.resolve(0));
   mockDequeuePending.mockImplementation(() =>
     Promise.resolve({ outcome: "empty" } as unknown as DequeueResult),
@@ -187,6 +188,11 @@ describe("drainPendingOnce — dequeued path", () => {
     expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
     expect(mockRegisterInFlight).toHaveBeenCalledTimes(1);
     expect(mockRegisterInFlight.mock.calls[0]?.[0]).toBe(entry.deliveryId);
+    // Verify the watcher handoff actually fires after spawn (CodeRabbit
+    // PR #22). Without this assertion removing the `watchJobCompletion()`
+    // call would still pass the rest of the suite.
+    expect(mockWatchJobCompletion).toHaveBeenCalledTimes(1);
+    expect(mockWatchJobCompletion.mock.calls[0]?.[0]).toBe(entry.deliveryId);
     expect(mockReleaseInFlight).not.toHaveBeenCalled();
   });
 

--- a/test/k8s/pending-queue-drainer.test.ts
+++ b/test/k8s/pending-queue-drainer.test.ts
@@ -39,8 +39,11 @@ void mock.module("../../src/k8s/pending-queue", () => ({
   releaseInFlight: mockReleaseInFlight,
 }));
 
+const mockWatchJobCompletion = mock(() => Promise.resolve("succeeded" as const));
+
 void mock.module("../../src/k8s/job-spawner", () => ({
   spawnIsolatedJob: mockSpawnIsolatedJob,
+  watchJobCompletion: mockWatchJobCompletion,
   JobSpawnerError: class JobSpawnerError extends Error {
     constructor(
       readonly kind: string,

--- a/test/webhook/router.test.ts
+++ b/test/webhook/router.test.ts
@@ -102,10 +102,28 @@ const mockEnqueuePending = mock(() =>
 );
 const mockRegisterInFlight = mock(() => Promise.resolve(1));
 
+const mockReleaseInFlight = mock(() => Promise.resolve());
+// Stub exports used by sibling modules (drainer, job-spawner watcher) so
+// cross-test-file module caching doesn't fail imports when this mock is
+// evaluated first.
+const mockDequeuePending = mock(() => Promise.resolve({ outcome: "empty" as const }));
+const mockPendingLength = mock(() => Promise.resolve(0));
+const mockGetPosition = mock(() => Promise.resolve(null));
+const mockStoreBotContext = mock(() => Promise.resolve());
+const mockLoadBotContext = mock(() => Promise.resolve(null));
+const mockDeleteBotContext = mock(() => Promise.resolve());
+
 void mock.module("../../src/k8s/pending-queue", () => ({
   inFlightCount: mockInFlightCount,
   enqueuePending: mockEnqueuePending,
   registerInFlight: mockRegisterInFlight,
+  releaseInFlight: mockReleaseInFlight,
+  dequeuePending: mockDequeuePending,
+  pendingLength: mockPendingLength,
+  getPosition: mockGetPosition,
+  storeBotContext: mockStoreBotContext,
+  loadBotContext: mockLoadBotContext,
+  deleteBotContext: mockDeleteBotContext,
   PENDING_LIST_KEY: "dispatch:isolated-job:pending",
   IN_FLIGHT_SET_KEY: "dispatch:isolated-job:in-flight",
   BOT_CONTEXT_TTL_SECONDS: 3600,

--- a/test/webhook/router.us3-capacity.integration.test.ts
+++ b/test/webhook/router.us3-capacity.integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * T042 (US3): integration-level coverage of the isolated-job capacity
+ * back-pressure flow. Ties together the router dispatch gate, the
+ * pending-queue mocks, the spawn side-effect, and the completion-watcher
+ * wiring.
+ *
+ * Scenarios asserted (spec.md §US3 acceptance):
+ *   1. Under capacity           → direct spawn + register slot + fire watcher.
+ *   2. At capacity, queue room  → enqueue + "Queued" comment + no spawn.
+ *   3. Queue full               → capacity-rejected row + rejection comment.
+ *
+ * Scenario 4 (wall-clock timeout, FR-021 no retry) is covered directly
+ * against `watchJobCompletion` in `test/k8s/job-spawner.watch.test.ts` —
+ * the watcher is pure except for K8s / Valkey / DB, so a unit-level test
+ * with injected fakes is more precise than reaching through the router.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Octokit } from "octokit";
+
+import type { BotContext } from "../../src/types";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (all external collaborators)
+// ---------------------------------------------------------------------------
+
+type EnqueueOutcome =
+  | { readonly outcome: "enqueued"; readonly position: number }
+  | { readonly outcome: "rejected-full"; readonly currentLength: number };
+
+const mockInFlightCount = mock(() => Promise.resolve(0));
+const mockEnqueuePending = mock(
+  (): Promise<EnqueueOutcome> => Promise.resolve({ outcome: "enqueued", position: 1 }),
+);
+const mockRegisterInFlight = mock(() => Promise.resolve(1));
+const mockReleaseInFlight = mock(() => Promise.resolve());
+
+void mock.module("../../src/k8s/pending-queue", () => ({
+  inFlightCount: mockInFlightCount,
+  enqueuePending: mockEnqueuePending,
+  registerInFlight: mockRegisterInFlight,
+  releaseInFlight: mockReleaseInFlight,
+  dequeuePending: mock(() => Promise.resolve({ outcome: "empty" as const })),
+  pendingLength: mock(() => Promise.resolve(0)),
+  getPosition: mock(() => Promise.resolve(null)),
+  storeBotContext: mock(() => Promise.resolve()),
+  loadBotContext: mock(() => Promise.resolve(null)),
+  deleteBotContext: mock(() => Promise.resolve()),
+  PENDING_LIST_KEY: "dispatch:isolated-job:pending",
+  IN_FLIGHT_SET_KEY: "dispatch:isolated-job:in-flight",
+  BOT_CONTEXT_TTL_SECONDS: 3600,
+}));
+
+const mockSpawnIsolatedJob = mock(() => Promise.resolve({ success: true, durationMs: 0 }));
+const mockWatchJobCompletion = mock(() => Promise.resolve("succeeded" as const));
+
+void mock.module("../../src/k8s/job-spawner", () => ({
+  spawnIsolatedJob: mockSpawnIsolatedJob,
+  watchJobCompletion: mockWatchJobCompletion,
+  jobNameForDelivery: (d: string): string => `bot-${d}`,
+  JobSpawnerError: class JobSpawnerError extends Error {
+    constructor(
+      readonly kind: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+const mockCreateExecution = mock(() => Promise.resolve("exec-id"));
+void mock.module("../../src/orchestrator/history", () => ({
+  createExecution: mockCreateExecution,
+  markExecutionFailed: mock(() => Promise.resolve()),
+  markExecutionOffered: mock(() => Promise.resolve()),
+  markExecutionRunning: mock(() => Promise.resolve()),
+  markExecutionCompleted: mock(() => Promise.resolve()),
+  requeueExecution: mock(() => Promise.resolve()),
+  getExecutionState: mock(() => Promise.resolve(null)),
+  getOrphanedExecutions: mock(() => Promise.resolve([])),
+  recoverStaleExecutions: mock(() => Promise.resolve()),
+}));
+
+const mockGetDb = mock(() => null as unknown);
+void mock.module("../../src/db", () => ({
+  getDb: mockGetDb,
+}));
+
+void mock.module("../../src/logger", () => ({
+  logger: {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    child: mock(() => ({
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+      child: mock(() => ({}) as never),
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { dispatch } = await import("../../src/webhook/router");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const silentLog = {
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  error: mock(() => {}),
+  debug: mock(() => {}),
+  child: mock((): typeof silentLog => silentLog),
+} as unknown as BotContext["log"];
+
+let counter = 0;
+
+function makeCtx(opts: { createComment?: ReturnType<typeof mock> } = {}): BotContext {
+  counter++;
+  const deliveryId = `del-${counter}`;
+  const createComment =
+    opts.createComment ?? mock(() => Promise.resolve({ data: { id: 1000 + counter } }));
+  return {
+    owner: "acme",
+    repo: "widgets",
+    entityNumber: counter,
+    isPR: false,
+    eventName: "issue_comment",
+    triggerUsername: "alice",
+    triggerTimestamp: "2026-04-15T00:00:00Z",
+    triggerBody: "@chrisleekr-bot help",
+    commentId: counter,
+    deliveryId,
+    defaultBranch: "main",
+    octokit: {
+      auth: mock(() => Promise.resolve({ token: "ghs_test" })),
+      rest: {
+        issues: {
+          listComments: mock(() => Promise.resolve({ data: [] })),
+          createComment,
+          getComment: mock(() => Promise.resolve({ data: { body: "Working..." } })),
+          updateComment: mock(() => Promise.resolve({ data: { id: 1 } })),
+        },
+      },
+    } as unknown as Octokit,
+    log: silentLog,
+  } as BotContext;
+}
+
+const decision = {
+  target: "isolated-job" as const,
+  reason: "label" as const,
+  maxTurns: 30,
+};
+
+beforeEach(() => {
+  mockInFlightCount.mockClear();
+  mockEnqueuePending.mockClear();
+  mockRegisterInFlight.mockClear();
+  mockReleaseInFlight.mockClear();
+  mockSpawnIsolatedJob.mockClear();
+  mockWatchJobCompletion.mockClear();
+  mockCreateExecution.mockClear();
+  mockGetDb.mockClear();
+  mockGetDb.mockImplementation(() => ({}) as unknown);
+  mockInFlightCount.mockImplementation(() => Promise.resolve(0));
+  mockEnqueuePending.mockImplementation(
+    (): Promise<EnqueueOutcome> => Promise.resolve({ outcome: "enqueued", position: 1 }),
+  );
+  mockSpawnIsolatedJob.mockImplementation(() => Promise.resolve({ success: true, durationMs: 0 }));
+  mockWatchJobCompletion.mockImplementation(() => Promise.resolve("succeeded" as const));
+});
+
+afterEach(() => {
+  mockGetDb.mockImplementation(() => null as unknown);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — under capacity
+// ---------------------------------------------------------------------------
+
+describe("US3 Scenario 1 — under capacity", () => {
+  it("spawns directly, registers the slot, and fires the completion watcher", async () => {
+    mockInFlightCount.mockImplementation(() => Promise.resolve(1));
+    const ctx = makeCtx();
+
+    await dispatch(ctx, decision);
+
+    expect(mockInFlightCount).toHaveBeenCalledTimes(1);
+    expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInFlight).toHaveBeenCalledWith(ctx.deliveryId);
+    expect(mockWatchJobCompletion).toHaveBeenCalledTimes(1);
+    const watchCall = mockWatchJobCompletion.mock.calls[0] as unknown as [string];
+    expect(watchCall[0]).toBe(ctx.deliveryId);
+    expect(mockEnqueuePending).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — at capacity, queue has room
+// ---------------------------------------------------------------------------
+
+describe("US3 Scenario 2 — at capacity, queue has room", () => {
+  it("enqueues, posts a 'Queued' comment, does NOT spawn, does NOT fire watcher", async () => {
+    mockInFlightCount.mockImplementation(() => Promise.resolve(3));
+    mockEnqueuePending.mockImplementation(
+      (): Promise<EnqueueOutcome> => Promise.resolve({ outcome: "enqueued", position: 4 }),
+    );
+    const createComment = mock(() => Promise.resolve({ data: { id: 777 } }));
+    const ctx = makeCtx({ createComment });
+
+    await dispatch(ctx, decision);
+
+    expect(mockEnqueuePending).toHaveBeenCalledTimes(1);
+    expect(mockSpawnIsolatedJob).not.toHaveBeenCalled();
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+    expect(mockWatchJobCompletion).not.toHaveBeenCalled();
+
+    expect(createComment).toHaveBeenCalled();
+    const call = createComment.mock.calls[0] as unknown as [{ body: string }];
+    const body = call[0].body;
+    expect(body).toContain("\u23F3 Queued"); // ⏳
+    expect(body).toContain("position 4");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — queue full (FR-018 no downgrade)
+// ---------------------------------------------------------------------------
+
+describe("US3 Scenario 3 — queue full", () => {
+  it("writes capacity-rejected execution row, posts rejection comment, never downgrades", async () => {
+    mockInFlightCount.mockImplementation(() => Promise.resolve(3));
+    mockEnqueuePending.mockImplementation(
+      (): Promise<EnqueueOutcome> =>
+        Promise.resolve({ outcome: "rejected-full", currentLength: 20 }),
+    );
+    const createComment = mock(() => Promise.resolve({ data: { id: 888 } }));
+    const ctx = makeCtx({ createComment });
+
+    await dispatch(ctx, decision);
+
+    expect(mockSpawnIsolatedJob).not.toHaveBeenCalled();
+    expect(mockRegisterInFlight).not.toHaveBeenCalled();
+    expect(mockWatchJobCompletion).not.toHaveBeenCalled();
+
+    expect(mockCreateExecution).toHaveBeenCalled();
+    const execCall = mockCreateExecution.mock.calls[0] as unknown as [
+      { dispatchMode: string; dispatchReason: string },
+    ];
+    expect(execCall[0].dispatchMode).toBe("isolated-job");
+    expect(execCall[0].dispatchReason).toBe("capacity-rejected");
+
+    const rejectionCall = createComment.mock.calls[0] as unknown as [{ body: string }];
+    expect(rejectionCall[0].body.toLowerCase()).toContain("pool is at capacity");
+    expect(rejectionCall[0].body.toLowerCase()).toContain("will not silently downgrade");
+  });
+});

--- a/test/webhook/router.us3-capacity.integration.test.ts
+++ b/test/webhook/router.us3-capacity.integration.test.ts
@@ -187,11 +187,36 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("US3 Scenario 1 — under capacity", () => {
-  it("spawns directly, registers the slot, and fires the completion watcher", async () => {
+  it("spawns directly, registers the slot, and fires the completion watcher (detached)", async () => {
     mockInFlightCount.mockImplementation(() => Promise.resolve(1));
+
+    // CodeRabbit PR #22: keep the watcher promise deliberately pending so
+    // a regression that accidentally `await`s `watchJobCompletion()`
+    // inside `dispatch` would make this test hang (detected as a timeout
+    // by the race below). If the watcher resolves immediately, we can't
+    // tell await-then-resolve-fast apart from fire-and-forget.
+    let releaseWatch: (() => void) | undefined;
+    mockWatchJobCompletion.mockImplementation(
+      () =>
+        new Promise<"succeeded">((resolve) => {
+          releaseWatch = (): void => {
+            resolve("succeeded");
+          };
+        }),
+    );
+
     const ctx = makeCtx();
 
-    await dispatch(ctx, decision);
+    const dispatchPromise = dispatch(ctx, decision);
+    const outcome = await Promise.race([
+      dispatchPromise.then(() => "resolved" as const),
+      new Promise<"timed-out">((resolve) => {
+        setTimeout(() => {
+          resolve("timed-out");
+        }, 50);
+      }),
+    ]);
+    expect(outcome).toBe("resolved");
 
     expect(mockInFlightCount).toHaveBeenCalledTimes(1);
     expect(mockSpawnIsolatedJob).toHaveBeenCalledTimes(1);
@@ -200,6 +225,10 @@ describe("US3 Scenario 1 — under capacity", () => {
     const watchCall = mockWatchJobCompletion.mock.calls[0] as unknown as [string];
     expect(watchCall[0]).toBe(ctx.deliveryId);
     expect(mockEnqueuePending).not.toHaveBeenCalled();
+
+    // Let the pending watcher promise resolve so the test exits cleanly.
+    releaseWatch?.();
+    await dispatchPromise;
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the fire-and-forget gap left by #21 (Slice E part 1). After an isolated-Job spawns, the router now fires a detached \`watchJobCompletion(deliveryId)\` promise that polls \`readNamespacedJobStatus\` until the Job terminates or the wall-clock deadline elapses, then deterministically releases the in-flight slot.

### Invariants enforced

- **T046** — \`activeDeadlineSeconds\` is now \`config.jobActiveDeadlineSeconds\` (default 1800, max 3500 to stay below GitHub's 1h installation-token TTL). The watcher enforces the same ceiling client-side and, on deadline, best-effort deletes the Job + \`markExecutionFailed(deliveryId, \"... wall-clock deadline ...\")\`.
- **T047** — \`releaseInFlight(deliveryId)\` runs in a \`finally\` block on every exit path (success, failure, timeout, K8s error, unexpected throw). The in-flight capacity counter can no longer leak slots.
- **T048 / FR-021** — On a graceful Pod failure the watcher releases the slot and returns; it does **not** re-enqueue or re-dispatch. The entrypoint owns the row + tracking comment on the happy path; failures are the maintainer's to re-trigger.
- **T042** — New \`test/webhook/router.us3-capacity.integration.test.ts\` covers US3 scenarios 1–3 end-to-end. Scenario 4 (timeout) is covered by the watcher unit test (\`test/k8s/job-spawner.watch.test.ts\`, 8 cases) where injected fakes give precise deterministic assertions.
- **T049** — JSDoc pass: every new export (\`watchJobCompletion\`, \`JobWatchOutcome\`, \`WatchJobCompletionOptions\`, \`jobNameForDelivery\`) documents the invariants above.

The watcher is also wired into the drainer in \`pending-queue-drainer.ts\`, so drained entries get the same timeout + cleanup guarantees.

### Before

```mermaid
flowchart LR
    Router["router.dispatchIsolatedJob"]:::gate --> Spawn["spawnIsolatedJob"]:::io
    Spawn --> Register["registerInFlight"]:::io
    Register --> Return["webhook 200 OK"]:::ok
    Return -.->|"30-min later K8s kills pod<br/>activeDeadlineSeconds hardcoded"| Leak["in-flight slot leaks<br/>no timeout row<br/>stale Working... comment"]:::bad
    classDef gate fill:#e0f2fe,stroke:#075985,color:#0c4a6e
    classDef io fill:#fef3c7,stroke:#92400e,color:#78350f
    classDef ok fill:#dcfce7,stroke:#166534,color:#14532d
    classDef bad fill:#fee2e2,stroke:#991b1b,color:#7f1d1d
```

### After

```mermaid
flowchart LR
    Router["router.dispatchIsolatedJob"]:::gate --> Spawn["spawnIsolatedJob"]:::io
    Spawn --> Register["registerInFlight"]:::io
    Register --> Detach["void watchJobCompletion"]:::bg
    Register --> Return["webhook 200 OK"]:::ok
    Detach --> Poll["poll readNamespacedJobStatus<br/>every jobWatchPollIntervalMs"]:::bg
    Poll --> Terminal{"terminal?"}:::gate
    Terminal -->|"succeeded / failed"| Release["finally releaseInFlight"]:::io
    Terminal -->|"wall-clock deadline"| Cleanup["delete Job + markExecutionFailed<br/>then finally releaseInFlight"]:::io
    classDef gate fill:#e0f2fe,stroke:#075985,color:#0c4a6e
    classDef io fill:#fef3c7,stroke:#92400e,color:#78350f
    classDef bg fill:#ede9fe,stroke:#5b21b6,color:#3b0764
    classDef ok fill:#dcfce7,stroke:#166534,color:#14532d
```

## Changes

- **src/config.ts + .env.example** — new \`jobActiveDeadlineSeconds\` (default 1800, max 3500) and \`jobWatchPollIntervalMs\` (default 5000) config keys.
- **src/k8s/job-spawner.ts** — exported \`jobNameForDelivery\`, \`watchJobCompletion\`, \`JobWatchOutcome\`, \`WatchJobCompletionOptions\`; \`buildJobSpec\` now reads \`activeDeadlineSeconds\` from config.
- **src/webhook/router.ts + src/k8s/pending-queue-drainer.ts** — fire \`void watchJobCompletion(ctx.deliveryId)\` after a successful spawn on both paths.
- **test/k8s/job-spawner.watch.test.ts** — 8 new tests covering all outcomes (succeeded, failed, DeadlineExceeded, client-side timeout, 404 abandoned, transient 500 retry, release-throws resilience, T047 finally invariant).
- **test/webhook/router.us3-capacity.integration.test.ts** — new 3-test US3 acceptance integration suite.
- **test/webhook/router.test.ts + test/k8s/pending-queue-drainer.test.ts** — extended existing mocks so the new \`releaseInFlight\` / \`watchJobCompletion\` imports resolve under cross-test-file module caching.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — 0 errors
- [x] \`bun run format\` — clean
- [x] \`scripts/test-isolated.sh\` — 32/32 files pass
- [x] \`test/k8s/job-spawner.watch.test.ts\` — 8/8 pass in isolation
- [x] \`test/webhook/router.us3-capacity.integration.test.ts\` — 3/3 pass in isolation
- [ ] CI green on GitHub Actions
- [ ] CodeRabbit review addressed
- [ ] Copilot review addressed (if posted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job completion monitoring with configurable wall-clock timeout and polling interval settings for improved control over isolated job execution lifecycle.
  * Enhanced job cleanup and resource slot management for better resource utilization.

* **Chores**
  * Updated default AI model configuration to Claude Opus 4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->