### PR TITLE
fix(workflow): fix release.yml

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -35,6 +35,7 @@ permissions:
   contents: write # semantic-release: push git tag (no GitHub release in dev)
   security-events: write
   id-token: write
+  attestations: write # Required by the nested 'merge' job
 
 jobs:
   ci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: write # semantic-release: tags, release commit, GitHub release
+  attestations: write # Required by the nested 'merge' job
   security-events: write
   id-token: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ concurrency:
 
 permissions:
   contents: write # semantic-release: tags, release commit, GitHub release
-  attestations: write # Required by the nested 'merge' job
   security-events: write
   id-token: write
+  attestations: write # Required by the nested 'merge' job
 
 jobs:
   ci:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- cspell:ignore WCAG -->
<!--
Thanks for your contribution!
Please follow the structure below; sections are explicit so reviewers can
skim quickly and the bot's review handler can ground its findings in the
intent stated here.
-->

## Summary

<!-- Brief description of what this PR does and why. One paragraph. -->

The `release.yml` workflow was failing at startup with a GitHub Actions validation error. The reusable `docker-build.yml` workflow requests `attestations: read` at the workflow level and `attestations: write` in the `merge` job, but the calling `docker` job in `release.yml` had no `attestations` permission declared — defaulting it to `none`. GitHub blocks any nested workflow from elevating permissions beyond what the caller grants.


```
[Invalid workflow file: .github/workflows/release.yml#L109](https://github.com/chrisleekr/github-app-playground/actions/runs/25274688103/workflow)
The workflow is not valid. .github/workflows/release.yml (Line: 109, Col: 3): Error calling workflow 'chrisleekr/github-app-playground/.github/workflows/docker-build.yml@3b6036cffa5b73aefcd8fb0b788bb526ac401df3'. The workflow is requesting 'attestations: read', but is only allowed 'attestations: none'. .github/workflows/release.yml (Line: 109, Col: 3): Error calling workflow 'chrisleekr/github-app-playground/.github/workflows/docker-build.yml@3b6036cffa5b73aefcd8fb0b788bb526ac401df3'. The nested job 'merge' is requesting 'attestations: write', but is only allowed 'attestations: none'.
```

### Why

GitHub Actions enforces that `GITHUB_TOKEN` permissions can only be maintained or reduced through a reusable workflow chain — never elevated. Granting `attestations: write` at the caller level satisfies both the `read` and `write` scopes required by the nested `docker-build.yml` jobs.

## Diagram

<!--
Optional. Add a single mermaid block with before / after when the flow or
behaviour changes. Skip for trivial PRs (one-line fixes, docs, formatting).

GitHub mermaid rules to follow:
- classDef pairs must meet WCAG 2 AA (≥ 4.5:1 contrast).
- Use `<br/>` for newlines, not `\n`.
- No parentheses inside node labels — they break the parser.
- Use inline `:::className` (e.g. `Node["label"]:::keep`); the separate
  `class Node className` form is rejected by GitHub's renderer.
- Single `subgraph` only — a second `subgraph` after `end` fails to render.
- Node IDs must be 3+ chars to avoid clashing with mermaid keywords.
-->

## Changes

<!-- - List each significant change. Group related changes together. -->


- Add `attestations: write` to the top-level `permissions` block in `.github/workflows/release.yml`
- Add `attestations: write` to the top-level `permissions` block in `.github/workflows/dev-release.yml`


## Related Issues

- Closes #(issue number)

## Test plan

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] All existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enhance the release process infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->