### PR TITLE
fix(auth): prevent empty ANTHROPIC_API_KEY from shadowing real OAuth token

### DIFF
--- a/src/ai/llm-client.ts
+++ b/src/ai/llm-client.ts
@@ -105,13 +105,19 @@ export interface CreateLLMClientParams {
 export function createLLMClient(params: CreateLLMClientParams): LLMClient {
   let sdk: AnthropicLikeSdk;
   if (params.provider === "anthropic") {
-    const apiKey = params.anthropicApiKey ?? params.claudeCodeOauthToken;
-    if (apiKey === undefined || apiKey.length === 0) {
+    const apiKeyRaw = params.anthropicApiKey;
+    const oauthRaw = params.claudeCodeOauthToken;
+    const apiKey = apiKeyRaw !== undefined && apiKeyRaw.length > 0 ? apiKeyRaw : undefined;
+    const oauth = oauthRaw !== undefined && oauthRaw.length > 0 ? oauthRaw : undefined;
+    const chosen = apiKey ?? oauth;
+    if (chosen === undefined) {
+      const apiKeyState = apiKeyRaw === undefined ? "missing" : "empty";
+      const oauthState = oauthRaw === undefined ? "missing" : "empty";
       throw new Error(
-        "createLLMClient: provider=anthropic requires anthropicApiKey or claudeCodeOauthToken",
+        `createLLMClient: provider=anthropic requires a non-empty anthropicApiKey or claudeCodeOauthToken (anthropicApiKey=${apiKeyState}, claudeCodeOauthToken=${oauthState})`,
       );
     }
-    sdk = new Anthropic({ apiKey }) as unknown as AnthropicLikeSdk;
+    sdk = new Anthropic({ apiKey: chosen }) as unknown as AnthropicLikeSdk;
   } else {
     if (params.awsRegion === undefined || params.awsRegion.length === 0) {
       throw new Error("createLLMClient: provider=bedrock requires awsRegion");

--- a/src/ai/llm-client.ts
+++ b/src/ai/llm-client.ts
@@ -107,8 +107,12 @@ export function createLLMClient(params: CreateLLMClientParams): LLMClient {
   if (params.provider === "anthropic") {
     const apiKeyRaw = params.anthropicApiKey;
     const oauthRaw = params.claudeCodeOauthToken;
-    const apiKey = apiKeyRaw !== undefined && apiKeyRaw.length > 0 ? apiKeyRaw : undefined;
-    const oauth = oauthRaw !== undefined && oauthRaw.length > 0 ? oauthRaw : undefined;
+    // Trim before checking length so whitespace-only credentials are treated as
+    // absent — matches `nonEmptyOptionalString` in config.ts. Direct callers
+    // (tests, future code paths) that bypass the schema must not be able to
+    // leak " " into `new Anthropic({ apiKey })` and produce a confusing 401.
+    const apiKey = apiKeyRaw !== undefined && apiKeyRaw.trim().length > 0 ? apiKeyRaw : undefined;
+    const oauth = oauthRaw !== undefined && oauthRaw.trim().length > 0 ? oauthRaw : undefined;
     const chosen = apiKey ?? oauth;
     if (chosen === undefined) {
       const apiKeyState = apiKeyRaw === undefined ? "missing" : "empty";

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,21 @@
 import { z } from "zod";
 
 /**
+ * Optional string that treats empty / whitespace-only input as absent.
+ *
+ * Why: `envFrom: secretRef` injects every Secret key as an env var, even
+ * keys whose decrypted value is "". Plain `z.string().optional()` would
+ * keep that "" alive and let it shadow a real credential downstream
+ * (e.g. `apiKey ?? oauthToken` returns "" instead of falling through).
+ * Coercing here makes the invariant uniform: if the field is defined
+ * on `Config`, the value is non-empty.
+ */
+const nonEmptyOptionalString = z.preprocess(
+  (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+  z.string().optional(),
+);
+
+/**
  * Zod-validated environment variables.
  * Fails fast at startup if required vars are missing.
  */
@@ -34,8 +49,14 @@ const configSchema = z
     // Either Console API key (pay-as-you-go) or Max/Pro subscription OAuth token
     // (generated via `claude setup-token`, sk-ant-oat... prefix).
     // See https://code.claude.com/docs/en/authentication#authentication-precedence
-    anthropicApiKey: z.string().optional(),
-    claudeCodeOauthToken: z.string().optional(),
+    //
+    // `preprocess` coerces empty / whitespace-only strings to `undefined` so a
+    // Secret key whose decrypted value is "" (e.g. `envFrom: secretRef` over a
+    // SealedSecret with a stale empty entry) cannot shadow a real OAuth token
+    // via downstream `??` short-circuits. Callers can rely on the invariant:
+    // if defined, the value is non-empty after trim.
+    anthropicApiKey: nonEmptyOptionalString,
+    claudeCodeOauthToken: nonEmptyOptionalString,
 
     // --- 4. AWS Bedrock credentials ---
 

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -33,14 +33,26 @@ function isResultMessage(msg: unknown): msg is SDKResultMessage {
  * env mapping in `src/mcp/registry.ts`.
  */
 function buildProviderEnv(installationToken?: string): Record<string, string | undefined> {
+  // Strip empty credential env vars before forwarding to the CLI. The CLI's
+  // documented auth precedence chain (ANTHROPIC_API_KEY at position 3 beats
+  // CLAUDE_CODE_OAUTH_TOKEN at position 5) treats an empty string as a
+  // present-but-blank credential and selects it, blocking the real token
+  // from being used. Common cause: `envFrom: secretRef` over a Secret that
+  // carries a stale empty key.
+  const isBlank = (v: string | undefined): boolean => typeof v === "string" && v.trim() === "";
+  const { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ...rest } = process.env;
+  const baseEnv: Record<string, string | undefined> = { ...rest };
+  if (!isBlank(ANTHROPIC_API_KEY)) baseEnv["ANTHROPIC_API_KEY"] = ANTHROPIC_API_KEY;
+  if (!isBlank(CLAUDE_CODE_OAUTH_TOKEN))
+    baseEnv["CLAUDE_CODE_OAUTH_TOKEN"] = CLAUDE_CODE_OAUTH_TOKEN;
   const tokenEnv: Record<string, string> =
     installationToken !== undefined && installationToken !== ""
       ? { GH_TOKEN: installationToken, GITHUB_TOKEN: installationToken }
       : {};
   if (config.provider === "bedrock") {
-    return { ...process.env, ...tokenEnv, CLAUDE_CODE_USE_BEDROCK: "1" };
+    return { ...baseEnv, ...tokenEnv, CLAUDE_CODE_USE_BEDROCK: "1" };
   }
-  return { ...process.env, ...tokenEnv };
+  return { ...baseEnv, ...tokenEnv };
 }
 
 /**

--- a/test/ai/llm-client.test.ts
+++ b/test/ai/llm-client.test.ts
@@ -35,14 +35,26 @@ describe("resolveModelId", () => {
 describe("createLLMClient — validation guards", () => {
   it("throws when provider=anthropic and no credentials supplied", () => {
     expect(() => createLLMClient({ provider: "anthropic" })).toThrow(
-      /requires anthropicApiKey or claudeCodeOauthToken/,
+      /anthropicApiKey=missing, claudeCodeOauthToken=missing/,
     );
   });
 
   it("throws when anthropicApiKey is empty string", () => {
     expect(() => createLLMClient({ provider: "anthropic", anthropicApiKey: "" })).toThrow(
-      /requires anthropicApiKey or claudeCodeOauthToken/,
+      /anthropicApiKey=empty, claudeCodeOauthToken=missing/,
     );
+  });
+
+  it("falls through to oauth when anthropicApiKey is empty string and oauth is set", () => {
+    // Reproduces the production trap: ANTHROPIC_API_KEY="" must not shadow a
+    // real CLAUDE_CODE_OAUTH_TOKEN. Defense in depth — config.ts also coerces
+    // empty strings to undefined, but llm-client.ts must not depend on that.
+    const c = createLLMClient({
+      provider: "anthropic",
+      anthropicApiKey: "",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+    });
+    expect(c.provider).toBe("anthropic");
   });
 
   it("throws when provider=bedrock and no region supplied", () => {

--- a/test/ai/llm-client.test.ts
+++ b/test/ai/llm-client.test.ts
@@ -57,6 +57,21 @@ describe("createLLMClient — validation guards", () => {
     expect(c.provider).toBe("anthropic");
   });
 
+  it("treats whitespace-only anthropicApiKey as empty (matches config.ts trim semantics)", () => {
+    // A whitespace-only key would otherwise produce a confusing 401 from the
+    // SDK instead of the clear "missing vs empty" error.
+    expect(() => createLLMClient({ provider: "anthropic", anthropicApiKey: "   " })).toThrow(
+      /anthropicApiKey=empty, claudeCodeOauthToken=missing/,
+    );
+
+    const c = createLLMClient({
+      provider: "anthropic",
+      anthropicApiKey: "   ",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+    });
+    expect(c.provider).toBe("anthropic");
+  });
+
   it("throws when provider=bedrock and no region supplied", () => {
     expect(() => createLLMClient({ provider: "bedrock" })).toThrow(
       /provider=bedrock requires awsRegion/,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -53,6 +53,39 @@ describe("configSchema — Anthropic provider", () => {
     const result = configSchema.safeParse({ ...BASE, provider: "anthropic" });
     expect(result.success).toBe(false);
   });
+
+  it("coerces empty-string credentials to undefined so they cannot shadow a real value", () => {
+    // Reproduces the production trap: a SealedSecret entry that decrypts to ""
+    // gets injected by `envFrom: secretRef` as ANTHROPIC_API_KEY="". Without
+    // coercion, downstream `apiKey ?? oauthToken` returns "" instead of the
+    // real OAuth token, and createLLMClient throws.
+    const result = configSchema.safeParse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      allowedOwners: "luxuryescapes",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.anthropicApiKey).toBeUndefined();
+      expect(result.data.claudeCodeOauthToken).toBe("sk-ant-oat-test");
+    }
+  });
+
+  it("coerces whitespace-only credentials to undefined", () => {
+    const result = configSchema.safeParse({
+      ...BASE,
+      provider: "anthropic",
+      anthropicApiKey: "   ",
+      claudeCodeOauthToken: "sk-ant-oat-test",
+      allowedOwners: "luxuryescapes",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.anthropicApiKey).toBeUndefined();
+    }
+  });
 });
 
 describe("configSchema — Bedrock provider", () => {


### PR DESCRIPTION
## Description

Production failure: `intent-classifier` threw `createLLMClient: provider=anthropic requires anthropicApiKey or claudeCodeOauthToken` even though `CLAUDE_CODE_OAUTH_TOKEN` was correctly set in the pod (108 chars, verified via `kubectl exec`).

Root cause is a multi-layer trap. The deployed Secret carries a stale `ANTHROPIC_API_KEY` key with an empty decrypted value. `envFrom: secretRef` injects it as `ANTHROPIC_API_KEY=""`. Downstream code then:

1. **`config.ts`** — `z.string().optional()` accepts `""`; the refinement only requires "at least one non-empty", so `""` survives into `Config`.
2. **`intent-classifier.ts`, `triage-client-factory.ts`** — conditional spread guards on `!== undefined`, letting `""` through.
3. **`llm-client.ts`** — `apiKey ?? oauthToken` returns `""` (nullish coalescing does NOT short-circuit on empty string), so the empty value beats the real OAuth token. `apiKey.length === 0` then throws.
4. **`executor.ts`** — `...process.env` blindly forwards `ANTHROPIC_API_KEY=""` to the Claude CLI subprocess; the CLI's auth precedence chain (API key at position 3 beats OAuth at position 5) selects the empty value, breaking agent execution too.

Fix: normalize at the schema boundary so `Config` cannot carry empty credential strings, plus defense-in-depth in `executor.ts` and `llm-client.ts` (the CLI subprocess and direct callers don't go through the schema).

### Before

```mermaid
flowchart TD
    Secret["SealedSecret<br/>ANTHROPIC_API_KEY = ''"]:::bad
    Env["Pod env<br/>ANTHROPIC_API_KEY=''<br/>CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat..."]:::bad
    Cfg["Config<br/>anthropicApiKey: ''<br/>claudeCodeOauthToken: 'sk-ant...'"]:::bad
    Spread["intent-classifier spread<br/>!== undefined lets '' through"]:::bad
    Coalesce["llm-client<br/>'' ?? 'sk-ant...' === ''"]:::bad
    Throw["throw: requires anthropicApiKey<br/>or claudeCodeOauthToken"]:::bad
    SubProc["Claude CLI subprocess<br/>auth chain picks empty key"]:::bad

    Secret --> Env
    Env --> Cfg
    Cfg --> Spread
    Spread --> Coalesce
    Coalesce --> Throw
    Env --> SubProc

    classDef bad fill:#7a1f1f,color:#ffffff,stroke:#ff6b6b,stroke-width:2px
```

### After

```mermaid
flowchart TD
    Secret["SealedSecret<br/>ANTHROPIC_API_KEY = '' still stale"]:::neutral
    Env["Pod env<br/>ANTHROPIC_API_KEY=''<br/>CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat..."]:::neutral
    Cfg["Config<br/>anthropicApiKey: undefined<br/>claudeCodeOauthToken: 'sk-ant...'"]:::good
    Spread["intent-classifier spread<br/>only oauth field included"]:::good
    Coalesce["llm-client<br/>chosen = 'sk-ant...'"]:::good
    Client["Anthropic client built<br/>with OAuth token"]:::good
    SubProc["Claude CLI subprocess<br/>empty key stripped before spread<br/>OAuth token wins"]:::good

    Secret --> Env
    Env -- preprocess coerces empty to undefined --> Cfg
    Cfg --> Spread
    Spread --> Coalesce
    Coalesce --> Client
    Env -- buildProviderEnv strips blanks --> SubProc

    classDef good fill:#1f4d2b,color:#ffffff,stroke:#4ade80,stroke-width:2px
    classDef neutral fill:#3f3f46,color:#ffffff,stroke:#a1a1aa,stroke-width:2px
```

## Related Issues

- None — surfaced by direct production debugging on the live `github-app` pod.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

Verification:

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (127 pre-existing warnings, unchanged)
- `bun test ./test/config.test.ts ./test/ai/llm-client.test.ts ./test/workflows/intent-classifier.test.ts ./test/webhook/events/issue-comment.test.ts` — 60 pass / 0 fail
- New tests lock the invariant: `ANTHROPIC_API_KEY=""` plus a real OAuth token must produce a working client (not throw).

## Screenshots/Recordings

N/A — no UI surface affected.

## Changes

- **`src/config.ts`** — added `nonEmptyOptionalString` (`z.preprocess` wrapper) and applied it to `anthropicApiKey` and `claudeCodeOauthToken` so empty/whitespace strings coerce to `undefined` at the schema boundary.
- **`src/core/executor.ts`** — `buildProviderEnv` strips empty `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` from `process.env` before forwarding to the Claude CLI subprocess.
- **`src/ai/llm-client.ts`** — independently filter empty strings (defense in depth) and tighten the error to distinguish `missing` vs `empty` per credential field for faster future diagnosis.
- **`test/config.test.ts`** — added two tests covering empty-string and whitespace-only credential coercion.
- **`test/ai/llm-client.test.ts`** — updated existing assertions to the new error format and added a positive test that empty `anthropicApiKey` falls through to a real OAuth token.

## Out of scope

- The SealedSecret in `argocd-apps/sealed-secrets/github-app/` still carries the stale empty `ANTHROPIC_API_KEY` entry. Code is now tolerant of it, but the operator should re-encrypt without that field for cleanliness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed credential validation to properly handle empty or whitespace-only environment variables, preventing them from incorrectly overriding valid credentials.
  * Enhanced error messages to clearly indicate which credentials are missing versus empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->