### PR TITLE
fix(executor): capture Claude CLI stderr via SDK callback

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -239,13 +239,20 @@ export async function executeAgent({
     abortController: controller,
     // Without this, a non-zero CLI exit surfaces only as
     // `Error("Claude Code process exited with code N")` with no detail. The
-    // SDK pipes the CLI's stderr here line-by-line; trim and log so the real
-    // failure reason (auth, rate-limit, model rejection, etc.) lands in pino.
+    // SDK pipes the CLI's stderr here line-by-line; log so the real failure
+    // reason (auth, rate-limit, model rejection, etc.) lands in pino.
+    // trimEnd preserves leading indentation in multi-line stack traces; the
+    // 500-char cap matches the convention in src/daemon/updater.ts and
+    // scoped-rebase-executor.ts so an unexpectedly large chunk can't blow
+    // up log ingestion.
     stderr: (chunk: string) => {
-      const trimmed = chunk.trim();
-      if (trimmed !== "") {
-        log.warn({ stderr: trimmed }, "Claude CLI stderr");
-      }
+      const tail = chunk.trimEnd();
+      if (tail === "") return;
+      const truncated = tail.length > 500;
+      log.warn(
+        { stderr: tail.slice(0, 500), ...(truncated ? { truncated: true } : {}) },
+        "Claude CLI stderr",
+      );
     },
   };
   const resolvedMaxTurns = maxTurns ?? config.agentMaxTurns;

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -237,6 +237,16 @@ export async function executeAgent({
     systemPrompt: { type: "preset", preset: "claude_code" },
     env: buildProviderEnv(installationToken, artifactsDir),
     abortController: controller,
+    // Without this, a non-zero CLI exit surfaces only as
+    // `Error("Claude Code process exited with code N")` with no detail. The
+    // SDK pipes the CLI's stderr here line-by-line; trim and log so the real
+    // failure reason (auth, rate-limit, model rejection, etc.) lands in pino.
+    stderr: (chunk: string) => {
+      const trimmed = chunk.trim();
+      if (trimmed !== "") {
+        log.warn({ stderr: trimmed }, "Claude CLI stderr");
+      }
+    },
   };
   const resolvedMaxTurns = maxTurns ?? config.agentMaxTurns;
   if (resolvedMaxTurns !== undefined) {

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -2,6 +2,7 @@ import { query, type SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import { config } from "../config";
 import type { BotContext, ExecutionResult, McpServerConfig } from "../types";
+import { redactSecrets } from "../utils/sanitize";
 
 function isResultMessage(msg: unknown): msg is SDKResultMessage {
   return (
@@ -239,18 +240,29 @@ export async function executeAgent({
     abortController: controller,
     // Without this, a non-zero CLI exit surfaces only as
     // `Error("Claude Code process exited with code N")` with no detail. The
-    // SDK pipes the CLI's stderr here line-by-line; log so the real failure
-    // reason (auth, rate-limit, model rejection, etc.) lands in pino.
-    // trimEnd preserves leading indentation in multi-line stack traces; the
+    // SDK forwards CLI stderr here in stream chunks (not necessarily one
+    // line per call); log so the real failure reason (auth, rate-limit,
+    // model rejection, etc.) lands in pino. Pipe through redactSecrets
+    // first because CLI errors can echo bearer tokens / connection URLs
+    // that buildProviderEnv works hard to keep out of the subprocess —
+    // we don't want to undo that by leaking them into pod logs. trimEnd
+    // preserves leading indentation in multi-line stack traces; the
     // 500-char cap matches the convention in src/daemon/updater.ts and
     // scoped-rebase-executor.ts so an unexpectedly large chunk can't blow
     // up log ingestion.
     stderr: (chunk: string) => {
-      const tail = chunk.trimEnd();
+      const redacted = redactSecrets(chunk);
+      const tail = redacted.body.trimEnd();
       if (tail === "") return;
       const truncated = tail.length > 500;
       log.warn(
-        { stderr: tail.slice(0, 500), ...(truncated ? { truncated: true } : {}) },
+        {
+          stderr: tail.slice(0, 500),
+          ...(truncated ? { truncated: true } : {}),
+          ...(redacted.matchCount > 0
+            ? { redactedSecretCount: redacted.matchCount, redactedSecretKinds: redacted.kinds }
+            : {}),
+        },
         "Claude CLI stderr",
       );
     },

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -18,7 +18,10 @@ import type { McpServerConfig } from "../../src/types";
 import { makeBotContext } from "../factories";
 
 interface QueryCall {
-  options: { abortController?: AbortController };
+  options: {
+    abortController?: AbortController;
+    stderr?: (chunk: string) => void;
+  };
 }
 
 let lastQueryCall: QueryCall | undefined;
@@ -42,10 +45,15 @@ function emptyIterator(): AsyncIterableIterator<unknown> {
 let nextIterator: IteratorFactory = emptyIterator;
 
 void mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: mock((opts: { prompt: string; options: { abortController?: AbortController } }) => {
-    lastQueryCall = { options: opts.options };
-    return nextIterator();
-  }),
+  query: mock(
+    (opts: {
+      prompt: string;
+      options: { abortController?: AbortController; stderr?: (chunk: string) => void };
+    }) => {
+      lastQueryCall = { options: opts.options };
+      return nextIterator();
+    },
+  ),
 }));
 
 const { executeAgent } = await import("../../src/core/executor");
@@ -194,5 +202,65 @@ describe("executeAgent — cancellation", () => {
     expect(result.success).toBe(false);
     expect(lastQueryCall?.options.abortController?.signal.aborted).toBe(true);
     expect(result.errorMessage).toBe("daemon cancel");
+  });
+});
+
+describe("executeAgent — stderr callback", () => {
+  beforeEach(() => {
+    lastQueryCall = undefined;
+    nextIterator = emptyIterator;
+  });
+
+  it("forwards a stderr callback into the SDK query options", async () => {
+    await executeAgent(baseParams());
+
+    expect(lastQueryCall?.options.stderr).toBeTypeOf("function");
+  });
+
+  it("logs non-empty stderr chunks at warn level on the request logger", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    lastQueryCall?.options.stderr?.("oauth token expired\n");
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(logWarn.mock.calls[0]).toEqual([{ stderr: "oauth token expired" }, "Claude CLI stderr"]);
+  });
+
+  it("preserves leading indentation so multi-line stack traces stay readable", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    lastQueryCall?.options.stderr?.("Error: boom\n    at foo (file.ts:1:1)\n");
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn.mock.calls[0]?.[0]).toEqual({
+      stderr: "Error: boom\n    at foo (file.ts:1:1)",
+    });
+  });
+
+  it("skips whitespace-only chunks to avoid log spam", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    lastQueryCall?.options.stderr?.("\n");
+    lastQueryCall?.options.stderr?.("   \t\n");
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("caps stderr at 500 chars and flags truncation", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    const oversized = "x".repeat(600);
+    lastQueryCall?.options.stderr?.(oversized);
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const [fields] = logWarn.mock.calls[0] ?? [];
+    expect(fields).toEqual({ stderr: "x".repeat(500), truncated: true });
   });
 });

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -263,4 +263,32 @@ describe("executeAgent — stderr callback", () => {
     const [fields] = logWarn.mock.calls[0] ?? [];
     expect(fields).toEqual({ stderr: "x".repeat(500), truncated: true });
   });
+
+  it("redacts secrets from stderr before logging and surfaces the kind", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    const oauth = `sk-ant-oat01-${"A".repeat(80)}`;
+    lastQueryCall?.options.stderr?.(`auth failed: token=${oauth} expired`);
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const [fields] = logWarn.mock.calls[0] ?? [];
+    expect(fields).toEqual({
+      stderr: "auth failed: token= expired",
+      redactedSecretCount: 1,
+      redactedSecretKinds: ["ANTHROPIC_OAUTH"],
+    });
+  });
+
+  it("skips chunks that become empty after secret redaction", async () => {
+    const params = baseParams();
+    await executeAgent(params);
+
+    const oauthOnly = `sk-ant-oat01-${"A".repeat(80)}\n`;
+    lastQueryCall?.options.stderr?.(oauthOnly);
+
+    const logWarn = params.ctx.log.warn as ReturnType<typeof mock>;
+    expect(logWarn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

When the bundled Claude Code CLI subprocess exits non-zero, the Agent SDK throws a content-free `Error("Claude Code process exited with code N")` and the daemon logs only that wrapper — the CLI's actual stderr (auth failure, 429 rate-limit, model rejection, OOM, missing binary, etc.) is never surfaced. Today's pod failure (`github-app-playground-daemon-default-5b89f6dc4-twmdk` on issue #93, `durationMs: 248ms`) was diagnosable only by `kubectl exec` into the pod and reproducing the call by hand. The SDK already exposes a `stderr: (data: string) => void` callback hook in `query()` options — we just weren't wiring it.

This change subscribes the daemon's request-scoped pino logger to that callback. No new deps, no env-var changes, no API surface changes.

## Diagram

```mermaid
flowchart LR
  subgraph Flow["Failure surfacing path"]
    direction TB
    BeforeCLI["Claude CLI exits 1<br/>writes to stderr"]:::before
    BeforeSDK["SDK wraps in<br/>Error 'exited with code 1'"]:::before
    BeforePino["pino logs<br/>err.message only<br/>stderr SWALLOWED"]:::beforeBad
    BeforeOps["Operator must kubectl exec<br/>and reproduce by hand"]:::beforeBad

    BeforeCLI --> BeforeSDK --> BeforePino --> BeforeOps

    AfterCLI["Claude CLI exits 1<br/>writes to stderr"]:::after
    AfterSDK["SDK pipes stderr chunks<br/>to callback hook"]:::after
    AfterPino["pino logs each line as<br/>warn 'Claude CLI stderr'"]:::afterGood
    AfterOps["Operator reads pod log<br/>root cause visible"]:::afterGood

    AfterCLI --> AfterSDK --> AfterPino --> AfterOps
  end

  classDef before fill:#fde8e8,stroke:#9b1c1c,color:#1a1a1a
  classDef beforeBad fill:#9b1c1c,stroke:#1a1a1a,color:#ffffff
  classDef after fill:#def7ec,stroke:#03543f,color:#1a1a1a
  classDef afterGood fill:#03543f,stroke:#1a1a1a,color:#ffffff
```

## Changes

- `src/core/executor.ts`: add `stderr` callback to `queryOptions` passed to the SDK `query()` call. Each non-empty stderr chunk is trimmed and logged at `warn` level on the existing request-scoped logger as `{ stderr: <line> }, "Claude CLI stderr"`. Empty/whitespace-only chunks are skipped to avoid log spam.

## Related Issues

- No tracked issue — operator-driven follow-up after diagnosing pod `5b89f6dc4-twmdk` failure on issue #93.

## Test plan

- [x] Tested locally — `bun run typecheck` clean
- [x] Existing tests pass — `bun test test/core/executor.test.ts` 5/5
- [ ] Added/updated tests — none added; the change is a pure pass-through to pino. A unit test would have to assert pino received a specific structured-log call when the SDK mock emits stderr, which couples the test to SDK internals. Manual verification on next CLI failure in a non-prod pod is the cheaper signal.
- [x] No new lint warnings introduced (the two pre-existing `executeAgent` complexity/length warnings are unchanged in kind, count went 146 → 152 lines on a function already over the 120 limit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI execution can now be properly cancelled using abort signals.
  * Improved error diagnostics with enhanced stderr output logging for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->