### PR TITLE
fix(orchestrator): await Valkey connect before flipping isReady

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
     "oninitialized",
     "pgdata",
     "PKCE",
+    "readyz",
     "resumability",
     "sarif",
     "Streamable",

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ import { closeDb, getDb } from "./db";
 import { runMigrations } from "./db/migrate";
 import { logger } from "./logger";
 import { recoverStaleExecutions } from "./orchestrator/history";
-import { closeValkey, getValkeyClient, isValkeyHealthy } from "./orchestrator/valkey";
+import { closeValkey, connectValkey, isValkeyHealthy } from "./orchestrator/valkey";
 import { startWebSocketServer, stopWebSocketServer } from "./orchestrator/ws-server";
 import type { BotContext } from "./types";
 import { handleIssueComment } from "./webhook/events/issue-comment";
@@ -103,7 +103,13 @@ const server = http.createServer((req, res) => {
   if (req.url === "/readyz") {
     // Readiness: should we receive traffic?
     // Server mode always needs Valkey (FM-7); daemon mode skips this file entirely.
-    const ready = isReady && isValkeyHealthy();
+    const valkeyHealthy = isValkeyHealthy();
+    const ready = isReady && valkeyHealthy;
+    if (!ready) {
+      // Debug-level so K8s probes don't swamp logs at info; flip LOG_LEVEL=debug
+      // to see exactly which flag is false during startup races.
+      logger.debug({ isReady, valkeyHealthy }, "/readyz returning 503");
+    }
     res
       .writeHead(ready ? 200 : 503, { "Content-Type": "text/plain" })
       .end(ready ? "ready" : "not ready");
@@ -298,12 +304,16 @@ async function runStartupChecks(): Promise<void> {
     await recoverStaleExecutions(db);
   }
 
-  getValkeyClient();
+  // Block until Valkey is actually connected (FM-7). Without this, isReady
+  // flips true synchronously while RedisClient.onconnect fires on a later
+  // tick, producing 503s on /readyz until then. See src/orchestrator/valkey.ts.
+  await connectValkey();
+
   startWebSocketServer();
   logger.info({ wsPort: config.wsPort }, "Orchestrator WebSocket server started");
 
   isReady = true;
-  logger.info("Startup checks passed, server is ready");
+  logger.info({ valkeyHealthy: isValkeyHealthy() }, "Startup checks passed, server is ready");
 }
 
 void runStartupChecks().catch((err: unknown) => {

--- a/src/orchestrator/valkey.ts
+++ b/src/orchestrator/valkey.ts
@@ -13,7 +13,13 @@ import { logger } from "../logger";
 
 let client: RedisClient | null = null;
 let valkeyConnected = false;
+let valkeyShuttingDown = false;
 let connectStartedAt: number | null = null;
+// Resolvers waiting for the next onconnect to fire. Drained in onconnect.
+// Keeps connectValkey()'s readiness signal tied to the actual flag flip,
+// not to client.connect()'s promise — Bun does not document ordering between
+// connect() resolving and onconnect firing.
+const pendingConnectResolvers: (() => void)[] = [];
 
 /**
  * Get or create the Valkey client singleton.
@@ -31,12 +37,22 @@ export function getValkeyClient(): RedisClient | null {
     valkeyConnected = true;
     const elapsedMs = connectStartedAt === null ? null : Date.now() - connectStartedAt;
     logger.info({ elapsedMs }, "Valkey connected");
+    // Drain any connectValkey() awaiters now that the flag is true.
+    while (pendingConnectResolvers.length > 0) {
+      const resolve = pendingConnectResolvers.shift();
+      resolve?.();
+    }
   };
 
   client.onclose = (): void => {
     const wasConnected = valkeyConnected;
+    const intentional = valkeyShuttingDown;
     valkeyConnected = false;
-    logger.warn({ wasConnected }, "Valkey connection closed");
+    if (intentional) {
+      logger.info({ wasConnected }, "Valkey connection closed (intentional shutdown)");
+    } else {
+      logger.warn({ wasConnected }, "Valkey connection closed");
+    }
   };
 
   return client;
@@ -59,12 +75,14 @@ function redactValkeyUrl(url: string): string {
 /**
  * Block until the Valkey client is connected (FM-7 startup race fix).
  *
- * Bun's RedisClient connects asynchronously: the `onconnect` callback fires on a
- * later tick. Without awaiting, `isReady` flips true before `valkeyConnected`,
- * so /readyz returns 503 until onconnect fires. This races against K8s probes.
+ * Awaits the `onconnect` callback specifically — NOT `client.connect()`'s
+ * promise — because Bun does not document that the callback fires before the
+ * promise resolves. Since `valkeyConnected` is only flipped inside `onconnect`,
+ * tying our readiness signal to the callback guarantees `isValkeyHealthy()`
+ * returns true the instant `connectValkey()` resolves.
  *
- * Wraps `client.connect()` with a timeout so an unreachable Valkey causes the
- * pod to crash-loop (visible failure) rather than silently sit not-ready.
+ * Times out so an unreachable Valkey crash-loops the pod (visible failure)
+ * instead of silently sitting not-ready.
  */
 export async function connectValkey(timeoutMs = 15_000): Promise<void> {
   const c = getValkeyClient();
@@ -81,16 +99,32 @@ export async function connectValkey(timeoutMs = 15_000): Promise<void> {
   logger.info({ timeoutMs }, "Awaiting Valkey connection");
 
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`Valkey connect timed out after ${String(timeoutMs)}ms`));
-    }, timeoutMs);
-  });
+  let resolverRef: (() => void) | undefined;
 
   try {
-    await Promise.race([c.connect(), timeout]);
+    await new Promise<void>((resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`Valkey connect timed out after ${String(timeoutMs)}ms`));
+      }, timeoutMs);
+
+      resolverRef = (): void => {
+        resolve();
+      };
+      pendingConnectResolvers.push(resolverRef);
+
+      // Kick the connection (idempotent if already connecting). We discard the
+      // promise's resolution and rely on onconnect to flip the flag, but we
+      // forward connection errors so we don't wait for the timeout on hard fail.
+      c.connect().catch((err: unknown) => {
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+    });
     logger.info({ elapsedMs: Date.now() - startedAt }, "Valkey connect awaited");
   } catch (err) {
+    if (resolverRef !== undefined) {
+      const idx = pendingConnectResolvers.indexOf(resolverRef);
+      if (idx >= 0) pendingConnectResolvers.splice(idx, 1);
+    }
     logger.error(
       { err, elapsedMs: Date.now() - startedAt },
       "Valkey connect failed during startup",
@@ -128,8 +162,16 @@ export function closeValkey(): void {
   const current = client;
   if (current !== null) {
     client = null;
-    valkeyConnected = false;
-    current.close();
+    // Mark intentional so onclose can distinguish shutdown from real disconnect.
+    // Don't pre-clear valkeyConnected — let onclose do it so wasConnected
+    // reflects the true pre-shutdown state in logs.
+    valkeyShuttingDown = true;
+    try {
+      current.close();
+    } finally {
+      valkeyShuttingDown = false;
+      valkeyConnected = false;
+    }
     logger.info("Valkey client closed");
   }
 }

--- a/src/orchestrator/valkey.ts
+++ b/src/orchestrator/valkey.ts
@@ -13,6 +13,7 @@ import { logger } from "../logger";
 
 let client: RedisClient | null = null;
 let valkeyConnected = false;
+let connectStartedAt: number | null = null;
 
 /**
  * Get or create the Valkey client singleton.
@@ -22,19 +23,82 @@ export function getValkeyClient(): RedisClient | null {
   if (client !== null) return client;
   if (config.valkeyUrl === undefined) return null;
 
+  connectStartedAt = Date.now();
+  logger.info({ valkeyUrl: redactValkeyUrl(config.valkeyUrl) }, "Valkey client created");
   client = new RedisClient(config.valkeyUrl);
 
   client.onconnect = (): void => {
     valkeyConnected = true;
-    logger.info("Valkey connected");
+    const elapsedMs = connectStartedAt === null ? null : Date.now() - connectStartedAt;
+    logger.info({ elapsedMs }, "Valkey connected");
   };
 
   client.onclose = (): void => {
+    const wasConnected = valkeyConnected;
     valkeyConnected = false;
-    logger.warn("Valkey connection closed");
+    logger.warn({ wasConnected }, "Valkey connection closed");
   };
 
   return client;
+}
+
+/**
+ * Strip credentials from a Valkey URL so it's safe to log.
+ */
+function redactValkeyUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.password !== "") u.password = "***";
+    if (u.username !== "") u.username = "***";
+    return u.toString();
+  } catch {
+    return "<unparseable>";
+  }
+}
+
+/**
+ * Block until the Valkey client is connected (FM-7 startup race fix).
+ *
+ * Bun's RedisClient connects asynchronously: the `onconnect` callback fires on a
+ * later tick. Without awaiting, `isReady` flips true before `valkeyConnected`,
+ * so /readyz returns 503 until onconnect fires. This races against K8s probes.
+ *
+ * Wraps `client.connect()` with a timeout so an unreachable Valkey causes the
+ * pod to crash-loop (visible failure) rather than silently sit not-ready.
+ */
+export async function connectValkey(timeoutMs = 15_000): Promise<void> {
+  const c = getValkeyClient();
+  if (c === null) {
+    logger.info("Valkey not configured, skipping connect");
+    return;
+  }
+  if (valkeyConnected) {
+    logger.debug("Valkey already connected, skipping connect");
+    return;
+  }
+
+  const startedAt = Date.now();
+  logger.info({ timeoutMs }, "Awaiting Valkey connection");
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Valkey connect timed out after ${String(timeoutMs)}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    await Promise.race([c.connect(), timeout]);
+    logger.info({ elapsedMs: Date.now() - startedAt }, "Valkey connect awaited");
+  } catch (err) {
+    logger.error(
+      { err, elapsedMs: Date.now() - startedAt },
+      "Valkey connect failed during startup",
+    );
+    throw err;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 /**

--- a/test/orchestrator/valkey.test.ts
+++ b/test/orchestrator/valkey.test.ts
@@ -355,10 +355,16 @@ describe("connectValkey", () => {
     const client = valkey.getValkeyClient();
     if (client === null) throw new Error("expected client");
     // Stub Bun.RedisClient.connect so we don't depend on a real Valkey.
-    client.connect = (): Promise<void> => Promise.resolve();
+    // Critical: fire onconnect — connectValkey awaits the callback, not the promise.
+    client.connect = (): Promise<void> => {
+      client.onconnect?.();
+      return Promise.resolve();
+    };
 
     await valkey.connectValkey(1000);
 
+    // The whole point of connectValkey: when it resolves, isValkeyHealthy must be true.
+    expect(valkey.isValkeyHealthy()).toBe(true);
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({ elapsedMs: expect.any(Number) }),
       "Valkey connect awaited",
@@ -411,6 +417,7 @@ describe("connectValkey", () => {
     expect(createdCall).toBeDefined();
     const meta = createdCall?.[0] as { valkeyUrl: string };
     expect(meta.valkeyUrl).not.toContain("secret");
+    expect(meta.valkeyUrl).not.toContain("user");
     expect(meta.valkeyUrl).toContain("***");
   });
 });

--- a/test/orchestrator/valkey.test.ts
+++ b/test/orchestrator/valkey.test.ts
@@ -173,7 +173,10 @@ describe("getValkeyClient", () => {
 
     client.onconnect();
     expect(valkey.isValkeyHealthy()).toBe(true);
-    expect(mockLoggerInfo).toHaveBeenCalledWith("Valkey connected");
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
+      "Valkey connected",
+    );
   });
 
   it("sets up onclose callback that updates health state", () => {
@@ -189,7 +192,10 @@ describe("getValkeyClient", () => {
 
     client.onclose();
     expect(valkey.isValkeyHealthy()).toBe(false);
-    expect(mockLoggerWarn).toHaveBeenCalledWith("Valkey connection closed");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ wasConnected: true }),
+      "Valkey connection closed",
+    );
   });
 });
 
@@ -330,5 +336,81 @@ describe("closeValkey", () => {
 
     valkey.closeValkey();
     expect(valkey.isValkeyHealthy()).toBe(false);
+  });
+});
+
+describe("connectValkey", () => {
+  it("returns immediately when valkeyUrl is not configured", async () => {
+    if (!isRealModule) return;
+
+    mockConfig.valkeyUrl = undefined;
+    await valkey.connectValkey(1000);
+    expect(mockLoggerInfo).toHaveBeenCalledWith("Valkey not configured, skipping connect");
+  });
+
+  it("resolves once client.connect() resolves and logs duration", async () => {
+    if (!isRealModule) return;
+
+    mockConfig.valkeyUrl = "redis://127.0.0.1:59999";
+    const client = valkey.getValkeyClient();
+    if (client === null) throw new Error("expected client");
+    // Stub Bun.RedisClient.connect so we don't depend on a real Valkey.
+    client.connect = (): Promise<void> => Promise.resolve();
+
+    await valkey.connectValkey(1000);
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
+      "Valkey connect awaited",
+    );
+  });
+
+  it("rejects when connect exceeds timeoutMs", async () => {
+    if (!isRealModule) return;
+
+    mockConfig.valkeyUrl = "redis://127.0.0.1:59999";
+    const client = valkey.getValkeyClient();
+    if (client === null) throw new Error("expected client");
+    client.connect = (): Promise<void> => new Promise(() => {}); // never resolves
+
+    let caught: unknown;
+    try {
+      await valkey.connectValkey(20);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/timed out after 20ms/);
+  });
+
+  it("skips connect work when already connected", async () => {
+    if (!isRealModule) return;
+
+    mockConfig.valkeyUrl = "redis://127.0.0.1:59999";
+    const c = valkey.getValkeyClient();
+    if (c?.onconnect === undefined) throw new Error("expected client+cb");
+    c.onconnect();
+    mockLoggerInfo.mockClear();
+
+    await valkey.connectValkey(1000);
+
+    // Should not log "Awaiting Valkey connection" — fast-path returns early.
+    const awaitingLogs = mockLoggerInfo.mock.calls.filter(
+      (call) => call[1] === "Awaiting Valkey connection",
+    );
+    expect(awaitingLogs.length).toBe(0);
+  });
+
+  it("redacts credentials in the client-created log", () => {
+    if (!isRealModule) return;
+
+    mockConfig.valkeyUrl = "redis://user:secret@127.0.0.1:59999";
+    valkey.getValkeyClient();
+
+    const createdCall = mockLoggerInfo.mock.calls.find((c) => c[1] === "Valkey client created");
+    expect(createdCall).toBeDefined();
+    const meta = createdCall?.[0] as { valkeyUrl: string };
+    expect(meta.valkeyUrl).not.toContain("secret");
+    expect(meta.valkeyUrl).toContain("***");
   });
 });


### PR DESCRIPTION
## Description

Fixes a startup race condition where the webhook server's `/readyz` probe returned 503 for several seconds after pod start, sometimes long enough to trip K8s `failureThreshold` and trigger restarts.

`runStartupChecks()` was setting `isReady = true` synchronously immediately after `getValkeyClient()`, but Bun's `RedisClient.onconnect` (the only thing that flips `valkeyConnected = true`) fires on a later event-loop tick. Since `/readyz` ANDs `isReady` with `isValkeyHealthy()`, every probe between those two moments returned 503.

`runStartupChecks()` now awaits `connectValkey()`, which races `client.connect()` against a 15s timeout. If Valkey is unreachable the pod crash-loops (visible failure) instead of silently sitting not-ready.

### Before — race condition

```mermaid
sequenceDiagram
    participant App as runStartupChecks
    participant RC as RedisClient
    participant Probe as K8s /readyz

    App->>RC: new RedisClient&#40;url&#41;
    App->>App: isReady = true
    Probe->>App: GET /readyz
    App-->>Probe: 503 &#40;valkeyConnected=false&#41;
    Note over Probe: failureThreshold ticks up
    RC-->>App: onconnect fires &#40;later tick&#41;
    App->>App: valkeyConnected = true
    Probe->>App: GET /readyz
    App-->>Probe: 200
```

### After — awaited connect

```mermaid
sequenceDiagram
    participant App as runStartupChecks
    participant RC as RedisClient
    participant Probe as K8s /readyz

    App->>RC: new RedisClient&#40;url&#41;
    App->>RC: await client.connect&#40;&#41; race timeout 15s
    RC-->>App: onconnect fires
    RC-->>App: connect&#40;&#41; resolves
    App->>App: isReady = true
    Probe->>App: GET /readyz
    App-->>Probe: 200
```

## Changes

**`src/orchestrator/valkey.ts`**
- New `connectValkey(timeoutMs = 15_000)` — awaits `client.connect()` via `Promise.race` against a timeout, throws on timeout/error so startup fails loudly.
- New `redactValkeyUrl()` — strips username/password before logging the connection target.
- `onconnect` now logs `elapsedMs` measured from client construction (visibility into how long Bun took to connect).
- `onclose` now logs `wasConnected` so you can tell a real disconnect from a never-connected close.

**`src/app.ts`**
- `runStartupChecks()` swaps `getValkeyClient()` for `await connectValkey()`.
- The "server is ready" log now includes `valkeyHealthy` so the value is visible at the moment the flag flipped.
- `/readyz` 503 path emits a `debug`-level log with `{ isReady, valkeyHealthy }` so future races can be diagnosed by setting `LOG_LEVEL=debug`.

**`test/orchestrator/valkey.test.ts`**
- Updated 2 existing assertions for the new structured-log shapes.
- Added `describe("connectValkey")` (5 tests): unconfigured-skip, success path with duration log, timeout rejection, fast-path skip when already connected, credential redaction.

**`.vscode/settings.json`** — added `readyz` to the cSpell project dictionary (already used throughout the codebase).

## Related Issues

- Closes the readiness-probe issue surfaced in the post-merge investigation of #35.

## Testing

- [x] I have tested these changes locally (`bun test test/orchestrator/valkey.test.ts` → 20/20 pass, 98.65% line / 100% func coverage on `valkey.ts`).
- [x] I have added/updated tests as needed (5 new tests for `connectValkey`).
- [x] All existing tests pass (`bun run typecheck`, `bun run lint` clean; pre-existing multi-file mock-pollution failures unchanged from `main`).

## Screenshots/Recordings

N/A — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured database connection is established before the server reports readiness.
  * Health check endpoint now validates database connectivity status.

* **Improvements**
  * Added connection timeout protection for more robust startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->