### PR TITLE
fix(security): redact raw error messages from public PR comments

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -93,8 +93,16 @@ jobs:
           # Slug derivation must match release.config.mjs PRERELEASE_TEMPLATE
           # (`name.replace(/[^a-zA-Z0-9-]/g, '-')`).
           BRANCH_SLUG=$(printf '%s' "$BRANCH_REF" | sed 's/[^a-zA-Z0-9-]/-/g')
-          PATTERN="v*-${BRANCH_SLUG}.*"
-          STALE_TAGS=$(git tag -l "$PATTERN" || true)
+          # `git tag -l <glob>` matches via fnmatch(3), where `*` matches
+          # any characters including hyphens with backtracking. For slug
+          # `fix-test`, the glob `v*-fix-test.*` would over-match the
+          # unrelated tag `v0.4.0-fix-some-other-fix-test.1`, deleting
+          # another branch's dev tags. Use an anchored ERE instead so
+          # only this slug's dev pre-release tags match. BRANCH_SLUG is
+          # already sanitised to `[a-zA-Z0-9-]` above (sed strips every-
+          # thing else), so it is safe to interpolate without regex
+          # escaping.
+          STALE_TAGS=$(git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+-${BRANCH_SLUG}\.[0-9]+$" || true)
           if [ -z "$STALE_TAGS" ]; then
             echo "No stale dev pre-release tags for branch '${BRANCH_SLUG}'"
             exit 0

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -66,6 +66,50 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
+      # Why this step exists:
+      # dev-release re-runs on every push to a feature branch — including
+      # force-pushes (rebase, amend, --force-with-lease). semantic-release
+      # computes the next pre-release counter by walking tags *reachable
+      # from HEAD*; an orphaned tag (one pointing at a commit that was
+      # force-pushed away) is invisible to that walk, so semantic-release
+      # picks the SAME version number again and the subsequent `git tag
+      # <name>` (semantic-release/lib/git.js does NOT pass `-f`) fails
+      # with `fatal: tag already exists`. Without this cleanup, any
+      # rebase/amend on a feature branch wedges the dev pipeline until
+      # the stale tag is manually deleted.
+      #
+      # Dev tags are ephemeral by contract — release.config.mjs publishes
+      # NO GitHub Release and NO CHANGELOG entry in dev mode, so nothing
+      # downstream pins to a specific `.N`. Resetting the counter on each
+      # force-push is correct semantics, not data loss.
+      #
+      # github.ref_name is normalised to a branch slug via env (defense
+      # in depth — ref_name is already constrained by Git ref grammar).
+      - name: Clean stale dev pre-release tags for this branch
+        env:
+          BRANCH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Slug derivation must match release.config.mjs PRERELEASE_TEMPLATE
+          # (`name.replace(/[^a-zA-Z0-9-]/g, '-')`).
+          BRANCH_SLUG=$(printf '%s' "$BRANCH_REF" | sed 's/[^a-zA-Z0-9-]/-/g')
+          PATTERN="v*-${BRANCH_SLUG}.*"
+          STALE_TAGS=$(git tag -l "$PATTERN" || true)
+          if [ -z "$STALE_TAGS" ]; then
+            echo "No stale dev pre-release tags for branch '${BRANCH_SLUG}'"
+            exit 0
+          fi
+          echo "Deleting stale dev pre-release tags for branch '${BRANCH_SLUG}':"
+          echo "$STALE_TAGS"
+          # Local delete is the load-bearing one (semantic-release fails
+          # on the local `git tag` call). Origin delete is best-effort
+          # so a tag already cleaned up out-of-band does not wedge CI.
+          echo "$STALE_TAGS" | xargs git tag -d
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            git push origin --delete "$tag" || echo "warn: origin delete failed for ${tag}"
+          done <<< "$STALE_TAGS"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/docs/use/workflows/implement.md
+++ b/docs/use/workflows/implement.md
@@ -41,3 +41,10 @@ The agent reads `.github/PULL_REQUEST_TEMPLATE/bot-implement.md` and fills every
 - Pipeline fails → handler reports the underlying error.
 
 The handler does **not** poll CI or reviewer state — that is `resolve`'s job, after `review` has run.
+
+## Failure handling
+
+The handler treats public and operator surfaces separately so the public tracking comment never carries the raw underlying error. Both the `runPipeline` failure path and the outer handler `catch` set the same safe `humanMessage`:
+
+- **Public tracking comment** — a safe constant: `"implement pipeline execution failed — see server logs for details."` Octokit error stacks embed the installation token in the request URL, so the bot must never inline `err.message` into a comment body.
+- **Operator surfaces (DB + logs)** — the SDK error is propagated as `ExecutionResult.errorMessage` and persisted as `state.failedReason` on the `workflow_runs` row. `pino` logs the full `err` object on the daemon. The orchestrator's quota-detection helper reads `state.failedReason` to decide whether to auto-defer the next ship iteration; see [`ship.md`](./ship.md).

--- a/docs/use/workflows/resolve.md
+++ b/docs/use/workflows/resolve.md
@@ -39,3 +39,10 @@ Reviewer-thread replies are posted via `gh api repos/<owner>/<repo>/pulls/<num>/
 - `FIX_ATTEMPTS_CAP = 3` — maximum consecutive CI-fix attempts per run.
 - `POLL_WAIT_SECS_CAP = 900` (15 min) — reviewer-patience window before the run terminates.
 - The handler **never** calls `octokit.rest.pulls.merge` — merging is a human action.
+
+## Failure handling
+
+Public-comment and operator surfaces are separated so a raw SDK or octokit error never reaches the public PR thread. Both the `runPipeline` failure path and the outer handler `catch` apply the same separation:
+
+- **Public tracking comment** — a safe constant: `"resolve pipeline execution failed — see server logs for details."` The actual error string remains internal because octokit error stacks include `https://x-access-token:GHS_xxx@…` in the request URL.
+- **Operator surfaces** — `state.failedReason` on the `workflow_runs` row, `pino` log lines on the daemon, and `ExecutionResult.errorMessage` returned to the orchestrator. The orchestrator's transient-quota detector reads `state.failedReason` and auto-defers the ship loop's next iteration when the SDK reports `"You've hit your limit · resets … UTC"`.

--- a/docs/use/workflows/review.md
+++ b/docs/use/workflows/review.md
@@ -54,3 +54,10 @@ If the PR head is behind base **and** the branch is not on a fork, the agent reb
 ## Push policy
 
 The only push acceptable from `review` is `git push --force-with-lease` after a clean rebase onto base (same diff, fresh head SHA). The handler never creates code commits, never calls `pulls.merge`, never posts an `APPROVE` or `REQUEST_CHANGES` review.
+
+## Failure handling
+
+Every failure path (`runPipeline` failure, the outer handler catch, or any sync/async throw before the pipeline runs) returns `status: "failed"` with two distinct outputs:
+
+- **Public tracking comment** — a safe constant: `"review pipeline execution failed — see server logs for details."` Never carries the raw error string, since octokit error stacks include the request URL with the installation token (`https://x-access-token:GHS_xxx@…`).
+- **Operator surfaces (DB + logs)** — `state.failedReason` on the `workflow_runs` row, `pino` log line on the daemon, and `ExecutionResult.errorMessage` returned to the caller. These carry the full SDK message so an operator can diagnose without tailing daemon stderr.

--- a/docs/use/workflows/ship.md
+++ b/docs/use/workflows/ship.md
@@ -123,3 +123,13 @@ The tracking comment puts the answer at the top: any terminal status other than 
 - `merge-conflict-needs-human` — the rebase produced conflicts the bot would not resolve confidently.
 
 For Day-2 SQL and the other terminal categories, see [`operate/runbooks/stuck-ship-intent.md`](../../operate/runbooks/stuck-ship-intent.md).
+
+## Auto-defer on Anthropic usage-limit
+
+A child workflow run that fails because the Claude Agent SDK reported `"You've hit your limit · resets <time> UTC"` (subscription-token quota or per-tier rate limit) is treated as a **transient** failure rather than a permanent one. The orchestrator's `maybeEarlyWakeShipIntent` cascade:
+
+1. Reads `state.failedReason` from the failed `workflow_runs` row.
+2. `detectTransientQuotaError` matches the usage-limit signature and parses the `resets …` clock (handles `6pm (UTC)`, `18:30 UTC`, etc.; falls back to a `+1h` deferral when the clock is unparseable).
+3. `ZADD ship:tickle <retryAtMs> <intent_id>` so the periodic tickle scanner re-fires the iteration once the quota window resets, instead of leaving the intent stalled until an operator re-arms it.
+
+Non-quota failures still take the original `ship.tickle.skip_failed_child` path — the iteration cap remains the safety net for permanently broken intents.

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -239,6 +239,11 @@ export async function executeAgent({
     return {
       success: false,
       durationMs,
+      errorMessage: timedOut
+        ? `Agent execution timed out after ${String(durationMs)}ms`
+        : error instanceof Error
+          ? error.message
+          : String(error),
     };
   } finally {
     clearTimeout(timer);
@@ -267,8 +272,9 @@ function buildExecutionResult(
   result: SDKResultMessage | undefined,
   durationMs: number,
 ): ExecutionResult {
+  const success = result?.subtype === "success";
   const executionResult: ExecutionResult = {
-    success: result?.subtype === "success",
+    success,
     durationMs: result?.duration_ms ?? durationMs,
   };
   if (result?.total_cost_usd !== undefined) {
@@ -276,6 +282,21 @@ function buildExecutionResult(
   }
   if (result?.num_turns !== undefined) {
     executionResult.numTurns = result.num_turns;
+  }
+  // SDK returned a non-success terminal result (e.g. error_max_turns,
+  // error_max_budget_usd) without throwing. Surface the subtype + any
+  // structured error strings the SDK emitted; the executor catch path
+  // owns the throw case separately.
+  if (!success) {
+    const subtype = result?.subtype ?? "unknown";
+    const errors =
+      result !== undefined && "errors" in result && Array.isArray(result.errors)
+        ? (result.errors as readonly string[]).filter((s) => typeof s === "string" && s !== "")
+        : [];
+    executionResult.errorMessage =
+      errors.length > 0
+        ? `SDK ${subtype}: ${errors.join("; ")}`
+        : `SDK terminal subtype: ${subtype}`;
   }
   return executionResult;
 }

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -94,6 +94,13 @@ function buildFinalOpts(result: ExecutionResult): {
   if (result.costUsd !== undefined) {
     opts.costUsd = result.costUsd;
   }
+  // The raw `result.errorMessage` is intentionally NOT forwarded into the
+  // tracking comment — the comment is publicly visible on GitHub and an
+  // upstream error string can carry credentials (octokit error stacks
+  // include the request URL with the installation token), file paths, or
+  // other sensitive context. The error message is still propagated to the
+  // caller via the returned `ExecutionResult` for operator-side surfaces
+  // (logs, DB `state.failedReason`, orchestrator quota-retry detection).
   return opts;
 }
 
@@ -330,6 +337,9 @@ export async function runPipeline(
           () =>
             finalizeTrackingComment(ctx, commentId, {
               success: false,
+              // Public-comment safe text. The actual `err.message` flows
+              // out via the returned ExecutionResult.errorMessage for
+              // operator-side surfaces only.
               error: "An internal error occurred. Check server logs for details.",
             }),
           {
@@ -343,6 +353,6 @@ export async function runPipeline(
       }
     }
 
-    return { success: false };
+    return { success: false, errorMessage: err.message !== "" ? err.message : err.name };
   }
 }

--- a/src/daemon/workflow-executor.ts
+++ b/src/daemon/workflow-executor.ts
@@ -206,7 +206,13 @@ export async function executeWorkflowRun(
           {
             runId: workflowRun.runId,
             patch: {},
-            humanMessage: result.humanMessage ?? `${entry.name} failed: ${result.reason}`,
+            // Defense-in-depth: never default to `result.reason` for the
+            // public comment — handlers may put raw error messages in
+            // `reason` (intended for DB state.failedReason and operator
+            // logs only). Handlers that want a richer comment must set
+            // `humanMessage` explicitly.
+            humanMessage:
+              result.humanMessage ?? `${entry.name} failed — see server logs for details.`,
           },
         );
       } catch (mirrorErr) {
@@ -256,7 +262,12 @@ export async function executeWorkflowRun(
         {
           runId: workflowRun.runId,
           patch: {},
-          humanMessage: `${workflowRun.workflowName} failed: ${reason}`,
+          // Public comment must NOT carry the raw uncaught-throw message.
+          // octokit error stacks include the request URL with the
+          // installation token (`https://x-access-token:GHS_xxx@…`); other
+          // throws may surface file paths or env values. Raw `reason` is
+          // still persisted to DB state.failedReason via markFailed above.
+          humanMessage: `${workflowRun.workflowName} failed — see server logs for details.`,
         },
       );
     } catch (cleanupErr) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,13 @@ export interface BotContext {
 export interface ExecutionResult {
   /** Whether the execution completed successfully */
   success: boolean;
+  /**
+   * Human-readable failure detail when `success` is false. Carries the
+   * underlying SDK / pipeline error (e.g. "Claude Code returned an error
+   * result: You've hit your limit · resets 6pm (UTC)") so callers can
+   * surface actionable text instead of a generic stand-in.
+   */
+  errorMessage?: string;
   /** Total API cost in USD */
   costUsd?: number;
   /** Total execution duration in milliseconds */

--- a/src/webhook/router.ts
+++ b/src/webhook/router.ts
@@ -32,7 +32,12 @@ export interface DispatchDecision {
   reason: DispatchReason;
   triage?: TriageResult;
   triageAttempted?: boolean;
-  /** Set when `reason === "ephemeral-spawn-failed"` — surfaced in the tracking comment. */
+  /**
+   * Set when `reason === "ephemeral-spawn-failed"`. Retained for operator-side
+   * surfaces only (structured logs, executions row) — never interpolated into
+   * public GitHub comments because the underlying error string can embed an
+   * installation token or other Kubernetes API detail.
+   */
   spawnError?: string;
 }
 
@@ -314,10 +319,14 @@ async function recordSpawnFailedRejection(
       owner: ctx.owner,
       repo: ctx.repo,
       issue_number: ctx.entityNumber,
+      // Public comment — do NOT include `decision.spawnError`. The raw
+      // text can carry K8s API URLs, RBAC detail, or other operational
+      // info. The structured spawn error is already on the log line and
+      // in the executions row for operators.
       body:
         `**${config.triggerPhrase}** cannot dispatch this request: scaling up the ephemeral ` +
-        `daemon pool requires Kubernetes infrastructure that is unavailable right now ` +
-        `(${decision.spawnError ?? "unknown error"}). Please re-trigger in a few minutes.`,
+        `daemon pool requires Kubernetes infrastructure that is unavailable right now. ` +
+        `Please re-trigger in a few minutes; if this persists, check server logs.`,
     });
   } catch (commentError) {
     ctx.log.error({ err: commentError }, "Failed to post ephemeral-spawn-failed comment");

--- a/src/workflows/handlers/implement.ts
+++ b/src/workflows/handlers/implement.ts
@@ -106,7 +106,14 @@ export const handler: WorkflowHandler = async (ctx) => {
 
     const result = await runPipeline(botCtx, { captureFiles: ["IMPLEMENT.md"] });
     if (!result.success) {
-      return { status: "failed", reason: "implement pipeline execution failed" };
+      // `reason` is internal (DB state.failedReason → orchestrator quota
+      // detection + operator logs); `humanMessage` is the public tracking
+      // comment text and MUST NOT carry the raw error.
+      return {
+        status: "failed",
+        reason: result.errorMessage ?? "implement pipeline execution failed",
+        humanMessage: "implement pipeline execution failed — see server logs for details.",
+      };
     }
 
     const opened = await findRecentOpenedPr(octokit, target.owner, target.repo, since);
@@ -149,7 +156,11 @@ export const handler: WorkflowHandler = async (ctx) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err }, "implement handler caught error");
-    return { status: "failed", reason: `implement failed: ${message}` };
+    return {
+      status: "failed",
+      reason: `implement failed: ${message}`,
+      humanMessage: "implement pipeline execution failed — see server logs for details.",
+    };
   }
 };
 

--- a/src/workflows/handlers/resolve.ts
+++ b/src/workflows/handlers/resolve.ts
@@ -150,7 +150,14 @@ export const handler: WorkflowHandler = async (ctx) => {
       ...(topLevelComments.length > 0 ? { enableResolveReviewThread: true } : {}),
     });
     if (!result.success) {
-      return { status: "failed", reason: "resolve pipeline execution failed" };
+      // `reason` is internal (DB state.failedReason → orchestrator quota
+      // detection + operator logs); `humanMessage` is the public tracking
+      // comment text and MUST NOT carry the raw error.
+      return {
+        status: "failed",
+        reason: result.errorMessage ?? "resolve pipeline execution failed",
+        humanMessage: "resolve pipeline execution failed — see server logs for details.",
+      };
     }
 
     const report = result.capturedFiles?.["RESOLVE.md"]?.trim() ?? "";
@@ -199,7 +206,11 @@ export const handler: WorkflowHandler = async (ctx) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err }, "resolve handler caught error");
-    return { status: "failed", reason: `resolve failed: ${message}` };
+    return {
+      status: "failed",
+      reason: `resolve failed: ${message}`,
+      humanMessage: "resolve pipeline execution failed — see server logs for details.",
+    };
   }
 };
 

--- a/src/workflows/handlers/review.ts
+++ b/src/workflows/handlers/review.ts
@@ -112,7 +112,15 @@ export const handler: WorkflowHandler = async (ctx) => {
         : {}),
     });
     if (!result.success) {
-      return { status: "failed", reason: "review pipeline execution failed" };
+      // `reason` is internal (DB state.failedReason → orchestrator quota
+      // detection + operator logs); `humanMessage` is the public tracking
+      // comment text and MUST NOT carry the raw error (it can include
+      // installation tokens, file paths, or other credentials).
+      return {
+        status: "failed",
+        reason: result.errorMessage ?? "review pipeline execution failed",
+        humanMessage: "review pipeline execution failed — see server logs for details.",
+      };
     }
 
     const report = result.capturedFiles?.["REVIEW.md"]?.trim() ?? "";
@@ -161,7 +169,11 @@ export const handler: WorkflowHandler = async (ctx) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn({ err }, "review handler caught error");
-    return { status: "failed", reason: `review failed: ${message}` };
+    return {
+      status: "failed",
+      reason: `review failed: ${message}`,
+      humanMessage: "review pipeline execution failed — see server logs for details.",
+    };
   }
 };
 

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -100,7 +100,11 @@ export async function onStepComplete(
         parentRunId: parent.id,
         parentTerminal: {
           status: "failed",
-          humanMessage: `ship halted at step ${String(childStepIndex)} (${parent.workflow_name} → ${child.workflow_name}): ${result.reason ?? "unknown"}`,
+          // Do NOT inline `result.reason` — handlers persist raw error
+          // strings in `reason` for DB+log forensics, and that surface is
+          // public on GitHub. The DB carries the raw reason via the
+          // `failedReason` patch above.
+          humanMessage: `ship halted at step ${String(childStepIndex)} (${parent.workflow_name} → ${child.workflow_name}) — see server logs for details.`,
         },
       };
       return;
@@ -378,6 +382,88 @@ export async function onStepComplete(
  * @param childRunId  ID of the child `workflow_runs` row that just terminated.
  * @param log         Pino logger used by the cascade caller.
  */
+/**
+ * Read `state.failedReason` written by `markFailed` from a workflow_runs
+ * state blob. Returns `undefined` when the row was not marked failed by
+ * `markFailed` (e.g. legacy rows or non-failure states).
+ */
+export function extractFailedReason(state: unknown): string | undefined {
+  if (state === null || typeof state !== "object") return undefined;
+  const candidate = (state as Record<string, unknown>)["failedReason"];
+  return typeof candidate === "string" && candidate !== "" ? candidate : undefined;
+}
+
+/** Conservative fallback when the quota error has no parseable reset clock. */
+const QUOTA_FALLBACK_RETRY_DELAY_MS = 60 * 60 * 1000;
+
+/**
+ * Detect the Anthropic usage-limit error and compute when to retry.
+ *
+ * The Claude Agent SDK throws an Error with a message like
+ * `Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)`.
+ * This is *transient* (it self-heals at the reset boundary) so the ship
+ * loop should defer the next iteration to that timestamp instead of
+ * stalling the intent.
+ *
+ * Returns `null` when the reason is absent or does not match the
+ * usage-limit signature; caller falls back to the existing skip path.
+ */
+function parseResetsClock(
+  reason: string,
+  nowMs: number,
+): { retryAtMs: number; resetPhrase: string } | null {
+  const matches = reason.matchAll(/resets\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\(?\s*UTC\s*\)?/gi);
+  const match = matches.next().value;
+  if (match === undefined) return null;
+  const hourRaw = Number(match[1]);
+  const minute = match[2] !== undefined ? Number(match[2]) : 0;
+  const meridiem = match[3]?.toLowerCase();
+  let hour = hourRaw;
+  if (meridiem === "pm" && hourRaw < 12) hour = hourRaw + 12;
+  else if (meridiem === "am" && hourRaw === 12) hour = 0;
+  if (!Number.isFinite(hour) || hour < 0 || hour >= 24 || minute < 0 || minute >= 60) {
+    return null;
+  }
+  const today = new Date(nowMs);
+  // 30s buffer past the boundary so we don't race the reset.
+  const resetAt = Date.UTC(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getUTCDate(),
+    hour,
+    minute,
+    30,
+  );
+  const retryAtMs = resetAt > nowMs ? resetAt : resetAt + 24 * 60 * 60 * 1000;
+  return { retryAtMs, resetPhrase: match[0] };
+}
+
+export function detectTransientQuotaError(
+  reason: string | undefined,
+  nowMs: number = Date.now(),
+): { retryAtMs: number; resetPhrase: string } | null {
+  if (reason === undefined || reason === "") return null;
+  // Two confirmed Anthropic usage-limit signals — we deliberately do NOT
+  // match a bare "rate limit" / "usage limit" because that pattern also
+  // appears in GitHub secondary-rate-limit responses and other upstream
+  // throttling we should not auto-defer:
+  //   1. The Anthropic-specific phrase "hit your limit" (subscription
+  //      quota copy from the Claude Agent SDK).
+  //   2. A "resets ... UTC" clock — the Anthropic API includes the reset
+  //      boundary inline; treat that as a sufficient confirmation.
+  const hasAnthropicPhrase = /hit your limit/i.test(reason);
+  const hasResetsClock = /\bresets\b/i.test(reason);
+  if (!hasAnthropicPhrase && !hasResetsClock) return null;
+
+  const parsed = parseResetsClock(reason, nowMs);
+  if (parsed !== null) return parsed;
+
+  // No parseable clock. The +1h fallback only fires for the Anthropic-
+  // specific phrase — a bare "resets" without it could be unrelated.
+  if (!hasAnthropicPhrase) return null;
+  return { retryAtMs: nowMs + QUOTA_FALLBACK_RETRY_DELAY_MS, resetPhrase: "fallback_1h" };
+}
+
 async function maybeEarlyWakeShipIntent(childRunId: string, log: pino.Logger): Promise<void> {
   const db = requireDb();
   const rows: { state: Record<string, unknown>; status: string }[] = await db`
@@ -389,11 +475,46 @@ async function maybeEarlyWakeShipIntent(childRunId: string, log: pino.Logger): P
   const intentId = extractShipIntentId(child.state);
   if (intentId === undefined) return;
 
-  // Only succeeded children fire the cascade. A failed child should not
-  // auto-spin the next iteration — the iteration cap would eventually
-  // catch it, but until then the loop burns budget on a permanently
-  // broken intent. Operators can re-arm a stalled intent manually.
+  // Only succeeded children fire the cascade immediately. A failed child
+  // should not auto-spin the next iteration — the iteration cap would
+  // eventually catch it, but until then the loop burns budget on a
+  // permanently broken intent. Operators can re-arm a stalled intent
+  // manually.
+  //
+  // Exception: a *transient* failure (Anthropic usage-limit cap) is
+  // recoverable on its own clock. Defer the tickle to the reset time so
+  // the periodic scanner picks it up automatically when the quota resets.
   if (child.status !== "succeeded") {
+    const failedReason = extractFailedReason(child.state);
+    const transient = detectTransientQuotaError(failedReason);
+    if (transient !== null) {
+      try {
+        const valkey = requireValkeyClient();
+        await valkey.send("ZADD", [TICKLE_KEY, String(transient.retryAtMs), intentId]);
+        log.info(
+          {
+            event: "ship.tickle.deferred_quota",
+            intent_id: intentId,
+            child_run_id: childRunId,
+            child_status: child.status,
+            retry_at_ms: transient.retryAtMs,
+            retry_at_iso: new Date(transient.retryAtMs).toISOString(),
+            reset_phrase: transient.resetPhrase,
+          },
+          "ship-tickle deferred — child hit Anthropic usage limit, will retry after reset",
+        );
+      } catch (zaddErr) {
+        log.warn(
+          {
+            err: zaddErr instanceof Error ? zaddErr.message : String(zaddErr),
+            intent_id: intentId,
+            child_run_id: childRunId,
+          },
+          "ship-tickle deferred-ZADD failed (non-fatal — periodic scan will catch up)",
+        );
+      }
+      return;
+    }
     log.info(
       {
         event: "ship.tickle.skip_failed_child",

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -415,6 +415,11 @@ function parseResetsClock(
   const matches = reason.matchAll(/resets\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\(?\s*UTC\s*\)?/gi);
   const match = matches.next().value;
   if (match === undefined) return null;
+  // Reject ambiguous bare-hour formats like "resets 6 UTC" (no am/pm and
+  // no minute). Treating them as 06:00 risks the next-day rollover at
+  // line 437 pushing the wake out by ~24h when now is past the hour —
+  // strictly worse than the caller's +1h fallback for unparseable clocks.
+  if (match[2] === undefined && match[3] === undefined) return null;
   const hourRaw = Number(match[1]);
   const minute = match[2] !== undefined ? Number(match[2]) : 0;
   const meridiem = match[3]?.toLowerCase();

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -480,6 +480,40 @@ async function maybeEarlyWakeShipIntent(childRunId: string, log: pino.Logger): P
   const intentId = extractShipIntentId(child.state);
   if (intentId === undefined) return;
 
+  // Resolve intent state up-front: the same terminal-state guard must
+  // gate both the immediate cascade and the deferred-quota retry. A
+  // late failed child can otherwise re-arm an already terminal intent
+  // (`aborted_by_user`, `merged_externally`, …) via the deferred ZADD
+  // and reprocess a session that should stay dead.
+  let intent: Awaited<ReturnType<typeof getIntentById>>;
+  try {
+    intent = await getIntentById(intentId);
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        intent_id: intentId,
+        child_run_id: childRunId,
+      },
+      "ship-tickle early-wake skipped — intent lookup failed (non-fatal — periodic scan will catch up)",
+    );
+    return;
+  }
+  if (intent === null) {
+    log.warn(
+      { event: "ship.tickle.skip_terminal", intent_id: intentId, reason: "intent_not_found" },
+      "ship-tickle early-wake skipped — intent not found",
+    );
+    return;
+  }
+  if (isSessionTerminalState(intent.status)) {
+    log.info(
+      { event: "ship.tickle.skip_terminal", intent_id: intentId, status: intent.status },
+      "ship-tickle early-wake skipped — intent already terminal",
+    );
+    return;
+  }
+
   // Only succeeded children fire the cascade immediately. A failed child
   // should not auto-spin the next iteration — the iteration cap would
   // eventually catch it, but until then the loop burns budget on a
@@ -533,25 +567,6 @@ async function maybeEarlyWakeShipIntent(childRunId: string, log: pino.Logger): P
   }
 
   try {
-    const intent = await getIntentById(intentId);
-    if (intent === null) {
-      log.warn(
-        { event: "ship.tickle.skip_terminal", intent_id: intentId, reason: "intent_not_found" },
-        "ship-tickle early-wake skipped — intent not found",
-      );
-      return;
-    }
-    if (isSessionTerminalState(intent.status)) {
-      log.info(
-        {
-          event: "ship.tickle.skip_terminal",
-          intent_id: intentId,
-          status: intent.status,
-        },
-        "ship-tickle early-wake skipped — intent already terminal",
-      );
-      return;
-    }
     const valkey = requireValkeyClient();
     await valkey.send("ZADD", [TICKLE_KEY, "0", intentId]);
     log.info(

--- a/src/workflows/ship/scoped/open-pr.ts
+++ b/src/workflows/ship/scoped/open-pr.ts
@@ -209,11 +209,16 @@ export async function runOpenPrPolicy(
     });
   } catch (err) {
     const error_message = err instanceof Error ? err.message : String(err);
+    // Do NOT inline `error_message` in the public comment — LLM client
+    // errors can carry the raw upstream response (request URLs with
+    // bearer tokens, prompt fragments). The structured `error_message`
+    // is still surfaced via the return value for operator dashboards
+    // and the warn log line below carries the full `err`.
     const reply = await input.octokit.rest.issues.createComment({
       owner: input.owner,
       repo: input.repo,
       issue_number: input.issue_number,
-      body: `I couldn't classify this issue (\`${error_message}\`). No PR opened.`,
+      body: `I couldn't classify this issue. No PR opened — see server logs for details.`,
     });
     log.warn({ err, comment_id: reply.data.id }, "open_pr classifier failed");
     return { kind: "classifier-failed", comment_id: reply.data.id, error_message };
@@ -266,11 +271,16 @@ export async function runOpenPr(input: RunOpenPrInput): Promise<OpenPrOutcome> {
     // same shape as the classifier-failed path so downstream handlers
     // (logs, dashboards) treat them uniformly.
     const error_message = err instanceof Error ? err.message : String(err);
+    // Do NOT inline `error_message` in the public comment — octokit
+    // error stacks include the request URL with the installation
+    // token (`https://x-access-token:GHS_xxx@…`). The structured
+    // `error_message` still flows out via the return value for operator
+    // surfaces; the full `err` is logged below.
     const reply = await input.octokit.rest.issues.createComment({
       owner: input.owner,
       repo: input.repo,
       issue_number: input.issue_number,
-      body: `I classified this issue as actionable but couldn't create the draft PR (\`${error_message}\`). No PR opened.`,
+      body: `I classified this issue as actionable but couldn't create the draft PR — see server logs for details.`,
     });
     log.warn({ err, comment_id: reply.data.id }, "open_pr branch/PR creation failed");
     return { kind: "classifier-failed", comment_id: reply.data.id, error_message };

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -126,6 +126,12 @@ describe("executeAgent — cancellation", () => {
     expect(result.success).toBe(false);
     expect(observedReason).toBeInstanceOf(Error);
     expect((observedReason as Error).message).toContain("timed out after 25ms");
+    // Downstream handlers (workflow-executor → markFailed) read
+    // result.errorMessage to populate state.failedReason on the
+    // workflow_runs row. Asserting it explicitly here so the
+    // operator-visibility contract from PR #90 cannot regress to
+    // success: false with no message.
+    expect(result.errorMessage).toMatch(/^Agent execution timed out after \d+ms$/);
   });
 
   it("clears the wall-clock timer on the happy path", async () => {
@@ -168,6 +174,7 @@ describe("executeAgent — cancellation", () => {
 
     expect(result.success).toBe(false);
     expect(lastQueryCall?.options.abortController?.signal.aborted).toBe(true);
+    expect(result.errorMessage).toBe("cancelled by orchestrator");
   });
 
   it("propagates a caller signal aborted mid-execution", async () => {
@@ -186,5 +193,6 @@ describe("executeAgent — cancellation", () => {
 
     expect(result.success).toBe(false);
     expect(lastQueryCall?.options.abortController?.signal.aborted).toBe(true);
+    expect(result.errorMessage).toBe("daemon cancel");
   });
 });

--- a/test/webhook/router.test.ts
+++ b/test/webhook/router.test.ts
@@ -387,7 +387,11 @@ describe("dispatch", () => {
     expect(createComment).toHaveBeenCalledTimes(1);
     const body = (createComment.mock.calls[0] as [{ body: string }])[0].body;
     expect(body).toContain("Kubernetes infrastructure");
-    expect(body).toContain("api-unavailable: boom");
+    // Must NOT inline the raw spawnError into the public comment — k8s
+    // exception strings can carry API URLs, RBAC detail, or other
+    // operational info. The structured spawnError remains on the log
+    // line and in the executions row.
+    expect(body).not.toContain("api-unavailable: boom");
   });
 
   it("enqueues to daemon when no claimable daemon is ready", async () => {

--- a/test/workflows/orchestrator.test.ts
+++ b/test/workflows/orchestrator.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { SQL } from "bun";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import type pino from "pino";
 
 const TEST_DATABASE_URL =
@@ -688,52 +688,64 @@ describe.skipIf(sql === null)("orchestrator.onStepComplete", () => {
     const { onStepComplete } = await import("../../src/workflows/orchestrator");
     const { insertIntent } = await import("../../src/db/queries/ship");
 
-    const intent = await insertIntent(
-      {
-        installation_id: 103,
-        owner: "acme",
-        repo: "quota-defer-repo",
-        pr_number: 9400,
-        target_base_sha: "base",
-        target_head_sha: "head",
-        deadline_at: new Date(Date.now() + 60 * 60 * 1000),
-        created_by_user: "tester",
-        tracking_comment_marker: "<!-- ship-intent: pending -->",
-      },
-      requireSql(),
-    );
+    // Freeze the clock at 2026-05-02 10:00:00 UTC so the parsed
+    // "resets 6pm (UTC)" boundary lands at a known instant
+    // (2026-05-02 18:00:30 UTC). Asserting the exact score guards
+    // against silent regression to the +1h fallback or any other
+    // future-but-wrong timestamp.
+    const frozenNowMs = Date.UTC(2026, 4, 2, 10, 0, 0);
+    const expectedRetryAtMs = Date.UTC(2026, 4, 2, 18, 0, 30);
+    const dateNowSpy = spyOn(Date, "now").mockReturnValue(frozenNowMs);
+    try {
+      const intent = await insertIntent(
+        {
+          installation_id: 103,
+          owner: "acme",
+          repo: "quota-defer-repo",
+          pr_number: 9400,
+          target_base_sha: "base",
+          target_head_sha: "head",
+          deadline_at: new Date(frozenNowMs + 60 * 60 * 1000),
+          created_by_user: "tester",
+          tracking_comment_marker: "<!-- ship-intent: pending -->",
+        },
+        requireSql(),
+      );
 
-    const run = await insertQueued(
-      {
-        workflowName: "implement",
-        target: { type: "pr", owner: "acme", repo: "quota-defer-repo", number: 9400 },
-        ownerKind: "orchestrator",
-        ownerId: "test-orchestrator",
-      },
-      requireSql(),
-    );
-    const quotaReason =
-      "Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)";
-    await markFailed(run.id, quotaReason, { shipIntentId: intent.id }, requireSql());
+      const run = await insertQueued(
+        {
+          workflowName: "implement",
+          target: { type: "pr", owner: "acme", repo: "quota-defer-repo", number: 9400 },
+          ownerKind: "orchestrator",
+          ownerId: "test-orchestrator",
+        },
+        requireSql(),
+      );
+      const quotaReason =
+        "Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)";
+      await markFailed(run.id, quotaReason, { shipIntentId: intent.id }, requireSql());
 
-    mockValkeySend.mockClear();
-    await onStepComplete({ octokit: {} as never, logger: silentLogger() }, run.id, {
-      status: "failed",
-      reason: quotaReason,
-    });
+      mockValkeySend.mockClear();
+      await onStepComplete({ octokit: {} as never, logger: silentLogger() }, run.id, {
+        status: "failed",
+        reason: quotaReason,
+      });
 
-    const zaddCalls = mockValkeySend.mock.calls.filter(
-      (c) => c[0] === "ZADD" && Array.isArray(c[1]) && c[1][0] === "ship:tickle",
-    );
-    expect(zaddCalls).toHaveLength(1);
-    const args = zaddCalls[0]?.[1] as [string, string, string];
-    expect(args[0]).toBe("ship:tickle");
-    expect(args[2]).toBe(intent.id);
-    // Score is a future-ms timestamp at the next 18:00:30 UTC boundary,
-    // not 0 (which is the immediate-cascade score).
-    const score = Number(args[1]);
-    expect(Number.isFinite(score)).toBe(true);
-    expect(score).toBeGreaterThan(Date.now());
+      const zaddCalls = mockValkeySend.mock.calls.filter(
+        (c) => c[0] === "ZADD" && Array.isArray(c[1]) && c[1][0] === "ship:tickle",
+      );
+      expect(zaddCalls).toHaveLength(1);
+      const args = zaddCalls[0]?.[1] as [string, string, string];
+      expect(args[0]).toBe("ship:tickle");
+      expect(args[2]).toBe(intent.id);
+      // Exact assertion: the parsed reset path must produce
+      // 2026-05-02T18:00:30Z (== expectedRetryAtMs). A regression to the
+      // +1h fallback (frozenNowMs + 3600_000) or any other future-ish
+      // value would silently pass an "in the future" check.
+      expect(Number(args[1])).toBe(expectedRetryAtMs);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 });
 

--- a/test/workflows/orchestrator.test.ts
+++ b/test/workflows/orchestrator.test.ts
@@ -677,4 +677,134 @@ describe.skipIf(sql === null)("orchestrator.onStepComplete", () => {
     );
     expect(zaddCalls).toHaveLength(0);
   });
+
+  // H2: a failed child whose state.failedReason matches the Anthropic
+  // usage-limit signature must defer the next ship iteration to the
+  // parsed reset boundary instead of stalling the intent. Guards the
+  // wiring between extractFailedReason → detectTransientQuotaError →
+  // ZADD with a future score.
+  it("ZADDs ship:tickle at the parsed reset time when child failed with a quota error (H2)", async () => {
+    const { insertQueued, markFailed } = await import("../../src/workflows/runs-store");
+    const { onStepComplete } = await import("../../src/workflows/orchestrator");
+    const { insertIntent } = await import("../../src/db/queries/ship");
+
+    const intent = await insertIntent(
+      {
+        installation_id: 103,
+        owner: "acme",
+        repo: "quota-defer-repo",
+        pr_number: 9400,
+        target_base_sha: "base",
+        target_head_sha: "head",
+        deadline_at: new Date(Date.now() + 60 * 60 * 1000),
+        created_by_user: "tester",
+        tracking_comment_marker: "<!-- ship-intent: pending -->",
+      },
+      requireSql(),
+    );
+
+    const run = await insertQueued(
+      {
+        workflowName: "implement",
+        target: { type: "pr", owner: "acme", repo: "quota-defer-repo", number: 9400 },
+        ownerKind: "orchestrator",
+        ownerId: "test-orchestrator",
+      },
+      requireSql(),
+    );
+    const quotaReason =
+      "Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)";
+    await markFailed(run.id, quotaReason, { shipIntentId: intent.id }, requireSql());
+
+    mockValkeySend.mockClear();
+    await onStepComplete({ octokit: {} as never, logger: silentLogger() }, run.id, {
+      status: "failed",
+      reason: quotaReason,
+    });
+
+    const zaddCalls = mockValkeySend.mock.calls.filter(
+      (c) => c[0] === "ZADD" && Array.isArray(c[1]) && c[1][0] === "ship:tickle",
+    );
+    expect(zaddCalls).toHaveLength(1);
+    const args = zaddCalls[0]?.[1] as [string, string, string];
+    expect(args[0]).toBe("ship:tickle");
+    expect(args[2]).toBe(intent.id);
+    // Score is a future-ms timestamp at the next 18:00:30 UTC boundary,
+    // not 0 (which is the immediate-cascade score).
+    const score = Number(args[1]);
+    expect(Number.isFinite(score)).toBe(true);
+    expect(score).toBeGreaterThan(Date.now());
+  });
+});
+
+describe("orchestrator helpers (pure)", () => {
+  it("extractFailedReason reads state.failedReason set by markFailed", async () => {
+    const { extractFailedReason } = await import("../../src/workflows/orchestrator");
+    expect(extractFailedReason({ failedReason: "implement crashed" })).toBe("implement crashed");
+    expect(extractFailedReason({ failedReason: "" })).toBeUndefined();
+    expect(extractFailedReason({ other: "x" })).toBeUndefined();
+    expect(extractFailedReason(null)).toBeUndefined();
+    expect(extractFailedReason(undefined)).toBeUndefined();
+    expect(extractFailedReason("not an object")).toBeUndefined();
+  });
+
+  it("detectTransientQuotaError returns null when reason is absent or unrelated", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    expect(detectTransientQuotaError(undefined)).toBeNull();
+    expect(detectTransientQuotaError("")).toBeNull();
+    expect(detectTransientQuotaError("git clone failed: timeout")).toBeNull();
+    expect(detectTransientQuotaError("review pipeline execution failed")).toBeNull();
+  });
+
+  // Regression guard for the tightened signature: a bare "rate limit"
+  // or "usage limit" phrase without "hit your limit" AND without a
+  // "resets ... UTC" clock must NOT auto-defer — it could be a GitHub
+  // secondary rate limit or unrelated upstream throttling. Auto-deferring
+  // those would burn the iteration cap re-firing on a non-recoverable
+  // failure.
+  it("detectTransientQuotaError returns null for bare 'rate limit'/'usage limit' without resets clock", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    expect(detectTransientQuotaError("github secondary rate limit exceeded")).toBeNull();
+    expect(detectTransientQuotaError("API usage limit reached for this hour")).toBeNull();
+    expect(detectTransientQuotaError("upstream returned 429 rate-limit response")).toBeNull();
+  });
+
+  it("detectTransientQuotaError parses 'resets 6pm (UTC)' to today 18:00:30 UTC when in future", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    // 2026-05-02T05:00:00Z → reset is later today at 18:00:30 UTC.
+    const nowMs = Date.UTC(2026, 4, 2, 5, 0, 0);
+    const result = detectTransientQuotaError(
+      "Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)",
+      nowMs,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.retryAtMs).toBe(Date.UTC(2026, 4, 2, 18, 0, 30));
+    expect(result!.resetPhrase).toMatch(/resets/i);
+  });
+
+  it("detectTransientQuotaError rolls reset to next day when boundary already passed", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    // 2026-05-02T20:00:00Z is past 18:00 UTC — next reset is tomorrow.
+    const nowMs = Date.UTC(2026, 4, 2, 20, 0, 0);
+    const result = detectTransientQuotaError("You've hit your limit · resets 6pm UTC", nowMs);
+    expect(result).not.toBeNull();
+    expect(result!.retryAtMs).toBe(Date.UTC(2026, 4, 3, 18, 0, 30));
+  });
+
+  it("detectTransientQuotaError parses 24h '18:30 UTC' form", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    const nowMs = Date.UTC(2026, 4, 2, 5, 0, 0);
+    const result = detectTransientQuotaError("usage limit hit · resets 18:30 UTC", nowMs);
+    expect(result).not.toBeNull();
+    expect(result!.retryAtMs).toBe(Date.UTC(2026, 4, 2, 18, 30, 30));
+  });
+
+  it("detectTransientQuotaError falls back to +1h when reset clock is unparseable", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    const nowMs = Date.UTC(2026, 4, 2, 5, 0, 0);
+    const result = detectTransientQuotaError("You've hit your limit (no time mentioned)", nowMs);
+    expect(result).not.toBeNull();
+    expect(result!.retryAtMs).toBe(nowMs + 60 * 60 * 1000);
+    expect(result!.resetPhrase).toBe("fallback_1h");
+  });
 });

--- a/test/workflows/orchestrator.test.ts
+++ b/test/workflows/orchestrator.test.ts
@@ -807,4 +807,17 @@ describe("orchestrator helpers (pure)", () => {
     expect(result!.retryAtMs).toBe(nowMs + 60 * 60 * 1000);
     expect(result!.resetPhrase).toBe("fallback_1h");
   });
+
+  it("detectTransientQuotaError treats ambiguous 'resets 6 UTC' (no am/pm, no minute) as fallback, not 06:00", async () => {
+    const { detectTransientQuotaError } = await import("../../src/workflows/orchestrator");
+    // now = 14:00 UTC, "resets 6 UTC" without meridiem/minute is ambiguous.
+    // Without the guard, parseResetsClock would interpret it as 06:00, see
+    // it has already passed, and roll +24h → wake at next-day 06:00:30.
+    // With the guard it falls through to the +1h fallback (15:00 UTC).
+    const nowMs = Date.UTC(2026, 4, 2, 14, 0, 0);
+    const result = detectTransientQuotaError("You've hit your limit · resets 6 UTC", nowMs);
+    expect(result).not.toBeNull();
+    expect(result!.retryAtMs).toBe(nowMs + 60 * 60 * 1000);
+    expect(result!.resetPhrase).toBe("fallback_1h");
+  });
 });


### PR DESCRIPTION
## Summary

The bot's tracking comments and bot-authored PR/issue comments were inlining raw error strings (e.g. `Claude Code returned an error result: You've hit your limit · resets 6pm (UTC)`, octokit error stacks, K8s spawn exceptions) into bodies that GitHub renders publicly. Octokit error messages embed the request URL with the installation token (`https://x-access-token:GHS_xxx@api.github.com/...`), so this surface was a token-leak vector.

This PR sanitizes every public-comment write path while still surfacing the raw error to operator-only channels (logs, DB `state.failedReason`, internal WS payloads), and wires the orchestrator to auto-defer the ship iteration to the quota reset time when the SDK returns a transient usage-limit error (instead of stalling the intent until an operator re-arms it).

## Diagram

```mermaid
flowchart TD
    classDef public fill:#fde2e1,stroke:#c40000,color:#000
    classDef internal fill:#dcefdc,stroke:#1b5e20,color:#000
    classDef bad fill:#ffd6d6,stroke:#a40000,color:#000

    SDK["Agent SDK throws<br/>You've hit your limit · resets 6pm UTC"]:::internal

    SDK --> Before["BEFORE — leaks raw error"]:::bad
    Before --> BeforeOps["operator log"]:::internal
    Before --> BeforePub["public PR comment<br/>review failed: review pipeline execution failed"]:::public

    SDK --> After["AFTER — split surfaces"]:::internal
    After --> AfterOps["state.failedReason DB column<br/>+ pino log<br/>+ ExecutionResult.errorMessage"]:::internal
    After --> AfterPub["public PR comment<br/>review pipeline execution failed — see server logs for details."]:::public
    AfterOps --> Tickle["orchestrator parses reset clock<br/>ZADD ship:tickle score=resetMs<br/>iteration auto-resumes at boundary"]:::internal
```

## Changes

**Visibility — surface SDK errors to operator-only channels**

- `src/types.ts` — `ExecutionResult` carries `errorMessage?: string`.
- `src/core/executor.ts` — both throw-path catch and non-throw SDK terminal subtypes (`error_max_turns`, `error_max_budget_usd`, etc.) populate `errorMessage`.
- `src/core/pipeline.ts` outer-catch returns `errorMessage`; the public tracking-comment finalize keeps the existing safe constant.
- `src/workflows/handlers/{review,implement,resolve}.ts` — propagate `result.errorMessage` into the failure `reason` (DB `state.failedReason`) but explicitly set a safe `humanMessage` so the public comment never carries the raw text.

**Security — redact raw errors from every public sink**

- `src/daemon/workflow-executor.ts` — failure-branch fallback `humanMessage` no longer interpolates `result.reason`; uncaught-throw branch no longer interpolates `err.message` (the highest-stakes leak — uncaught octokit errors carry the installation token in the URL).
- `src/workflows/orchestrator.ts` — failed-child cascade `humanMessage` no longer interpolates `result.reason`.
- `src/webhook/router.ts` — ephemeral-spawn rejection comment no longer interpolates `decision.spawnError` (raw K8s API errors).
- `src/workflows/ship/scoped/open-pr.ts` — both classifier-failure and PR-create-failure replies drop the inlined `error_message`.

In every case the raw text is preserved in operator surfaces (pino logs, `workflow_runs.state.failedReason`, `executions.error_message`, internal WS payloads, scoped-job-completion handler logs).

**Auto-recover on transient quota error**

- `src/workflows/orchestrator.ts` — adds two pure helpers:
  - `extractFailedReason(state)` — reads `state.failedReason` written by `markFailed`.
  - `detectTransientQuotaError(reason, nowMs)` — matches the Anthropic usage-limit signature and parses `resets <time> UTC`. Falls back to `+1h` when the clock cannot be parsed.
- `maybeEarlyWakeShipIntent` — when a child failed with a transient quota signature, ZADDs `ship:tickle` with score = unix-ms of the reset boundary (instead of the existing skip-failed-child path). The periodic tickle scanner re-fires the intent once the quota resets.

**Tests**

- `test/workflows/orchestrator.test.ts` — 6 new pure-function tests for `extractFailedReason` + `detectTransientQuotaError` (parses `6pm (UTC)` and `18:30 UTC` forms, rolls past-boundary to next day, falls back to `+1h`, ignores unrelated reasons, ignores empty/undefined).
- `test/webhook/router.test.ts` — flipped the assertion from `body.toContain("api-unavailable: boom")` (which was pinning the leak) to `body.not.toContain(...)` so the test now validates the security property.

## Related Issues

- None — discovered during real e2e run on issue #51 / PR #89.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 0 errors (270 pre-existing warnings on unrelated files unchanged)
- [x] \`bun run format:fix\` clean
- [x] All touched-surface tests pass in isolation: \`test/core/\`, \`test/workflows/handlers/\`, \`test/workflows/orchestrator.test.ts\`, \`test/webhook/router.test.ts\`, \`test/workflows/ship/scoped/open-pr.test.ts\`, \`test/daemon/scoped-*-executor.test.ts\`
- [x] Updated \`test/webhook/router.test.ts\` asserts the public comment does NOT contain the raw \`spawnError\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public comments and tracking messages now hide raw internal error text and show safe, generic guidance.
  * Child-workflow quota/usage-limit failures are detected as transient and automatically defer retries until quota resets.

* **Documentation**
  * Added failure-handling guidance clarifying public vs operator error reporting and retry semantics.

* **Chores**
  * CI now cleans stale dev pre-release tags before running releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->