### PR TITLE
fix(implement): match PR author by login in PAT mode

### DIFF
--- a/docs/use/workflows/implement.md
+++ b/docs/use/workflows/implement.md
@@ -28,7 +28,10 @@ Opens a PR with code, tests, and a filled-out PR template based on the prior pla
 
 ## PR detection
 
-`findRecentOpenedPr` filters on `pr.user?.type === 'Bot'` plus `created_at >= since - 5s`. It deliberately does not match on a hard-coded login slug — dev installs publish as `chrisleekr-bot-dev[bot]` and prod as `chrisleekr-bot[bot]`, so a slug check would produce false negatives.
+`findRecentOpenedPr` filter is auth-mode aware (`src/workflows/handlers/implement.ts`):
+
+- **App installation token (default)** — matches `pr.user?.type === 'Bot'` plus `created_at >= since - 5s`. Deliberately not keyed on a slug because dev installs publish as `chrisleekr-bot-dev[bot]` and prod as `chrisleekr-bot[bot]`.
+- **`GITHUB_PERSONAL_ACCESS_TOKEN` mode** — a PAT authors PRs as the human owner (`type === 'User'`), so the bot-type filter would skip them. The handler resolves the active token's login via `octokit.rest.users.getAuthenticated()` and matches `pr.user?.login === <PAT owner>`. If `/user` fails (transient), the handler logs warn and falls back to the bot-type filter — worst case is the same false negative we had before this fix, never a wrong-PR claim.
 
 ## PR body
 

--- a/docs/use/workflows/implement.md
+++ b/docs/use/workflows/implement.md
@@ -31,7 +31,7 @@ Opens a PR with code, tests, and a filled-out PR template based on the prior pla
 `findRecentOpenedPr` filter is auth-mode aware (`src/workflows/handlers/implement.ts`):
 
 - **App installation token (default)** — matches `pr.user?.type === 'Bot'` plus `created_at >= since - 5s`. Deliberately not keyed on a slug because dev installs publish as `chrisleekr-bot-dev[bot]` and prod as `chrisleekr-bot[bot]`.
-- **`GITHUB_PERSONAL_ACCESS_TOKEN` mode** — a PAT authors PRs as the human owner (`type === 'User'`), so the bot-type filter would skip them. The handler resolves the active token's login via `octokit.rest.users.getAuthenticated()` and matches `pr.user?.login === <PAT owner>`. If `/user` fails (transient), the handler logs warn and falls back to the bot-type filter — worst case is the same false negative we had before this fix, never a wrong-PR claim.
+- **`GITHUB_PERSONAL_ACCESS_TOKEN` mode** — a PAT authors PRs as the human owner (`type === 'User'`), so the bot-type filter would skip them. The handler resolves the active token's login via `octokit.rest.users.getAuthenticated()` and matches `pr.user?.login === <PAT owner>`. If `/user` fails the handler fails closed (the outer `try/catch` reports the run as `failed`); falling back to the bot-type filter would be unsafe in PAT mode because an unrelated bot PR opened in the same window (Dependabot, Renovate) would be claimed as ours.
 
 ## PR body
 

--- a/src/workflows/handlers/implement.ts
+++ b/src/workflows/handlers/implement.ts
@@ -244,8 +244,7 @@ async function resolveExpectedAuthorLogin(
   octokit: Parameters<WorkflowHandler>[0]["octokit"],
   log: Parameters<WorkflowHandler>[0]["logger"],
 ): Promise<string | null> {
-  const pat = config.githubPersonalAccessToken;
-  if (typeof pat !== "string" || pat.length === 0) return null;
+  if (config.githubPersonalAccessToken === undefined) return null;
   try {
     const { data } = await octokit.rest.users.getAuthenticated();
     return data.login;

--- a/src/workflows/handlers/implement.ts
+++ b/src/workflows/handlers/implement.ts
@@ -121,7 +121,7 @@ export const handler: WorkflowHandler = async (ctx) => {
       };
     }
 
-    const expectedLogin = await resolveExpectedAuthorLogin(octokit, log);
+    const expectedLogin = await resolveExpectedAuthorLogin(octokit);
     const opened = await findRecentOpenedPr(
       octokit,
       target.owner,
@@ -193,7 +193,10 @@ interface OpenedPr {
  *      * `GITHUB_PERSONAL_ACCESS_TOKEN` mode: `pr.user.login === <PAT owner>`.
  *        A PAT authors PRs as a real user (`type === "User"`), so the bot-type
  *        filter would reject the PR the agent just opened. The expected login
- *        is resolved at runtime via `/user`, so no env var has to track it.
+ *        is resolved at runtime via `/user`. If `/user` fails, the handler
+ *        fails closed (the outer `catch` reports `failed`) — falling back to
+ *        the bot-type filter would unsafely match an unrelated bot PR
+ *        (Dependabot/Renovate) opened in the same time window.
  *  - `created_at >= since - 5s` — the run's start. The 5s slop absorbs
  *    clock skew between the daemon's `Date.now()` and GitHub's server.
  *
@@ -233,28 +236,20 @@ async function findRecentOpenedPr(
  * Resolve the GitHub login that owns the active credential, but only when the
  * bot is running with `GITHUB_PERSONAL_ACCESS_TOKEN`. App installation tokens
  * cannot call `/user` (it requires user-to-server auth and returns 403), so
- * we skip the lookup and let the caller fall back to the bot-type filter.
+ * App mode short-circuits with `null` and the caller uses the bot-type filter.
  *
- * Failures are logged at warn and reported as `null` (= use bot-type filter).
- * That preserves App-mode behaviour and keeps PAT-mode runs from crashing if
- * `/user` is transiently unreachable; the worst case is the same false
- * negative we had before this fix, never a wrong-PR claim.
+ * In PAT mode we fail closed: if `/user` errors, this throws and the outer
+ * handler `try/catch` reports the run as `failed`. We deliberately do NOT
+ * fall back to the bot-type filter — that filter is unsafe in PAT mode
+ * because an unrelated bot PR opened during the same time window
+ * (Dependabot, Renovate, …) would be incorrectly claimed as ours.
  */
 async function resolveExpectedAuthorLogin(
   octokit: Parameters<WorkflowHandler>[0]["octokit"],
-  log: Parameters<WorkflowHandler>[0]["logger"],
 ): Promise<string | null> {
   if (config.githubPersonalAccessToken === undefined) return null;
-  try {
-    const { data } = await octokit.rest.users.getAuthenticated();
-    return data.login;
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "implement: PAT mode active but /user lookup failed — falling back to Bot-type filter",
-    );
-    return null;
-  }
+  const { data } = await octokit.rest.users.getAuthenticated();
+  return data.login;
 }
 
 /**

--- a/src/workflows/handlers/implement.ts
+++ b/src/workflows/handlers/implement.ts
@@ -1,3 +1,4 @@
+import { config } from "../../config";
 import { runPipeline } from "../../core/pipeline";
 import type { BotContext } from "../../types";
 import type { WorkflowHandler } from "../registry";
@@ -120,7 +121,14 @@ export const handler: WorkflowHandler = async (ctx) => {
       };
     }
 
-    const opened = await findRecentOpenedPr(octokit, target.owner, target.repo, since);
+    const expectedLogin = await resolveExpectedAuthorLogin(octokit, log);
+    const opened = await findRecentOpenedPr(
+      octokit,
+      target.owner,
+      target.repo,
+      since,
+      expectedLogin,
+    );
     if (opened === null) {
       return {
         status: "failed",
@@ -176,13 +184,16 @@ interface OpenedPr {
 
 /**
  * Locate the PR the agent opened during this pipeline run. Filters on:
- *  - `pr.user.type === "Bot"` — the App's installation token always
- *    authors PRs as the App's bot account, so any non-bot PR is human
- *    work we mustn't claim. We deliberately do NOT hard-code a slug
- *    (e.g. `chrisleekr-bot[bot]`) because the dev and prod installations
- *    publish as different slugs (`chrisleekr-bot-dev[bot]` vs
- *    `chrisleekr-bot[bot]`); a hard-coded match makes the handler return
- *    `failed` for a PR that was actually opened correctly.
+ *  - Authorship match keyed off the active GitHub credential:
+ *      * App installation token (default): `pr.user.type === "Bot"`. Any
+ *        non-bot PR is human work we mustn't claim. We deliberately do NOT
+ *        hard-code a slug (e.g. `chrisleekr-bot[bot]`) because dev and prod
+ *        installations publish as different slugs (`chrisleekr-bot-dev[bot]`
+ *        vs `chrisleekr-bot[bot]`).
+ *      * `GITHUB_PERSONAL_ACCESS_TOKEN` mode: `pr.user.login === <PAT owner>`.
+ *        A PAT authors PRs as a real user (`type === "User"`), so the bot-type
+ *        filter would reject the PR the agent just opened. The expected login
+ *        is resolved at runtime via `/user`, so no env var has to track it.
  *  - `created_at >= since - 5s` — the run's start. The 5s slop absorbs
  *    clock skew between the daemon's `Date.now()` and GitHub's server.
  *
@@ -194,6 +205,7 @@ async function findRecentOpenedPr(
   owner: string,
   repo: string,
   since: Date,
+  expectedLogin: string | null,
 ): Promise<OpenedPr | null> {
   const { data: prs } = await octokit.rest.pulls.list({
     owner,
@@ -204,13 +216,46 @@ async function findRecentOpenedPr(
     per_page: 30,
   });
   for (const pr of prs) {
-    if (pr.user?.type !== "Bot") continue;
+    if (expectedLogin === null) {
+      if (pr.user?.type !== "Bot") continue;
+    } else if (pr.user?.login !== expectedLogin) {
+      continue;
+    }
     const created = new Date(pr.created_at).getTime();
     if (created >= since.getTime() - 5_000) {
       return { number: pr.number, url: pr.html_url, branch: pr.head.ref };
     }
   }
   return null;
+}
+
+/**
+ * Resolve the GitHub login that owns the active credential, but only when the
+ * bot is running with `GITHUB_PERSONAL_ACCESS_TOKEN`. App installation tokens
+ * cannot call `/user` (it requires user-to-server auth and returns 403), so
+ * we skip the lookup and let the caller fall back to the bot-type filter.
+ *
+ * Failures are logged at warn and reported as `null` (= use bot-type filter).
+ * That preserves App-mode behaviour and keeps PAT-mode runs from crashing if
+ * `/user` is transiently unreachable; the worst case is the same false
+ * negative we had before this fix, never a wrong-PR claim.
+ */
+async function resolveExpectedAuthorLogin(
+  octokit: Parameters<WorkflowHandler>[0]["octokit"],
+  log: Parameters<WorkflowHandler>[0]["logger"],
+): Promise<string | null> {
+  const pat = config.githubPersonalAccessToken;
+  if (typeof pat !== "string" || pat.length === 0) return null;
+  try {
+    const { data } = await octokit.rest.users.getAuthenticated();
+    return data.login;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "implement: PAT mode active but /user lookup failed — falling back to Bot-type filter",
+    );
+    return null;
+  }
 }
 
 /**

--- a/test/workflows/handlers/implement.test.ts
+++ b/test/workflows/handlers/implement.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the `implement` handler — focused on the post-pipeline
+ * "did the agent open a PR?" verifier.
+ *
+ * Background: in `GITHUB_PERSONAL_ACCESS_TOKEN` mode the bot authors PRs as
+ * a real user (`pr.user.type === "User"`). The pre-fix verifier filtered on
+ * `type === "Bot"`, which made every PAT-mode implement run report
+ * `"implement completed but no PR was found"` even though the PR was opened
+ * correctly. These tests pin both modes so the regression can't return.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Octokit } from "octokit";
+import type pino from "pino";
+
+import type { WorkflowRunContext } from "../../../src/workflows/registry";
+
+const mockConfig: { githubPersonalAccessToken: string | undefined } = {
+  githubPersonalAccessToken: undefined,
+};
+
+void mock.module("../../../src/config", () => ({ config: mockConfig }));
+
+let pipelineResult: {
+  success: boolean;
+  costUsd?: number;
+  numTurns?: number;
+  durationMs?: number;
+  capturedFiles?: Record<string, string>;
+};
+
+void mock.module("../../../src/core/pipeline", () => ({
+  runPipeline: mock(() => Promise.resolve(pipelineResult)),
+}));
+
+void mock.module("../../../src/workflows/runs-store", () => ({
+  findLatestSucceededForTarget: mock(() =>
+    Promise.resolve({
+      id: "plan-row-1",
+      state: { plan: "## Plan\n\nDo the thing." },
+    }),
+  ),
+}));
+
+const { handler: implementHandler } = await import("../../../src/workflows/handlers/implement");
+
+function silentLog(): pino.Logger {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    child: mock(function (this: unknown) {
+      return this;
+    }),
+  } as unknown as pino.Logger;
+}
+
+interface PrStub {
+  number: number;
+  type: "Bot" | "User";
+  login: string;
+  createdAtOffsetMs?: number;
+  branch?: string;
+}
+
+function buildCtx(
+  prs: PrStub[],
+  options?: { authenticatedLogin?: string },
+): WorkflowRunContext & { setStateMock: ReturnType<typeof mock> } {
+  // Anchor created_at to "now" so the handler's `since` window includes them.
+  const now = Date.now();
+  const prData = prs.map((p) => ({
+    number: p.number,
+    html_url: `https://github.com/acme/widgets/pull/${String(p.number)}`,
+    head: { ref: p.branch ?? `feat/issue-1-${String(p.number)}` },
+    user: { type: p.type, login: p.login },
+    created_at: new Date(now + (p.createdAtOffsetMs ?? 1000)).toISOString(),
+  }));
+
+  const octokit = {
+    rest: {
+      issues: {
+        get: mock(() =>
+          Promise.resolve({
+            data: { title: "Implement the thing", user: { login: "humanA" } },
+          }),
+        ),
+      },
+      repos: {
+        get: mock(() => Promise.resolve({ data: { default_branch: "main" } })),
+      },
+      pulls: {
+        list: mock(() => Promise.resolve({ data: prData })),
+      },
+      users: {
+        getAuthenticated: mock(() =>
+          Promise.resolve({
+            data: { login: options?.authenticatedLogin ?? "chrisleekr" },
+          }),
+        ),
+      },
+    },
+  } as unknown as Octokit;
+
+  const setStateMock = mock(() => Promise.resolve());
+
+  return {
+    runId: "run-1",
+    workflowName: "implement",
+    target: { type: "issue", owner: "acme", repo: "widgets", number: 1 },
+    logger: silentLog(),
+    octokit,
+    deliveryId: "delivery-1",
+    daemonId: "daemon-1",
+    setState: setStateMock,
+    setStateMock,
+  } as unknown as WorkflowRunContext & { setStateMock: ReturnType<typeof mock> };
+}
+
+describe("implement handler — findRecentOpenedPr", () => {
+  beforeEach(() => {
+    pipelineResult = {
+      success: true,
+      costUsd: 0.5,
+      numTurns: 8,
+      durationMs: 12_000,
+      capturedFiles: { "IMPLEMENT.md": "## Summary\n\nImplemented." },
+    };
+    mockConfig.githubPersonalAccessToken = undefined;
+  });
+
+  afterEach(() => {
+    mockConfig.githubPersonalAccessToken = undefined;
+  });
+
+  it("App mode: accepts a PR authored by the App bot", async () => {
+    const ctx = buildCtx([{ number: 107, type: "Bot", login: "chrisleekr-bot[bot]" }]);
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("succeeded");
+    if (result.status === "succeeded") {
+      expect(result.state["pr_number"]).toBe(107);
+    }
+  });
+
+  it("App mode: rejects a PR authored by a User account", async () => {
+    const ctx = buildCtx([{ number: 107, type: "User", login: "chrisleekr" }]);
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.reason).toBe("implement completed but no PR was found");
+    }
+  });
+
+  it("PAT mode: accepts a PR authored by the PAT owner (regression: User type)", async () => {
+    mockConfig.githubPersonalAccessToken = "ghp_test_token";
+    const ctx = buildCtx([{ number: 107, type: "User", login: "chrisleekr" }], {
+      authenticatedLogin: "chrisleekr",
+    });
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("succeeded");
+    if (result.status === "succeeded") {
+      expect(result.state["pr_number"]).toBe(107);
+    }
+  });
+
+  it("PAT mode: rejects a PR authored by an unrelated bot", async () => {
+    mockConfig.githubPersonalAccessToken = "ghp_test_token";
+    const ctx = buildCtx([{ number: 107, type: "Bot", login: "renovate[bot]" }], {
+      authenticatedLogin: "chrisleekr",
+    });
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("failed");
+  });
+});

--- a/test/workflows/handlers/implement.test.ts
+++ b/test/workflows/handlers/implement.test.ts
@@ -68,14 +68,17 @@ function buildCtx(
   prs: PrStub[],
   options?: { authenticatedLogin?: string },
 ): WorkflowRunContext & { setStateMock: ReturnType<typeof mock> } {
-  // Anchor created_at to "now" so the handler's `since` window includes them.
+  // Anchor created_at slightly in the past so fixtures never produce future
+  // timestamps. The handler's filter is `created >= since - 5s`; since the
+  // mocked pipeline resolves synchronously, `since` is captured a few ms
+  // after `now`, so a 1s past offset still satisfies the window.
   const now = Date.now();
   const prData = prs.map((p) => ({
     number: p.number,
     html_url: `https://github.com/acme/widgets/pull/${String(p.number)}`,
     head: { ref: p.branch ?? `feat/issue-1-${String(p.number)}` },
     user: { type: p.type, login: p.login },
-    created_at: new Date(now + (p.createdAtOffsetMs ?? 1000)).toISOString(),
+    created_at: new Date(now - (p.createdAtOffsetMs ?? 1000)).toISOString(),
   }));
 
   const octokit = {

--- a/test/workflows/handlers/implement.test.ts
+++ b/test/workflows/handlers/implement.test.ts
@@ -138,6 +138,9 @@ describe("implement handler — findRecentOpenedPr", () => {
     const ctx = buildCtx([{ number: 107, type: "Bot", login: "chrisleekr-bot[bot]" }]);
     const result = await implementHandler(ctx);
     expect(result.status).toBe("succeeded");
+    expect(
+      ctx.octokit.rest.users.getAuthenticated as unknown as ReturnType<typeof mock>,
+    ).not.toHaveBeenCalled();
     if (result.status === "succeeded") {
       expect(result.state["pr_number"]).toBe(107);
     }
@@ -171,6 +174,9 @@ describe("implement handler — findRecentOpenedPr", () => {
     });
     const result = await implementHandler(ctx);
     expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.reason).toBe("implement completed but no PR was found");
+    }
   });
 
   it("PAT mode: fails closed when /user lookup fails (no fallback)", async () => {

--- a/test/workflows/handlers/implement.test.ts
+++ b/test/workflows/handlers/implement.test.ts
@@ -173,7 +173,7 @@ describe("implement handler — findRecentOpenedPr", () => {
     expect(result.status).toBe("failed");
   });
 
-  it("PAT mode: falls back to Bot-type filter when /user lookup fails", async () => {
+  it("PAT mode: fails closed when /user lookup fails (no fallback)", async () => {
     mockConfig.githubPersonalAccessToken = "ghp_test_token";
     const ctx = buildCtx([{ number: 107, type: "User", login: "chrisleekr" }]);
     (
@@ -182,7 +182,29 @@ describe("implement handler — findRecentOpenedPr", () => {
     const result = await implementHandler(ctx);
     expect(result.status).toBe("failed");
     if (result.status === "failed") {
-      expect(result.reason).toBe("implement completed but no PR was found");
+      expect(result.reason).toContain("503 Service Unavailable");
+    }
+  });
+
+  it("PAT mode: /user failure does NOT misclaim an unrelated bot PR", async () => {
+    // Regression for the false-positive scenario flagged by Copilot:
+    // before this fix, /user failure fell back to the Bot-type filter,
+    // which would happily match a Dependabot/Renovate PR opened in the
+    // same time window as the implement run.
+    mockConfig.githubPersonalAccessToken = "ghp_test_token";
+    const ctx = buildCtx([
+      { number: 999, type: "Bot", login: "dependabot[bot]" },
+      { number: 107, type: "User", login: "chrisleekr" },
+    ]);
+    (
+      ctx.octokit.rest.users.getAuthenticated as unknown as ReturnType<typeof mock>
+    ).mockImplementationOnce(() => Promise.reject(new Error("502 Bad Gateway")));
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      // Must NOT silently claim PR #999 (Dependabot's bot PR).
+      expect(result.reason).not.toContain("999");
+      expect(result.reason).toContain("502 Bad Gateway");
     }
   });
 });

--- a/test/workflows/handlers/implement.test.ts
+++ b/test/workflows/handlers/implement.test.ts
@@ -172,4 +172,17 @@ describe("implement handler — findRecentOpenedPr", () => {
     const result = await implementHandler(ctx);
     expect(result.status).toBe("failed");
   });
+
+  it("PAT mode: falls back to Bot-type filter when /user lookup fails", async () => {
+    mockConfig.githubPersonalAccessToken = "ghp_test_token";
+    const ctx = buildCtx([{ number: 107, type: "User", login: "chrisleekr" }]);
+    (
+      ctx.octokit.rest.users.getAuthenticated as unknown as ReturnType<typeof mock>
+    ).mockImplementationOnce(() => Promise.reject(new Error("503 Service Unavailable")));
+    const result = await implementHandler(ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.reason).toBe("implement completed but no PR was found");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Post-pipeline PR verifier in `src/workflows/handlers/implement.ts` filtered on `pr.user.type === "Bot"`. In `GITHUB_PERSONAL_ACCESS_TOKEN` mode (introduced by #104) the bot authors PRs as the PAT owner with `type === "User"`, so every PAT-mode implement run was marked `failed` with `"implement completed but no PR was found"` even when the PR opened correctly.
- Branch on auth mode: PAT mode resolves the active token's login via `octokit.rest.users.getAuthenticated()` and matches `pr.user.login`; App mode keeps the `type === "Bot"` filter (App installation tokens can't call `/user`).
- **PAT mode fails closed if `/user` errors** (no fallback to bot-type filter). Falling back is unsafe: an unrelated bot PR (Dependabot, Renovate) opened in the same run window would be silently claimed as ours. The outer handler `try/catch` reports the run as `failed`, surfacing the underlying error in `state.failedReason`.

> **Note**: an earlier draft of this PR fell back to the bot-type filter on `/user` failure. Copilot's review on commit `b9a1566` flagged that as a false-positive vector. The current behavior is fail-closed — see commit `b9a1566` and `docs/use/workflows/implement.md`.

## Why this matters

Issue #93's `implement` run on `feat/93-resolve-ci-recheck-gate` opened PR #107 correctly, but `workflow_runs` was written as `failed` because of this false negative. For `bot:ship` orchestration the `succeeded`-keyed cascade now sees a green run as red, blocking iteration.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx eslint` on changed files: 0 errors (2 pre-existing complexity/length warnings on the handler arrow, untouched)
- [x] `bun test test/workflows/handlers/implement.test.ts`: 6/6 pass, 93% line coverage on `implement.ts`
- [x] Coverage of both auth modes:
  - App mode + Bot author → succeeded (also asserts `/user` is NOT called)
  - App mode + User author → failed
  - PAT mode + matching User author → succeeded (regression case)
  - PAT mode + unrelated bot author → failed with exact reason
  - PAT mode + `/user` 503 (no extra PRs) → failed (fails closed)
  - PAT mode + `/user` 502 + Dependabot bot PR present → failed (must NOT claim PR #999)
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
