### PR TITLE
fix(triage): remove 500-char cap on verdict summary

### DIFF
--- a/docs/BOT-WORKFLOWS.md
+++ b/docs/BOT-WORKFLOWS.md
@@ -62,7 +62,7 @@ Composite workflows like `ship` insert a child row per step. When the child comp
 - **Outputs**:
   - `state.valid` — boolean verdict
   - `state.confidence` — 0-1 float from the agent's self-assessment
-  - `state.summary` — one-paragraph rationale
+  - `state.summary` — the agent's verdict rationale; length is uncapped (the agent writes as much as the verdict honestly requires). Embedded into the failed-cascade `reason` line when `valid === false`.
   - `state.recommendedNext` ∈ {`plan`, `stop`}
   - `state.evidence` — array of `{file, line?, note?}` cites
   - `state.reproduction` — `{ attempted: boolean, reproduced: boolean | null, details: string }`. `attempted=false` means non-bug class. `reproduced=null` with `attempted=true` means the agent honestly tried but couldn't reach a verdict (needs prod data, external service we lack). The agent never lies about reproduction status.

--- a/src/workflows/handlers/triage.ts
+++ b/src/workflows/handlers/triage.ts
@@ -71,7 +71,7 @@ const verdictSchema = z
   .object({
     valid: z.boolean(),
     confidence: z.number().min(0).max(1),
-    summary: z.string().min(1).max(500),
+    summary: z.string().min(1),
     recommendedNext: z.enum(["plan", "stop"]),
     evidence: z
       .array(
@@ -181,7 +181,7 @@ export const handler: WorkflowHandler = async (ctx) => {
 
     if (!verdict.valid) {
       // Fail-out so ship cascade halts at this step. The full report is in
-      // the tracking comment; the reason carries the one-line summary that
+      // the tracking comment; the reason carries the verdict summary that
       // ship surfaces in its own parent comment ("ship halted at step 0...").
       return {
         status: "failed",
@@ -317,7 +317,7 @@ function buildTriagePrompt(input: {
     `    {`,
     `      "valid": true | false,`,
     `      "confidence": <0.0-1.0>,`,
-    `      "summary": "<single line, ≤500 chars, no newlines>",`,
+    `      "summary": "<as long as needed to faithfully convey the verdict>",`,
     `      "recommendedNext": "plan" | "stop",`,
     `      "evidence": [`,
     `        { "file": "<path>", "line": <int|omit>, "note": "<short>" },`,


### PR DESCRIPTION
## Description

Drops the artificial `.max(500)` constraint on `verdict.summary` in the triage workflow. A real triage may need to cite multiple claims, reproductions, and evidence to honestly convey the verdict — capping the summary to 500 chars forced the agent to either truncate analysis or, as observed in production, overflow the cap and have a $1.15 / 21-turn run thrown away by post-validation.

The schema already supports detail elsewhere (`TRIAGE.md` is the full uncapped report, `reproduction.details` allows 2000 chars, structured `evidence[]` is unbounded). The 500-char cap on `summary` was the only field standing between a successful agent run and a `failed` outcome on cosmetic overflow.

Prompt template and stale comment updated to match the loosened schema.

### Before

```mermaid
flowchart LR
  Agent["Agent writes<br/>TRIAGE_VERDICT.json"]:::work
  Schema["verdictSchema<br/>summary.max=500"]:::gate
  Outcome["outcome=failed<br/>$1.15 of work discarded"]:::fail
  Agent --> Schema --> Outcome
  classDef work fill:#1f4e79,color:#ffffff,stroke:#0b2545
  classDef gate fill:#8b1d1d,color:#ffffff,stroke:#3b0a0a
  classDef fail fill:#5a0f0f,color:#ffffff,stroke:#220000
```

### After

```mermaid
flowchart LR
  AgentNew["Agent writes<br/>TRIAGE_VERDICT.json"]:::work
  SchemaNew["verdictSchema<br/>summary length unbounded"]:::ok
  OutcomeNew["outcome=succeeded<br/>verdict + report posted"]:::pass
  AgentNew --> SchemaNew --> OutcomeNew
  classDef work fill:#1f4e79,color:#ffffff,stroke:#0b2545
  classDef ok fill:#1b5e20,color:#ffffff,stroke:#0a2e0d
  classDef pass fill:#0d3d12,color:#ffffff,stroke:#001a04
```

## Related Issues

- Refs production triage failure on `chrisleekr/github-app-playground#16` (run `34e361c2-9e9a-433d-b419-f7568221923d`) where the agent produced a valid `VALID` verdict (confidence 0.9) but the post-run validator rejected `TRIAGE_VERDICT.json` with `summary too_big — expected ≤500 characters`.

## Testing

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint` — 0 errors, only pre-existing warnings unrelated to this change)
- [ ] No new tests added — this is a constraint relaxation; existing schema tests continue to validate all other invariants (`min(1)`, structured fields, `recommendedNext` enum, etc.)
- [ ] Manual re-trigger of triage on issue #16 to confirm the previously-failing run now succeeds

## Notes for reviewer

- Downstream consequence (intentional): `summary` is interpolated into the tracking-comment `reason` line as `triage rejected as invalid: ${verdict.summary}`. With the cap removed, that line may now span multiple paragraphs. It still renders as valid markdown. If a one-liner headline becomes valuable for log/UI purposes later, the right fix is a separate `headline` field — not re-imposing a cap on `summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed character and formatting constraints on triage verdict summaries, allowing more detailed and flexible feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->