### PR TITLE
fix(orchestrator): use IN ${db(ids)} in repo-knowledge to fix Bun.sql array binding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     "@hono/node-server": "1.19.13",
     "express-rate-limit": "8.3.2",
     "flatted": "3.4.2",
-    "hono": "4.12.12",
+    "hono": "4.12.14",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
     "yaml": "2.8.3",
@@ -663,7 +663,7 @@
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
-    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "hpagent": ["hpagent@1.2.0", "", {}, "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="],
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@hono/node-server": "1.19.13",
     "express-rate-limit": "8.3.2",
     "flatted": "3.4.2",
-    "hono": "4.12.12",
+    "hono": "4.12.14",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
     "yaml": "2.8.3"

--- a/src/orchestrator/repo-knowledge.ts
+++ b/src/orchestrator/repo-knowledge.ts
@@ -1,3 +1,5 @@
+import type { SQL } from "bun";
+
 import { requireDb } from "../db";
 import { logger } from "../logger";
 
@@ -71,9 +73,11 @@ export async function setRepoEnvVar(
  * Returns ALL pinned non-env entries plus top 5 non-pinned by most recent activity.
  * Bumps last_read_at on all returned rows.
  */
-export async function getRepoMemory(owner: string, repo: string): Promise<RepoMemoryEntry[]> {
-  const db = requireDb();
-
+export async function getRepoMemory(
+  owner: string,
+  repo: string,
+  db: SQL = requireDb(),
+): Promise<RepoMemoryEntry[]> {
   const rows: { id: string; category: string; content: string; pinned: boolean }[] = await db`
     (
       SELECT id, category, content, pinned FROM repo_memory
@@ -92,7 +96,7 @@ export async function getRepoMemory(owner: string, repo: string): Promise<RepoMe
 
   if (rows.length > 0) {
     const ids = rows.map((r) => r.id);
-    await db`UPDATE repo_memory SET last_read_at = now() WHERE id = ANY(${ids})`;
+    await db`UPDATE repo_memory SET last_read_at = now() WHERE id IN ${db(ids)}`;
   }
 
   return rows;
@@ -147,12 +151,10 @@ export async function saveRepoLearnings(
  * Delete repo memory entries by ID.
  * Used when Claude identifies outdated or incorrect memories.
  */
-export async function deleteRepoMemories(ids: string[]): Promise<number> {
+export async function deleteRepoMemories(ids: string[], db: SQL = requireDb()): Promise<number> {
   if (ids.length === 0) return 0;
-
-  const db = requireDb();
   const deleted: { id: string }[] = await db`
-    DELETE FROM repo_memory WHERE id = ANY(${ids}) RETURNING id
+    DELETE FROM repo_memory WHERE id IN ${db(ids)} RETURNING id
   `;
   return deleted.length;
 }

--- a/test/integration/repo-knowledge.test.ts
+++ b/test/integration/repo-knowledge.test.ts
@@ -5,32 +5,36 @@
  * causing PostgresError "malformed array literal" the moment
  * `repo_memory` had any rows.
  *
- * The fix wraps the array with `db.array(ids)` per Bun's documented
- * pattern (https://bun.sh/docs/runtime/sql, "Create PostgreSQL array
- * literals with sql.array()").
+ * The fix switches both queries to Bun's IN-list expansion form,
+ * `WHERE id IN ${db(ids)}`, which expands the UUID array as
+ * parameterised IN-list values instead of binding it through `ANY(...)`.
  *
  * This suite exercises the two affected functions against a real
  * Postgres instance:
- *   - getRepoMemory      -> UPDATE … WHERE id = ANY(…)
- *   - deleteRepoMemories -> DELETE … WHERE id = ANY(…)
+ *   - getRepoMemory      -> UPDATE … WHERE id IN (…)
+ *   - deleteRepoMemories -> DELETE … WHERE id IN (…)
  *
- * Skips cleanly when Postgres is unreachable so the suite still runs
- * for contributors without local infra.
+ * This suite is DESTRUCTIVE: `beforeAll` drops and re-creates the
+ * `repo_memory`, `triage_results`, `executions`, and `daemons` tables.
+ * To avoid wiping a developer's local database by accident, the suite
+ * is opt-in — it only runs when `TEST_DATABASE_URL` is explicitly set.
+ * It skips cleanly otherwise so `bun test` without infra is safe.
  */
 
 import { SQL } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
-const TEST_DATABASE_URL =
-  process.env["TEST_DATABASE_URL"] ?? "postgres://bot:bot@localhost:5432/github_app_test";
+const TEST_DATABASE_URL = process.env["TEST_DATABASE_URL"];
 
 let sql: SQL | null = null;
-try {
-  const conn = new SQL(TEST_DATABASE_URL);
-  await conn`SELECT 1 AS ok`;
-  sql = conn;
-} catch {
-  sql = null;
+if (TEST_DATABASE_URL !== undefined && TEST_DATABASE_URL.length > 0) {
+  try {
+    const conn = new SQL(TEST_DATABASE_URL);
+    await conn`SELECT 1 AS ok`;
+    sql = conn;
+  } catch {
+    sql = null;
+  }
 }
 
 function requireSql(): SQL {
@@ -56,15 +60,20 @@ describe.skipIf(sql === null)("repo-knowledge ANY() array binding regression", (
   });
 
   afterAll(async () => {
-    if (sql === null) return;
-    await sql`DELETE FROM repo_memory WHERE repo_owner = ${TEST_OWNER}`;
+    const db = sql;
+    if (db === null) return;
+    try {
+      await db`DELETE FROM repo_memory WHERE repo_owner = ${TEST_OWNER}`;
+    } finally {
+      await db.close();
+    }
   });
 
   it("getRepoMemory updates last_read_at without ANY() binding error when rows exist", async () => {
     const db = requireSql();
 
     // Seed three unpinned rows so getRepoMemory's ORDER BY ... LIMIT 5
-    // path is exercised and the UPDATE WHERE id = ANY(…) actually fires.
+    // path is exercised and the UPDATE … WHERE id IN (…) branch actually fires.
     await db`
       INSERT INTO repo_memory (repo_owner, repo_name, category, content, pinned, updated_at)
       VALUES
@@ -75,7 +84,9 @@ describe.skipIf(sql === null)("repo-knowledge ANY() array binding regression", (
 
     const { getRepoMemory } = await import("../../src/orchestrator/repo-knowledge");
 
-    // Before the fix this throws PostgresError 22P02 "malformed array literal".
+    // Before the fix this threw PostgresError 22P02 "malformed array literal"
+    // because Bun.sql encoded the JS string[] as a comma-joined string.
+    // The IN ${db(ids)} expansion exercises the fixed code path.
     const rows = await getRepoMemory(TEST_OWNER, TEST_REPO, db);
 
     expect(rows.length).toBe(3);
@@ -112,7 +123,7 @@ describe.skipIf(sql === null)("repo-knowledge ANY() array binding regression", (
     const remaining: { content: string }[] = await db`
       SELECT content FROM repo_memory
       WHERE repo_owner = ${TEST_OWNER} AND repo_name = ${TEST_REPO}
-        AND content LIKE 'to-delete%' OR content = 'keep-me'
+        AND (content LIKE 'to-delete%' OR content = 'keep-me')
     `;
     const contents = remaining.map((r) => r.content);
     expect(contents).toContain("keep-me");

--- a/test/integration/repo-knowledge.test.ts
+++ b/test/integration/repo-knowledge.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression test for the Bun.sql array-binding bug surfaced by the
+ * 2026-04-16 daemon-mode smoke test: passing a JS string[] directly to
+ * `WHERE id = ANY(${ids})` was encoded as a comma-joined string,
+ * causing PostgresError "malformed array literal" the moment
+ * `repo_memory` had any rows.
+ *
+ * The fix wraps the array with `db.array(ids)` per Bun's documented
+ * pattern (https://bun.sh/docs/runtime/sql, "Create PostgreSQL array
+ * literals with sql.array()").
+ *
+ * This suite exercises the two affected functions against a real
+ * Postgres instance:
+ *   - getRepoMemory      -> UPDATE … WHERE id = ANY(…)
+ *   - deleteRepoMemories -> DELETE … WHERE id = ANY(…)
+ *
+ * Skips cleanly when Postgres is unreachable so the suite still runs
+ * for contributors without local infra.
+ */
+
+import { SQL } from "bun";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+const TEST_DATABASE_URL =
+  process.env["TEST_DATABASE_URL"] ?? "postgres://bot:bot@localhost:5432/github_app_test";
+
+let sql: SQL | null = null;
+try {
+  const conn = new SQL(TEST_DATABASE_URL);
+  await conn`SELECT 1 AS ok`;
+  sql = conn;
+} catch {
+  sql = null;
+}
+
+function requireSql(): SQL {
+  if (sql === null) throw new Error("Database not available — test should have been skipped");
+  return sql;
+}
+
+const TEST_OWNER = "repo-knowledge-test-owner";
+const TEST_REPO = "repo-knowledge-test-repo";
+
+describe.skipIf(sql === null)("repo-knowledge ANY() array binding regression", () => {
+  beforeAll(async () => {
+    const db = requireSql();
+    await db.unsafe(`
+      DROP TABLE IF EXISTS _migrations CASCADE;
+      DROP TABLE IF EXISTS repo_memory CASCADE;
+      DROP TABLE IF EXISTS triage_results CASCADE;
+      DROP TABLE IF EXISTS executions CASCADE;
+      DROP TABLE IF EXISTS daemons CASCADE;
+    `);
+    const { runMigrations } = await import("../../src/db/migrate");
+    await runMigrations(db);
+  });
+
+  afterAll(async () => {
+    if (sql === null) return;
+    await sql`DELETE FROM repo_memory WHERE repo_owner = ${TEST_OWNER}`;
+  });
+
+  it("getRepoMemory updates last_read_at without ANY() binding error when rows exist", async () => {
+    const db = requireSql();
+
+    // Seed three unpinned rows so getRepoMemory's ORDER BY ... LIMIT 5
+    // path is exercised and the UPDATE WHERE id = ANY(…) actually fires.
+    await db`
+      INSERT INTO repo_memory (repo_owner, repo_name, category, content, pinned, updated_at)
+      VALUES
+        (${TEST_OWNER}, ${TEST_REPO}, 'gotchas', 'note A', false, NOW() - INTERVAL '1 hour'),
+        (${TEST_OWNER}, ${TEST_REPO}, 'setup',   'note B', false, NOW() - INTERVAL '2 hours'),
+        (${TEST_OWNER}, ${TEST_REPO}, 'env',     'note C', false, NOW() - INTERVAL '3 hours')
+    `;
+
+    const { getRepoMemory } = await import("../../src/orchestrator/repo-knowledge");
+
+    // Before the fix this throws PostgresError 22P02 "malformed array literal".
+    const rows = await getRepoMemory(TEST_OWNER, TEST_REPO, db);
+
+    expect(rows.length).toBe(3);
+    expect(rows.map((r) => r.content).sort()).toEqual(["note A", "note B", "note C"]);
+
+    const updatedRows: { id: string; last_read_at: Date | null }[] = await db`
+      SELECT id, last_read_at FROM repo_memory
+      WHERE repo_owner = ${TEST_OWNER} AND repo_name = ${TEST_REPO}
+    `;
+    expect(updatedRows.length).toBe(3);
+    for (const row of updatedRows) {
+      expect(row.last_read_at).not.toBeNull();
+    }
+  });
+
+  it("deleteRepoMemories removes the requested ids without ANY() binding error", async () => {
+    const db = requireSql();
+
+    const seeded: { id: string }[] = await db`
+      INSERT INTO repo_memory (repo_owner, repo_name, category, content, pinned)
+      VALUES
+        (${TEST_OWNER}, ${TEST_REPO}, 'gotchas', 'to-delete-1', false),
+        (${TEST_OWNER}, ${TEST_REPO}, 'gotchas', 'to-delete-2', false),
+        (${TEST_OWNER}, ${TEST_REPO}, 'gotchas', 'keep-me',     false)
+      RETURNING id, content
+    `;
+
+    const ids = seeded.slice(0, 2).map((r) => r.id);
+    const { deleteRepoMemories } = await import("../../src/orchestrator/repo-knowledge");
+
+    const deletedCount = await deleteRepoMemories(ids, db);
+    expect(deletedCount).toBe(2);
+
+    const remaining: { content: string }[] = await db`
+      SELECT content FROM repo_memory
+      WHERE repo_owner = ${TEST_OWNER} AND repo_name = ${TEST_REPO}
+        AND content LIKE 'to-delete%' OR content = 'keep-me'
+    `;
+    const contents = remaining.map((r) => r.content);
+    expect(contents).toContain("keep-me");
+    expect(contents).not.toContain("to-delete-1");
+    expect(contents).not.toContain("to-delete-2");
+  });
+
+  it("deleteRepoMemories with empty array is a no-op (does not query DB)", async () => {
+    const db = requireSql();
+    const { deleteRepoMemories } = await import("../../src/orchestrator/repo-knowledge");
+
+    const result = await deleteRepoMemories([], db);
+    expect(result).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

**Latent production bug** — surfaced by the 2026-04-16 local E2E daemon-mode smoke test (Phase 2). `Bun.sql` encodes a JS `string[]` passed to a tagged-template parameter as a single comma-joined string, so `WHERE id = ANY(${ids})` against a `uuid` column fails with `PostgresError 22P02 "malformed array literal"` the moment `repo_memory` has any rows. The daemon crashes on every dispatch once memory is seeded — blocks every daemon-mode execution.

### Before / After

```mermaid
flowchart TD
    Disp["Daemon dispatch receives job"]:::good
    Query["getRepoMemory owner, repo"]:::good
    Rows{"rows.length > 0 ?"}:::check
    Bug["db UPDATE repo_memory SET last_read_at=now WHERE id = ANY ids"]:::bad
    Err["PostgresError 22P02<br/>malformed array literal"]:::fail
    Fail["execution marked FAILED<br/>tracking comment errors"]:::fail
    Skip["skip bump"]:::muted

    Disp --> Query --> Rows
    Rows -->|no| Skip
    Rows -->|yes| Bug --> Err --> Fail

    classDef good fill:#BBDEFB,stroke:#0D47A1,color:#0D47A1
    classDef check fill:#FFE0B2,stroke:#BF360C,color:#BF360C
    classDef bad fill:#FFCDD2,stroke:#B71C1C,color:#B71C1C
    classDef fail fill:#F8BBD0,stroke:#880E4F,color:#880E4F
    classDef muted fill:#ECEFF1,stroke:#37474F,color:#37474F
```

```mermaid
flowchart TD
    Disp["Daemon dispatch receives job"]:::good
    Query["getRepoMemory owner, repo, db"]:::good
    Rows{"rows.length > 0 ?"}:::check
    Fix["db UPDATE repo_memory SET last_read_at=now WHERE id IN db ids"]:::good
    Ok["execution completed"]:::result
    Skip["skip bump"]:::muted

    Disp --> Query --> Rows
    Rows -->|no| Skip
    Rows -->|yes| Fix --> Ok

    classDef good fill:#BBDEFB,stroke:#0D47A1,color:#0D47A1
    classDef check fill:#FFE0B2,stroke:#BF360C,color:#BF360C
    classDef result fill:#C8E6C9,stroke:#1B5E20,color:#1B5E20
    classDef muted fill:#ECEFF1,stroke:#37474F,color:#37474F
```

### Why `IN ${db(ids)}` over `db.array(ids)`

Both are documented Bun.sql array patterns. `db.array(ids)` emits a PostgreSQL `ARRAY[...]` literal with JSON type metadata on Bun 1.3.9 — comparing `uuid` against `json` fails with `PostgresError 42883 "operator does not exist: uuid = json"`. The `IN ${db(ids)}` pattern expands the array as parameterised IN-list values rather than a single text-encoded array literal; version-independent and type-safe against `uuid` columns.

## Changes

- **`src/orchestrator/repo-knowledge.ts`**:
  - Add `import type { SQL } from "bun"` for the injectable DB parameter
  - `getRepoMemory(owner, repo, db: SQL = requireDb())` — signature gains optional `db` param; line 100 UPDATE switches from `WHERE id = ANY(${ids})` to `WHERE id IN ${db(ids)}`
  - `deleteRepoMemories(ids, db: SQL = requireDb())` — signature gains optional `db` param; line 158 DELETE switches from `WHERE id = ANY(${ids})` to `WHERE id IN ${db(ids)}`
  - Injectable `db` param mirrors existing pattern in `src/db/queries/dispatch-stats.ts`; enables the regression test to exercise the real query path against a Postgres instance without monkey-patching the `requireDb` singleton
- **`test/integration/repo-knowledge.test.ts`** (new):
  - 3 tests covering both fixed sites + the empty-array no-op short-circuit in `deleteRepoMemories`
  - Follows the `describe.skipIf(sql === null)` pattern from `test/integration/telemetry-aggregates.test.ts` so the suite skips cleanly when Postgres is unreachable
  - `beforeAll` drops tables + re-runs migrations; `afterAll` cleans up the test owner's rows

## Related Issues

None — caught during local E2E smoke testing (Phase 2 daemon dispatch).

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

**Verification:**

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (83 warnings, all pre-existing, none on touched lines)
- `TEST_DATABASE_URL=postgres://bot:bot@localhost:5432/github_app_test bun test test/integration/repo-knowledge.test.ts` — 3/3 pass
- **Real-world validation**: after applying fix, Phase 2 daemon dispatch smoke test succeeded end-to-end on `chrisleekr/test-github-actions#528` (comment [4259452871](https://github.com/chrisleekr/test-github-actions/pull/528#issuecomment-4259452871), 48s, `$0.42`, `status=completed`)

## Screenshots/Recordings

N/A — backend-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests to validate database operations and enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->