### PR TITLE
fix(ci): resolve gitleaks false positives and add dedicated secrets-scan workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
         with:
-          # Full history so gitleaks can scan all commits via `git log -p`.
+          # Full history kept for parity with dev-release/release workflows
+          # and to give semantic-release accurate diff context when this
+          # workflow is invoked via workflow_call. Secret scanning lives
+          # in .github/workflows/secrets-scan.yml now.
           fetch-depth: 0
 
       - name: Setup Bun
@@ -71,15 +74,6 @@ jobs:
         # exits 1 on ANY advisory regardless of --audit-level, so the
         # wrapper restores severity-based gating + an inline GHSA allowlist.
         run: bun run audit:ci
-
-      - name: Scan git history for secrets
-        uses: gitleaks/gitleaks-action@v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
-          # gitleaks-action@v2.3.9 bundles 8.24.3 which has [[allowlists]]
-          # bugs that misfire on docs/SETUP.md. 8.30.1 has the fix.
-          GITLEAKS_VERSION: "8.30.1"
 
       - name: Test
         run: bun run test

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -25,7 +25,9 @@ permissions:
 jobs:
   gitleaks:
     name: Gitleaks
-    runs-on: ubuntu-latest
+    # Pinned per project convention — see CLAUDE.md "CI/CD Pipeline" note
+    # on avoiding ubuntu-latest so a rolling alias can't silently flip.
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout source code

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,47 @@
+# Standalone gitleaks scan. Runs on every push to every source branch.
+# Intentionally decoupled from ci.yml so it executes fast, does not gate
+# dev-release/release pipelines (which call ci.yml via workflow_call),
+# and covers branches that currently have no push-time CI (chore/**,
+# docs/**, ci/**, test/**).
+name: Secrets Scan
+
+on:
+  push:
+    # gh-pages is MkDocs build output; it would only surface false
+    # positives mirroring docs/SETUP.md placeholders. The .gitleaks.toml
+    # allowlist covers those paths already, but skipping the branch
+    # entirely saves runner minutes on every docs deploy.
+    branches-ignore:
+      - gh-pages
+  workflow_dispatch:
+
+concurrency:
+  group: secrets-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          # For `push` events gitleaks-action scans the push range
+          # (GITHUB_EVENT_BEFORE..GITHUB_SHA), which needs enough depth
+          # to cover the delta. 0 = full history — simplest and safe.
+          # For `workflow_dispatch` this enables an on-demand full audit.
+          fetch-depth: 0
+
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          # gitleaks-action@v2.3.9 bundles 8.24.3 which has [[allowlists]]
+          # bugs that misfire on docs/SETUP.md. 8.30.1 has the fix.
+          GITLEAKS_VERSION: "8.30.1"

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,8 +1,15 @@
-# Standalone gitleaks scan. Runs on every push to every source branch.
-# Intentionally decoupled from ci.yml so it executes fast, does not gate
-# dev-release/release pipelines (which call ci.yml via workflow_call),
-# and covers branches that currently have no push-time CI (chore/**,
-# docs/**, ci/**, test/**).
+# Standalone gitleaks scan. Runs on every push to every source branch
+# AND on every pull request (including from forks). Intentionally decoupled
+# from ci.yml so it executes fast, does not gate dev-release/release pipelines
+# (which call ci.yml via workflow_call), and covers branches that currently
+# have no push-time CI (chore/**, docs/**, ci/**, test/**).
+#
+# Why `pull_request` (not `pull_request_target`): fork PRs need secret
+# scanning, and `pull_request` checks out the fork's code in the base-repo
+# context WITHOUT exposing base-repo secrets to fork code — gitleaks only
+# reads files, so this is safe. `pull_request_target` would run the fork's
+# workflow definition with write-scoped secrets, which is the dangerous
+# pattern we explicitly avoid.
 name: Secrets Scan
 
 on:
@@ -13,6 +20,7 @@ on:
     # entirely saves runner minutes on every docs deploy.
     branches-ignore:
       - gh-pages
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -60,3 +60,16 @@ regexes = [
 description = "docs/SETUP.md private-key format documentation"
 paths = ['''^docs/SETUP\.md$''']
 targetRules = ["private-key"]
+
+# MkDocs build output on the gh-pages branch mirrors docs/SETUP.md's PEM
+# placeholder blocks (e.g. <YOUR_BASE64_ENCODED_KEY_CONTENT_HERE>). The
+# `private-key` rule matches the -----BEGIN/END----- envelope even with
+# placeholder content. Scope narrowly: only the two paths MkDocs produces,
+# only the `private-key` rule — any other rule hit in gh-pages still fires.
+[[allowlists]]
+description = "MkDocs gh-pages output — placeholder PEM blocks from docs/SETUP.md"
+paths = [
+  '''^SETUP/index\.html$''',
+  '''^search/search_index\.json$''',
+]
+targetRules = ["private-key"]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 # Secret scanning: block commits containing API keys, tokens, private keys, etc.
 # gitleaks is a required quality gate — install once and keep it on PATH.
-# Install: brew install gitleaks | apt install gitleaks | go install github.com/gitleaks/gitleaks/v8@latest
+# Install: brew install gitleaks | sudo apt install gitleaks | go install github.com/gitleaks/gitleaks/v8@latest
 # Allowlist false positives in .gitleaks.toml rather than bypassing with --no-verify.
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "❌  gitleaks binary not found on PATH."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,16 @@
 # Secret scanning: block commits containing API keys, tokens, private keys, etc.
-# Requires `gitleaks` binary (https://github.com/gitleaks/gitleaks).
+# gitleaks is a required quality gate — install once and keep it on PATH.
 # Install: brew install gitleaks | apt install gitleaks | go install github.com/gitleaks/gitleaks/v8@latest
 # Allowlist false positives in .gitleaks.toml rather than bypassing with --no-verify.
-if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks protect --verbose --staged --config .gitleaks.toml || exit 1
-else
-  echo "⚠️  gitleaks not installed — skipping secret scan (install: https://github.com/gitleaks/gitleaks#installing)"
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "❌  gitleaks binary not found on PATH."
+  echo "   This repo requires gitleaks for pre-commit secret scanning."
+  echo "   Install:  brew install gitleaks   (macOS)"
+  echo "             sudo apt install gitleaks   (Debian/Ubuntu)"
+  echo "             go install github.com/gitleaks/gitleaks/v8@latest"
+  echo "   Docs:     https://github.com/gitleaks/gitleaks#installing"
+  exit 1
 fi
+gitleaks protect --verbose --staged --config .gitleaks.toml || exit 1
 
 bunx lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,12 @@ The scheduled research workflow in `.github/workflows/research.yml` also uses `C
 
 ## CI/CD Pipeline
 
-Four workflow files form the pipeline; each owns one responsibility.
+Five workflow files form the pipeline; each owns one responsibility.
 
 | Workflow                             | Trigger                                                   | Owns                                                                                                               |
 | ------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `.github/workflows/ci.yml`           | `pull_request` + `push: main` + `workflow_call`           | Quality gates only: typecheck, lint, format, audit:ci, gitleaks, test, build                                       |
+| `.github/workflows/ci.yml`           | `pull_request` + `push: main` + `workflow_call`           | Quality gates only: typecheck, lint, format, audit:ci, test, build                                                 |
+| `.github/workflows/secrets-scan.yml` | `push: branches-ignore: [gh-pages]` + `workflow_dispatch` | Standalone gitleaks secret scan — decoupled from ci.yml so every push (incl. chore/docs/ci/test branches) is gated |
 | `.github/workflows/dev-release.yml`  | `push: branches-ignore: [main, v*]` + `workflow_dispatch` | Calls `ci.yml` → semantic-release dev (pre-release tag) → calls `docker-build.yml`                                 |
 | `.github/workflows/release.yml`      | `workflow_dispatch` only (manual)                         | Calls `ci.yml` → semantic-release prod → calls `docker-build.yml`                                                  |
 | `.github/workflows/docker-build.yml` | `workflow_call` + `workflow_dispatch`                     | Reusable image builder: matrix split-and-merge (amd64 on `ubuntu-24.04` + arm64 on `ubuntu-24.04-arm`), Trivy scan |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,18 +107,20 @@ These checks are enforced by Husky on every commit:
 
 - **pre-commit** runs, in order:
   1. `gitleaks protect --verbose --staged --config .gitleaks.toml` scans
-     staged files for secrets (API keys, tokens, private keys). Requires the
-     `gitleaks` binary — install via `brew install gitleaks` on macOS, `apt
-install gitleaks` on Debian/Ubuntu, or
-     `go install github.com/gitleaks/gitleaks/v8@latest`. If gitleaks is not
-     installed the hook prints a warning and continues (rather than silently
-     skipping); install it before committing sensitive changes.
+     staged files for secrets (API keys, tokens, private keys). The
+     `gitleaks` binary is **required** — install via `brew install gitleaks`
+     on macOS, `sudo apt install gitleaks` on Debian/Ubuntu, or
+     `go install github.com/gitleaks/gitleaks/v8@latest`. The hook fails
+     closed: if the binary is missing, the commit is blocked with install
+     guidance.
   2. `lint-staged` runs Prettier + ESLint on staged `.ts`/`.js` files and
      Prettier on staged `.json`/`.md`/`.yml` files.
 - **commit-msg**: `commitlint` validates the commit message format.
 
 Allowlist false positives in `.gitleaks.toml` rather than bypassing the hook
-with `--no-verify`.
+with `--no-verify`. CI also runs gitleaks on every push via
+`.github/workflows/secrets-scan.yml`, independently of the main CI pipeline,
+so a bypassed local hook still fails the build.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,9 @@ These checks are enforced by Husky on every commit:
 - **commit-msg**: `commitlint` validates the commit message format.
 
 Allowlist false positives in `.gitleaks.toml` rather than bypassing the hook
-with `--no-verify`. CI also runs gitleaks on every push via
-`.github/workflows/secrets-scan.yml`, independently of the main CI pipeline,
-so a bypassed local hook still fails the build.
+with `--no-verify`. CI also runs gitleaks on every push to branches except
+`gh-pages` via `.github/workflows/secrets-scan.yml`, independently of the
+main CI pipeline, so a bypassed local hook still fails the build.
 
 ---
 


### PR DESCRIPTION
## Description

Release workflow run [24655615893](https://github.com/chrisleekr/github-app-playground/actions/runs/24655615893) failed at the `Scan git history for secrets` step with 5 `private-key` findings. All 5 are false positives — MkDocs-rendered placeholder PEM envelopes from `docs/SETUP.md` that landed on the `gh-pages` branch (`SETUP/index.html`, `search/search_index.json`). No real key material.

This PR:

1. **Suppresses the false positives** with a scoped allowlist in `.gitleaks.toml` (path-anchored, `targetRules = [\"private-key\"]` only — other detectors still fire on those paths).
2. **Decouples secret scanning from the release pipeline** by moving gitleaks out of `ci.yml` into a new standalone `secrets-scan.yml`. The new workflow triggers on `push` for every branch except `gh-pages`, closing a gap where pushes to `chore/**`, `docs/**`, `ci/**`, `test/**` previously got no secret scan at all.
3. **Hardens the pre-commit hook** — gitleaks is now a hard-required local gate that fails closed with install guidance rather than silently skipping when the binary is missing.

### Before

```mermaid
flowchart LR
    classDef keep fill:#1f6feb,stroke:#0d47a1,color:#ffffff
    classDef drop fill:#b91c1c,stroke:#7f1d1d,color:#ffffff
    classDef new fill:#15803d,stroke:#14532d,color:#ffffff

    Push["push / PR"]:::keep --> CI["ci.yml<br/>typecheck · lint · format · audit · test · build<br/>+ gitleaks"]:::drop
    Release["workflow_dispatch<br/>release.yml"]:::keep --> CI
    CI --> Block["Release blocked<br/>by gh-pages false positives"]:::drop
    OtherPush["push to chore/** docs/** ci/** test/**"]:::keep --> NoScan["No secret scan"]:::drop
```

### After

```mermaid
flowchart LR
    classDef keep fill:#1f6feb,stroke:#0d47a1,color:#ffffff
    classDef new fill:#15803d,stroke:#14532d,color:#ffffff

    Push["push / PR"]:::keep --> CI["ci.yml<br/>typecheck · lint · format · audit · test · build"]:::keep
    Release["workflow_dispatch<br/>release.yml"]:::keep --> CI
    AnyPush["push to any branch<br/>except gh-pages"]:::keep --> Scan["secrets-scan.yml<br/>standalone gitleaks"]:::new
    Commit["git commit"]:::keep --> Hook[".husky/pre-commit<br/>hard-required gitleaks"]:::new
```

## Related Issues

- Closes #(none — tracked via failed run 24655615893)

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

Verification performed:

- `gitleaks detect --log-opts=\"gh-pages\" --config .gitleaks.toml` — **0 findings** (allowlist suppresses the 5 false positives).
- Bare default config against same commits — confirmed findings are only placeholder PEM envelopes (literal `<YOUR_BASE64_ENCODED_KEY_CONTENT_HERE>`), no real secret material.
- `bun run check` — typecheck, lint, format, tests all pass.
- Pre-commit hook hard-fail path tested: running with empty PATH exits 1 with install guidance.
- Pre-commit hook detection path tested: a synthetic PEM with `-----BEGIN RSA PRIVATE KEY-----` is still flagged (allowlist did not over-broaden).

## Screenshots/Recordings

N/A — CI/workflow configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized secret scanning into a dedicated CI workflow for improved separation of concerns.
  * Enhanced local pre-commit checks to require secret scanning tool installation.

* **Documentation**
  * Updated developer guides to reflect updated secret scanning requirements and CI workflow structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->