### PR TITLE
fix(deploy): set NODE_ENV=production during build and bundle daemon entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ Thumbs.db
 
 mcp-config.json
 
+.claude/scheduled_tasks.lock
 
 # Spec Kit — ephemeral/local artifacts only
 .specify/extensions/.cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.101
 # Stage 1: Build — install all deps and bundle the main app
 FROM base AS development
 ENV HUSKY=0
+# Bun's bundler inlines `process.env.NODE_ENV` at build time and defaults to
+# "development" when unset, which causes dist/app.js to require `pino-pretty`
+# (a devDependency absent from the production image) via src/logger.ts.
+ENV NODE_ENV=production
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY . .

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -63,4 +63,25 @@ if (!jobEntrypointResult.success) {
   process.exit(1);
 }
 
+// Build 4: Daemon worker entry point — outputs dist/daemon/main.js
+// Invoked by the chart's daemon Deployment via `bun run dist/daemon/main.js`.
+// Self-contained bundle (splitting: false) since the daemon runs as its own process.
+const daemonResult = await Bun.build({
+  entrypoints: ["./src/daemon/main.ts"],
+  outdir: "./dist/daemon",
+  target: "bun",
+  minify: isProduction,
+  sourcemap: isProduction ? "external" : "inline",
+  splitting: false,
+  naming: "main.js",
+});
+
+if (!daemonResult.success) {
+  console.error("Build failed (daemon):");
+  for (const log of daemonResult.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}
+
 console.log("Build completed successfully");


### PR DESCRIPTION
## Summary

- Force `NODE_ENV=production` in the Docker `development` build stage so Bun's bundler statically substitutes `process.env.NODE_ENV` → `"production"`, killing the `pino-pretty` transport branch in `src/logger.ts` that crashed the orchestrator pod at runtime (`pino-pretty` is a `devDependency` and is absent from the production `node_modules`).
- Add a 4th `Bun.build` block in `scripts/build.ts` to bundle `src/daemon/main.ts` → `dist/daemon/main.js`. The chart 0.4.0 daemon Deployment runs `bun run dist/daemon/main.js`, which previously had no target in the image and crash-looped with `Module not found "dist/daemon/main.js"`.
- Housekeeping: ignore `.claude/scheduled_tasks.lock` (local Claude Code runtime artifact).

## Context

Discovered during a deploy-failure investigation on the homelab cluster — three pods in `CrashLoopBackOff` on chart `github-app-playground@0.4.0` / image `1.1.0`:

1. Orchestrator: `pino: unable to determine transport target for "pino-pretty"` — Bun bundler default-substitutes `NODE_ENV=development` when the env var is unset at build time, baking the dev-only pino transport into `dist/app.js`. Setting `ENV NODE_ENV=production` before `bun run build` forces the correct substitution and gives us a properly minified bundle as a side effect (`scripts/build.ts` already reads `NODE_ENV` to toggle `minify`/`sourcemap`).
2. Daemon pod: `Module not found "dist/daemon/main.js"` — `src/daemon/` was introduced for the chart-0.4.0 daemon topology but its entrypoint was never added to the bundle list.
3. (Separate — addressed downstream in `argocd-apps` and in [chrisleekr/helm-charts#16](https://github.com/chrisleekr/helm-charts/pull/16), not in this PR.)

The dev image `chrisleekr/github-app-playground:1.1.1-dev-24c7b4b.1` (already built by `dev-release.yml` on the prior push of this branch) has been validated live in-cluster:

- Orchestrator pod logs structured pino JSON and `Server listening on port 3000`.
- Daemon pod connects outbound to `ws://github-app-playground:3002/ws` and emits 30s heartbeats.

## Test plan

- [x] `dev-release.yml` green on the prior push (`24c7b4b`) — image `1.1.1-dev-24c7b4b.1` published, Trivy scans passed.
- [x] In-cluster smoke: orchestrator + daemon pods Ready on the dev image (old `dc949d4dd-*` replica retired).
- [ ] CI green on the chore commit (`e5727bd`).
- [ ] Follow-up prod release via `gh workflow run release.yml` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)