### PR TITLE
fix(mcp): bundle all stdio servers and resolve paths from any bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,11 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: MCP bundle smoke check
+        # Validates that every MCP server name registered in src/mcp/registry.ts
+        # resolves to an existing dist/mcp/servers/<name>.js when consumed from
+        # both bundle locations (dist/app.js + dist/daemon/main.js). Catches the
+        # build/resolve drift class that shipped in 001990d before the daemon
+        # image hits production. Must run AFTER `bun run build`.
+        run: bun run check:mcp-bundle

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "check:docs-sync": "bun run scripts/check-docs-sync.ts",
     "check:docs-versions": "bun run scripts/check-docs-versions.ts",
     "check:docs-citations": "bun run scripts/check-docs-citations.ts",
+    "check:mcp-bundle": "bun run scripts/check-mcp-bundle.ts",
     "prepare": "husky"
   },
   "license": "MIT",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -39,8 +39,13 @@ const serversDir = "./src/mcp/servers";
 // resolveServerPath("...") name in registry.ts is in this discovered set, so
 // adding a `.mts`/`.cts` server without broadening this filter trips CI
 // instead of silently shipping a missing bundle.
+//
+// Sort the result: `readdirSync` order is not guaranteed across filesystems,
+// and a stable order keeps Bun.build output deterministic so artifact diffs
+// only reflect real changes.
 const stdioEntrypoints = readdirSync(serversDir)
   .filter((f) => f.endsWith(".ts"))
+  .sort()
   .map((f) => join(serversDir, f))
   .filter((p) => readFileSync(p, "utf8").includes("StdioServerTransport"));
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -25,13 +25,27 @@ if (!result.success) {
 // sanitize.ts (and github-state's fetcher helpers) are inlined into each
 // bundle (splitting: false) since each server runs as an independent
 // child process with no shared runtime.
+//
+// Entrypoints are auto-discovered by scanning src/mcp/servers/ for files that
+// import StdioServerTransport. registry.ts spawns these as subprocesses, and
+// drift between the registry and a hardcoded entrypoint list previously
+// shipped MCP servers that did not exist in the production image. context7.ts
+// is HTTP-transport and consumed via direct import, so it is correctly omitted
+// by the StdioServerTransport filter.
+const { readdirSync, readFileSync } = await import("node:fs");
+const { join } = await import("node:path");
+const serversDir = "./src/mcp/servers";
+// `.ts` only by repo convention. test/mcp/registry.test.ts asserts every
+// resolveServerPath("...") name in registry.ts is in this discovered set, so
+// adding a `.mts`/`.cts` server without broadening this filter trips CI
+// instead of silently shipping a missing bundle.
+const stdioEntrypoints = readdirSync(serversDir)
+  .filter((f) => f.endsWith(".ts"))
+  .map((f) => join(serversDir, f))
+  .filter((p) => readFileSync(p, "utf8").includes("StdioServerTransport"));
+
 const mcpResult = await Bun.build({
-  entrypoints: [
-    "./src/mcp/servers/comment.ts",
-    "./src/mcp/servers/inline-comment.ts",
-    "./src/mcp/servers/resolve-review-thread.ts",
-    "./src/mcp/servers/github-state.ts",
-  ],
+  entrypoints: stdioEntrypoints,
   outdir: "./dist/mcp/servers",
   target: "bun",
   minify: isProduction,

--- a/scripts/check-mcp-bundle.ts
+++ b/scripts/check-mcp-bundle.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+/**
+ * Post-build smoke test for the MCP server bundle.
+ *
+ * Catches the failure mode that shipped in `001990d` (daemon Pod throwing
+ * `MCP server module not found for "repo-memory"`). Two cooperating bugs:
+ *
+ *   1. A server registered in `src/mcp/registry.ts` was missing from
+ *      `scripts/build.ts` entrypoints, so `dist/mcp/servers/<name>.js`
+ *      did not exist.
+ *   2. `resolveServerPath()` resolved candidate URLs against
+ *      `import.meta.url`, which after `Bun.build` inlines `registry.ts`
+ *      into `dist/app.js` or `dist/daemon/main.js` points at the bundle
+ *      rather than the source, so the URL math landed in the wrong dir.
+ *
+ * The source-level invariant test in `test/mcp/registry.test.ts` covers
+ * (1) without depending on a populated `dist/`. This script covers (2):
+ * it reads `dist/app.js` and `dist/daemon/main.js` as anchor URLs, walks
+ * the same candidate list `registry.ts` uses, and asserts every name
+ * registered via `resolveServerPath("...")` resolves to an existing
+ * `dist/mcp/servers/<name>.js` from BOTH bundle locations. Run it after
+ * `bun run build` (CI does this in `ci.yml`).
+ *
+ * Exit codes: 0 ok, 1 missing bundle, 2 unresolved candidate.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const registrySrc = readFileSync("src/mcp/registry.ts", "utf8");
+const registeredNames = Array.from(registrySrc.matchAll(/resolveServerPath\("([^"]+)"\)/g), (m) => {
+  if (m[1] === undefined) throw new Error("regex group 1 missing");
+  return m[1];
+});
+
+if (registeredNames.length === 0) {
+  console.error("FAIL: regex found zero resolveServerPath() call sites in registry.ts");
+  process.exit(2);
+}
+
+// Bundles consume registry.ts. Keep this list aligned with `scripts/build.ts`
+// build steps 1 and 3 (app + daemon entrypoints).
+const bundlePaths = ["dist/app.js", "dist/daemon/main.js"];
+
+// Mirrors the candidate list in `src/mcp/registry.ts:resolveServerPath`. Drift
+// here means the smoke and the runtime resolver disagree, which would silently
+// hide the bug class this script exists to catch.
+const candidatesFor = (name: string): string[] => [
+  `./servers/${name}.js`,
+  `./mcp/servers/${name}.js`,
+  `../mcp/servers/${name}.js`,
+  `./servers/${name}.ts`,
+];
+
+let failed = 0;
+
+for (const bundle of bundlePaths) {
+  if (!existsSync(bundle)) {
+    console.error(`FAIL: ${bundle} does not exist; run \`bun run build\` first.`);
+    process.exit(1);
+  }
+  const baseUrl = pathToFileURL(bundle).href;
+  for (const name of registeredNames) {
+    const hit = candidatesFor(name)
+      .map((c) => fileURLToPath(new URL(c, baseUrl)))
+      .find((p) => existsSync(p));
+    if (hit === undefined) {
+      console.error(`FAIL: ${bundle} cannot resolve MCP server "${name}" via any candidate URL`);
+      failed++;
+    } else {
+      console.log(`ok  ${bundle} -> ${name} -> ${hit}`);
+    }
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} unresolved candidate(s).`);
+  process.exit(2);
+}
+
+console.log(
+  `\nSmoke OK: ${registeredNames.length} MCP server name(s) resolve from ${bundlePaths.length} bundle location(s).`,
+);

--- a/scripts/check-mcp-bundle.ts
+++ b/scripts/check-mcp-bundle.ts
@@ -28,9 +28,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const registrySrc = readFileSync("src/mcp/registry.ts", "utf8");
-const registeredNames = Array.from(registrySrc.matchAll(/resolveServerPath\("([^"]+)"\)/g), (m) => {
-  if (m[1] === undefined) throw new Error("regex group 1 missing");
-  return m[1];
+// Tolerate single or double quotes and surrounding whitespace. Template
+// literals are intentionally not matched: a dynamic name would defeat the
+// smoke check, so the failure surfaces here rather than silently regressing.
+const callRegex = /resolveServerPath\(\s*(['"])([^'"]+)\1\s*\)/g;
+const registeredNames = Array.from(registrySrc.matchAll(callRegex), (m) => {
+  if (m[2] === undefined) throw new Error("regex group 2 missing");
+  return m[2];
 });
 
 if (registeredNames.length === 0) {

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -8,32 +8,37 @@ import { context7Server } from "./servers/context7";
 
 /**
  * Resolve the absolute filesystem path of an MCP server module by name.
- * registry.ts is consumed from three locations: unbundled at src/mcp/ in dev,
- * inlined into dist/app.js, and inlined into dist/daemon/main.js. After Bun
- * bundles, `import.meta.url` points at the bundle, not the original source,
- * so a single `./servers/${name}.js` URL only resolves correctly in dev.
- * The MCP servers are always emitted to dist/mcp/servers/ by scripts/build.ts;
- * try each plausible base relative to `import.meta.url` and return the first
- * `existsSync` hit. existsSync (not heuristics on the URL string) keeps this
+ * registry.ts is consumed from three locations: unbundled at src/mcp/ in dev
+ * (servers exist only as `.ts` siblings), inlined into dist/app.js (servers
+ * live one level up at dist/mcp/servers/), and inlined into dist/daemon/main.js
+ * (servers live two levels up). After `Bun.build`, `import.meta.url` points at
+ * the bundle, not the original source, so the base directory of `./servers/x`
+ * shifts per consumer. The compiled `.js` files are always emitted to
+ * dist/mcp/servers/ by scripts/build.ts; try each plausible base relative to
+ * `import.meta.url` and return the first `existsSync` hit, with `.ts` last as
+ * the dev fallback. existsSync (not heuristics on the URL string) keeps this
  * resilient to WORKDIR shapes that contain a `/src/` segment.
  */
 function resolveServerPath(name: string): string {
   const candidates = [
-    `./servers/${name}.js`, // dev: src/mcp/registry.ts → src/mcp/servers/
+    `./servers/${name}.js`, // bundled `.js` sitting next to the registry (rare, kept for symmetry)
     `./mcp/servers/${name}.js`, // bundled: dist/app.js → dist/mcp/servers/
     `../mcp/servers/${name}.js`, // bundled: dist/daemon/main.js → dist/mcp/servers/
-    `./servers/${name}.ts`, // dev fallback when only the .ts source is present
+    `./servers/${name}.ts`, // dev: src/mcp/registry.ts → src/mcp/servers/<name>.ts
   ];
+  const tried: string[] = [];
   for (const candidate of candidates) {
     const resolved = fileURLToPath(new URL(candidate, import.meta.url));
+    tried.push(resolved);
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- candidate is a hardcoded relative URL; only `name` is dynamic and is constrained to known server names by callers in this file
     if (existsSync(resolved)) return resolved;
   }
   // Surface a clear, actionable error rather than letting bun fail with a
   // bare ENOENT inside an MCP server subprocess (which only shows up as
-  // status:"failed" in the SDK init message).
+  // status:"failed" in the SDK init message). Include the absolute paths so
+  // a daemon Pod stack trace points directly at the missing files.
   throw new Error(
-    `MCP server module not found for "${name}": none of [${candidates.join(", ")}] resolved relative to ${import.meta.url}`,
+    `MCP server module not found for "${name}" (registry consumed from ${import.meta.url}). Checked: ${tried.join(", ")}`,
   );
 }
 

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -7,24 +7,33 @@ import type { BotContext, McpServerConfig, McpServerDef } from "../types";
 import { context7Server } from "./servers/context7";
 
 /**
- * Resolve the absolute filesystem path of an MCP server module by name,
- * preferring the compiled `.js` if present (prod image) and falling back to
- * `.ts` for dev. Heuristics like `import.meta.url.includes("/src/")` are
- * brittle: container images with a `/src/` segment in their WORKDIR would
- * false-positive and pick a `.ts` that does not exist after compilation.
- * existsSync against both candidates is path-shape-agnostic and removes the
- * 6-fold duplication that previously lived in this file.
+ * Resolve the absolute filesystem path of an MCP server module by name.
+ * registry.ts is consumed from three locations: unbundled at src/mcp/ in dev,
+ * inlined into dist/app.js, and inlined into dist/daemon/main.js. After Bun
+ * bundles, `import.meta.url` points at the bundle, not the original source,
+ * so a single `./servers/${name}.js` URL only resolves correctly in dev.
+ * The MCP servers are always emitted to dist/mcp/servers/ by scripts/build.ts;
+ * try each plausible base relative to `import.meta.url` and return the first
+ * `existsSync` hit. existsSync (not heuristics on the URL string) keeps this
+ * resilient to WORKDIR shapes that contain a `/src/` segment.
  */
 function resolveServerPath(name: string): string {
-  const jsPath = fileURLToPath(new URL(`./servers/${name}.js`, import.meta.url));
-  if (existsSync(jsPath)) return jsPath;
-  const tsPath = fileURLToPath(new URL(`./servers/${name}.ts`, import.meta.url));
-  if (existsSync(tsPath)) return tsPath;
+  const candidates = [
+    `./servers/${name}.js`, // dev: src/mcp/registry.ts → src/mcp/servers/
+    `./mcp/servers/${name}.js`, // bundled: dist/app.js → dist/mcp/servers/
+    `../mcp/servers/${name}.js`, // bundled: dist/daemon/main.js → dist/mcp/servers/
+    `./servers/${name}.ts`, // dev fallback when only the .ts source is present
+  ];
+  for (const candidate of candidates) {
+    const resolved = fileURLToPath(new URL(candidate, import.meta.url));
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- candidate is a hardcoded relative URL; only `name` is dynamic and is constrained to known server names by callers in this file
+    if (existsSync(resolved)) return resolved;
+  }
   // Surface a clear, actionable error rather than letting bun fail with a
   // bare ENOENT inside an MCP server subprocess (which only shows up as
   // status:"failed" in the SDK init message).
   throw new Error(
-    `MCP server module not found for "${name}": neither ${jsPath} nor ${tsPath} exists.`,
+    `MCP server module not found for "${name}": none of [${candidates.join(", ")}] resolved relative to ${import.meta.url}`,
   );
 }
 

--- a/test/mcp/registry.test.ts
+++ b/test/mcp/registry.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for the MCP server build/resolve invariants.
+ *
+ * Two bugs we never want to ship again, both surfaced as
+ * `MCP server module not found for "<name>"` from a daemon Pod:
+ *
+ *   1. A new server file under `src/mcp/servers/` is referenced by
+ *      `registry.ts` but missing from `scripts/build.ts` entrypoints,
+ *      so it does not exist in the production image.
+ *   2. `resolveServerPath` looks under the wrong base directory when
+ *      `registry.ts` is bundled into `dist/app.js` or `dist/daemon/main.js`
+ *      (see file comment for the full bundle-vs-source layout).
+ *
+ * The first suite exercises every opt-in path of `resolveMcpServers` with
+ * all flags set and asserts every stdio server's resolved path exists.
+ * Running from `src/` resolves through the `.ts` candidate, which proves the
+ * registry-side wiring is sound but does not by itself prove the production
+ * `.js` candidates resolve.
+ *
+ * The second suite closes that gap by replicating `scripts/build.ts`'s
+ * auto-discovery rule against the source tree and asserting every name
+ * registered in `registry.ts` is in the discovered set. If a server is
+ * registered without being bundled (as `repo-memory` was in `001990d`),
+ * this fails at test time rather than at runtime in a daemon Pod.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+import type { Logger } from "pino";
+
+import { resolveMcpServers } from "../../src/mcp/registry";
+import type { DaemonCapabilities } from "../../src/shared/daemon-types";
+import type { BotContext } from "../../src/types";
+
+const noopLog = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+  trace: () => undefined,
+  fatal: () => undefined,
+  child: () => noopLog,
+} as unknown as Logger;
+
+function ctx(overrides: Partial<BotContext> = {}): BotContext {
+  return {
+    owner: "chrisleekr",
+    repo: "github-app-playground",
+    entityNumber: 1,
+    isPR: true,
+    eventName: "issue_comment",
+    triggerUsername: "chrisleekr",
+    triggerTimestamp: "2026-05-10T00:00:00Z",
+    triggerBody: "@chrisleekr-bot test",
+    commentId: 42,
+    deliveryId: "delivery-1",
+    defaultBranch: "main",
+    labels: [],
+    octokit: {} as BotContext["octokit"],
+    log: noopLog,
+    ...overrides,
+  };
+}
+
+const fakeDaemonCaps: DaemonCapabilities = {
+  daemonId: "test",
+  hostname: "test-host",
+  os: { platform: "linux", arch: "x64", release: "test" },
+  tools: {},
+  generatedAt: new Date().toISOString(),
+} as unknown as DaemonCapabilities;
+
+describe("resolveMcpServers stdio paths", () => {
+  it("every registered stdio server resolves to a file that exists", () => {
+    const servers = resolveMcpServers(ctx(), 99, "ghs_token", {
+      workDir: "/tmp/test-workdir",
+      enableResolveReviewThread: true,
+      enableGithubState: true,
+      daemonCapabilities: fakeDaemonCaps,
+    });
+
+    const stdioPaths = Object.entries(servers)
+      .filter(([, def]) => def.type === "stdio")
+      .map(([name, def]) => {
+        // Stdio defs from registry.ts use args = ["run", serverPath]
+        const args = (def as { args?: string[] }).args ?? [];
+        return { name, path: args[1] };
+      });
+
+    expect(stdioPaths.length).toBeGreaterThan(0);
+    for (const { name, path } of stdioPaths) {
+      if (path === undefined || path === "") {
+        throw new Error(`MCP server "${name}" must resolve to a non-empty path`);
+      }
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- path comes from registry.ts resolveServerPath
+      expect(existsSync(path), `MCP server "${name}" file missing on disk: ${path}`).toBe(true);
+    }
+  });
+
+  it("registers repo_memory and daemon_capabilities when their inputs are provided", () => {
+    const servers = resolveMcpServers(ctx(), 99, "ghs_token", {
+      workDir: "/tmp/test-workdir",
+      daemonCapabilities: fakeDaemonCaps,
+    });
+
+    expect(servers["repo_memory"]).toBeDefined();
+    expect(servers["daemon_capabilities"]).toBeDefined();
+  });
+});
+
+/**
+ * Source-level invariant: every server name registry.ts asks `resolveServerPath`
+ * for must also be picked up by scripts/build.ts's auto-discovery filter, so it
+ * actually exists in the production image. This catches the regression that
+ * shipped in `001990d` (repo-memory.ts registered but missing from build
+ * entrypoints) without depending on a populated `dist/` (CI runs tests before
+ * build). The discovery rule is replicated verbatim from scripts/build.ts.
+ */
+describe("MCP server registration vs build discovery", () => {
+  const registryPath = join(import.meta.dir, "../../src/mcp/registry.ts");
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- registryPath is a fixed test fixture path, not user input
+  const registrySrc = readFileSync(registryPath, "utf8");
+  const registeredNames = Array.from(
+    registrySrc.matchAll(/resolveServerPath\("([^"]+)"\)/g),
+    (m) => {
+      if (m[1] === undefined) throw new Error("regex group 1 missing");
+      return m[1];
+    },
+  );
+
+  const serversDir = join(import.meta.dir, "../../src/mcp/servers");
+  const discovered = new Set(
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- serversDir is a fixed test fixture path, not user input
+    readdirSync(serversDir)
+      .filter((f) => f.endsWith(".ts"))
+      .filter((f) =>
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- file name comes from readdirSync of a fixed dir
+        readFileSync(join(serversDir, f), "utf8").includes("StdioServerTransport"),
+      )
+      .map((f) => f.replace(/\.ts$/, "")),
+  );
+
+  it("finds at least one resolveServerPath call site (regex sanity)", () => {
+    expect(registeredNames.length).toBeGreaterThan(0);
+  });
+
+  it.each(registeredNames.map((n) => [n]))("build.ts auto-discovery includes server %s", (name) => {
+    expect(
+      discovered.has(name),
+      `Server "${name}" is registered in registry.ts but scripts/build.ts auto-discovery does not pick up src/mcp/servers/${name}.ts. Either the file is missing, or it does not import StdioServerTransport (the discovery marker).`,
+    ).toBe(true);
+  });
+});

--- a/test/mcp/registry.test.ts
+++ b/test/mcp/registry.test.ts
@@ -122,13 +122,16 @@ describe("MCP server registration vs build discovery", () => {
   const registryPath = join(import.meta.dir, "../../src/mcp/registry.ts");
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- registryPath is a fixed test fixture path, not user input
   const registrySrc = readFileSync(registryPath, "utf8");
-  const registeredNames = Array.from(
-    registrySrc.matchAll(/resolveServerPath\("([^"]+)"\)/g),
-    (m) => {
-      if (m[1] === undefined) throw new Error("regex group 1 missing");
-      return m[1];
-    },
-  );
+  // Match resolveServerPath("name") or resolveServerPath('name'), tolerating
+  // whitespace around the argument. Template-literal calls would defeat the
+  // invariant (dynamic name) and are intentionally not matched: the test fails
+  // loudly if the source switches to a form this regex does not understand,
+  // forcing reconsideration rather than silently passing.
+  const callRegex = /resolveServerPath\(\s*(['"])([^'"]+)\1\s*\)/g;
+  const registeredNames = Array.from(registrySrc.matchAll(callRegex), (m) => {
+    if (m[2] === undefined) throw new Error("regex group 2 missing");
+    return m[2];
+  });
 
   const serversDir = join(import.meta.dir, "../../src/mcp/servers");
   const discovered = new Set(


### PR DESCRIPTION
## Summary

The `implement` workflow on a daemon Pod aborts with `MCP server module not found for "repo-memory"` because two compounding bugs leave the server unreachable in the production image. `scripts/build.ts` only listed 4 of the 6 stdio MCP servers as bundle entrypoints, so `repo-memory.ts` (added in #124) and `daemon-capabilities.ts` were registered in `registry.ts` but never emitted under `dist/mcp/servers/`. Even after fixing the build, `resolveServerPath()` looked under the wrong base directory: it built URLs against `import.meta.url`, which after Bun bundles `registry.ts` into `dist/daemon/main.js` points at the bundle, not the source, so it computed `dist/daemon/servers/<name>.js` instead of `dist/mcp/servers/<name>.js`.

## Diagram

```mermaid
flowchart TB
  subgraph CMP["MCP server resolve flow: before vs after"]
    direction TB

    BeforeBuild["scripts/build.ts<br/>hardcoded 4 entrypoints<br/>repo-memory + daemon-capabilities omitted"]:::bad
    BeforeResolve["resolveServerPath in dist/daemon/main.js<br/>./servers/x.js relative to bundle URL<br/>--> dist/daemon/servers/x.js wrong dir"]:::bad
    BeforeFail["Daemon Pod throws<br/>MCP server module not found"]:::bad

    BeforeBuild --> BeforeResolve --> BeforeFail

    AfterBuild["scripts/build.ts<br/>auto-discover stdio servers<br/>by StdioServerTransport import"]:::good
    AfterResolve["resolveServerPath tries candidate list<br/>./servers/x.js, ./mcp/servers/x.js,<br/>../mcp/servers/x.js, ./servers/x.ts<br/>first existsSync hit wins"]:::good
    AfterPass["Daemon Pod resolves<br/>dist/mcp/servers/repo-memory.js"]:::good

    AfterBuild --> AfterResolve --> AfterPass
  end

  classDef bad fill:#7a1f1f,color:#ffffff,stroke:#400,stroke-width:1px
  classDef good fill:#1f5d3a,color:#ffffff,stroke:#063,stroke-width:1px
```

## Changes

- `scripts/build.ts` — replace the hardcoded MCP entrypoint list with auto-discovery (`readdirSync` over `src/mcp/servers/` filtered by `StdioServerTransport` import). Picks up `repo-memory.ts` and `daemon-capabilities.ts` automatically; HTTP-only `context7.ts` is correctly excluded.
- `src/mcp/registry.ts` — `resolveServerPath` now walks a candidate URL list covering all three locations `registry.ts` is consumed from (dev `src/mcp/`, bundled into `dist/app.js`, bundled into `dist/daemon/main.js`) and returns the first `existsSync` hit. Updated docstring and error message.
- `test/mcp/registry.test.ts` (new) — two regression suites: every server returned by `resolveMcpServers` resolves to an existing file, plus a source-level invariant that asserts every `resolveServerPath("...")` name in `registry.ts` is in `build.ts`'s auto-discovery set, catching this class of drift at test time instead of inside a daemon Pod.

## Related Issues

- Surfaces as runtime failure of `implement` workflow on agentsync issue #41 (no GitHub issue filed in this repo).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on changed files
- [x] `bun run format` clean
- [x] `bun test test/mcp/registry.test.ts` — 9 pass
- [x] Full `bun run test` — 120/120 files pass with `TEST_DATABASE_URL` set
- [x] `bun run build` — `dist/mcp/servers/` now contains all 6 stdio servers
- [x] Manually verified candidate URL math against synthetic bundle URLs for all three consumer locations
- [x] Regression test fails when a `resolveServerPath` name is renamed to a non-existent server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process with automatic MCP server discovery.
  * Added post-build validation to ensure all registered servers are properly compiled.

* **Tests**
  * Added regression tests for MCP server resolution and bundling.

* **Bug Fixes**
  * Enhanced error messages for missing or unresolved MCP servers with detailed path information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/github-app-playground/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->