### PR TITLE
fix(webhook): subscribe issue_comment.edited/.deleted for cache write-through

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,9 +77,17 @@ const app = new App({
   webhooks: { secret: config.webhookSecret },
 });
 
-app.webhooks.on("issue_comment.created", ({ octokit, payload, id }) => {
-  handleIssueComment(octokit, payload as unknown as IssueCommentEvent, id);
-});
+// All three actions are subscribed so the chat-thread cache write-through
+// at `webhook/events/issue-comment.ts:writeCommentCacheThrough` fires on
+// edits and deletes too. The dispatch path is still gated to `created` by
+// the early-return inside the handler. Mirrors the review-comment block
+// below. See issue #129.
+app.webhooks.on(
+  ["issue_comment.created", "issue_comment.edited", "issue_comment.deleted"],
+  ({ octokit, payload, id }) => {
+    handleIssueComment(octokit, payload as unknown as IssueCommentEvent, id);
+  },
+);
 
 app.webhooks.on(
   [

--- a/src/webhook/events/issue-comment.ts
+++ b/src/webhook/events/issue-comment.ts
@@ -33,6 +33,9 @@ export function handleIssueComment(
     logger.warn({ err, deliveryId }, "issue-comment: cache write-through failed");
   });
 
+  // Dispatch is created-only: editing a previously-mentioned comment must
+  // not re-fire the workflow (would be surprising UX and double-bill the
+  // user). The cache write-through above must run BEFORE this gate.
   if (payload.action !== "created") return;
   if (payload.comment.user.type === "Bot") return;
 
@@ -141,7 +144,7 @@ export function handleIssueComment(
  * configured, so wrap in try/catch and downgrade DB-not-configured to
  * a no-op.
  */
-async function writeCommentCacheThrough(payload: IssueCommentEvent): Promise<void> {
+export async function writeCommentCacheThrough(payload: IssueCommentEvent): Promise<void> {
   const owner = payload.repository.owner.login;
   const repo = payload.repository.name;
   const targetNumber = payload.issue.number;

--- a/test/webhook/events/issue-comment-cache.test.ts
+++ b/test/webhook/events/issue-comment-cache.test.ts
@@ -150,12 +150,14 @@ describe("src/app.ts subscription (issue #129)", () => {
   it.each([["issue_comment.created"], ["issue_comment.edited"], ["issue_comment.deleted"]])(
     "subscribes to %s",
     (action) => {
-      // Match the action name as a quoted string in app.ts. Tolerates single or
-      // double quotes. Future array reshuffles or comment changes do not break
-      // the assertion; removing the action name does.
-      // eslint-disable-next-line security/detect-non-literal-regexp -- action comes from this file's hardcoded it.each table, no user input
-      const re = new RegExp(`['"]${action.replace(/\./g, "\\.")}['"]`);
-      expect(appSrc).toMatch(re);
+      // Tolerate either quote style. Substring instead of RegExp avoids any
+      // regex-escape footgun on the action name (CodeRabbit/CodeQL flagged
+      // the dynamic-regex variant on PR #131).
+      const hasDoubleQuoted = appSrc.includes(`"${action}"`);
+      const hasSingleQuoted = appSrc.includes(`'${action}'`);
+      expect(hasDoubleQuoted || hasSingleQuoted, `${action} not found as a quoted string`).toBe(
+        true,
+      );
     },
   );
 

--- a/test/webhook/events/issue-comment-cache.test.ts
+++ b/test/webhook/events/issue-comment-cache.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for issue #129: chat-thread `comment_cache` write-through
+ * must fire on every `issue_comment` action, not just `created`.
+ *
+ * Covers two layers:
+ *
+ *   1. Behaviour: `writeCommentCacheThrough` correctly inserts, updates, and
+ *      soft-deletes rows for `created` / `edited` / `deleted` payloads, and
+ *      `loadConversation` reflects the post-edit body. This is the contract
+ *      `src/db/queries/conversation-store.ts:7-13` documents.
+ *
+ *   2. Subscription: `src/app.ts` registers all three issue_comment actions
+ *      with `app.webhooks.on`. This is the source-level invariant: if a
+ *      future edit narrows the subscription back to `created`-only (the
+ *      original bug), the regex match fails and the test fires loudly. Same
+ *      shape as `test/mcp/registry.test.ts`'s build-discovery invariant.
+ *
+ * Skips DB tests when the configured Postgres is unreachable, matching the
+ * pattern in `test/db/queries/proposals-store.test.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { IssueCommentEvent } from "@octokit/webhooks-types";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+
+import { getDb } from "../../../src/db";
+import { loadConversation } from "../../../src/db/queries/conversation-store";
+import { writeCommentCacheThrough } from "../../../src/webhook/events/issue-comment";
+
+const TEST_OWNER = "issue-129-test-owner";
+const TEST_REPO = "issue-129-test-repo";
+const TEST_ISSUE_NUMBER = 12_999;
+const TEST_COMMENT_ID = 99_000_001;
+
+let dbAvailable = false;
+beforeAll(async () => {
+  const db = getDb();
+  if (db === null) return;
+  try {
+    await db`SELECT 1 FROM comment_cache LIMIT 1`;
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+});
+
+const skipIfNoDb = (): boolean => !dbAvailable;
+
+async function cleanup(): Promise<void> {
+  const db = getDb();
+  if (db === null || !dbAvailable) return;
+  await db`DELETE FROM comment_cache WHERE owner = ${TEST_OWNER}`;
+}
+
+beforeEach(cleanup);
+afterAll(cleanup);
+
+function basePayload(
+  action: "created" | "edited" | "deleted",
+  body: string,
+  overrides: { readonly updatedAt?: string } = {},
+): IssueCommentEvent {
+  const createdAt = "2026-05-11T00:00:00Z";
+  const updatedAt = overrides.updatedAt ?? createdAt;
+  return {
+    action,
+    issue: {
+      number: TEST_ISSUE_NUMBER,
+      pull_request: undefined,
+    } as unknown as IssueCommentEvent["issue"],
+    comment: {
+      id: TEST_COMMENT_ID,
+      body,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      user: { login: "alice", type: "User" },
+    } as unknown as IssueCommentEvent["comment"],
+    repository: {
+      name: TEST_REPO,
+      owner: { login: TEST_OWNER },
+    } as unknown as IssueCommentEvent["repository"],
+    sender: { login: "alice", type: "User" } as unknown as IssueCommentEvent["sender"],
+  } as unknown as IssueCommentEvent;
+}
+
+describe("writeCommentCacheThrough: action coverage (issue #129)", () => {
+  it("inserts a row on `created` and `loadConversation` returns it", async () => {
+    if (skipIfNoDb()) return;
+    await writeCommentCacheThrough(basePayload("created", "original body"));
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.comments.length).toBe(1);
+    expect(snap.comments[0]?.body).toBe("original body");
+  });
+
+  it("updates the body on `edited` so loadConversation returns the post-edit body", async () => {
+    if (skipIfNoDb()) return;
+    await writeCommentCacheThrough(basePayload("created", "original body"));
+    await writeCommentCacheThrough(
+      basePayload("edited", "post-edit body", { updatedAt: "2026-05-11T00:05:00Z" }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.comments.length).toBe(1);
+    expect(snap.comments[0]?.body).toBe("post-edit body");
+  });
+
+  it("soft-deletes on `deleted` so loadConversation no longer returns the row", async () => {
+    if (skipIfNoDb()) return;
+    await writeCommentCacheThrough(basePayload("created", "to be removed"));
+    await writeCommentCacheThrough(basePayload("deleted", "to be removed"));
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    // Soft-delete: loadConversation filters `deleted_at IS NULL`, so the row
+    // is invisible to the chat-thread reader.
+    expect(snap.comments.length).toBe(0);
+  });
+});
+
+/**
+ * Subscription-level invariant. Without this, narrowing the array back to
+ * `["issue_comment.created"]` (the exact bug fixed in #129) compiles, passes
+ * every behavioural test (which call `writeCommentCacheThrough` directly),
+ * but ships the regression. A grep-based test is cheap and load-bearing.
+ */
+describe("src/app.ts subscription (issue #129)", () => {
+  const appSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/app.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it.each([["issue_comment.created"], ["issue_comment.edited"], ["issue_comment.deleted"]])(
+    "subscribes to %s",
+    (action) => {
+      // Match the action name as a quoted string in app.ts. Tolerates single or
+      // double quotes. Future array reshuffles or comment changes do not break
+      // the assertion; removing the action name does.
+      // eslint-disable-next-line security/detect-non-literal-regexp -- action comes from this file's hardcoded it.each table, no user input
+      const re = new RegExp(`['"]${action.replace(/\./g, "\\.")}['"]`);
+      expect(appSrc).toMatch(re);
+    },
+  );
+
+  it("registers issue_comment via the multi-action array form, not the single-action form", () => {
+    // Catches a future narrowing back to the regression shape
+    // `app.webhooks.on("issue_comment.created", ...)`.
+    const singleActionForm = /app\.webhooks\.on\(\s*['"]issue_comment\.created['"]\s*,/;
+    expect(appSrc).not.toMatch(singleActionForm);
+  });
+});
+
+/**
+ * Source-level guard on the dispatch ordering inside `handleIssueComment`.
+ * The cache write-through must run for every action (the fix), but dispatch
+ * MUST stay gated to `created` only. A future refactor that moves the early
+ * return below dispatch would silently re-fire workflows on every edit;
+ * this regex assertion fails first.
+ */
+describe("handleIssueComment dispatch gate ordering (issue #129)", () => {
+  const handlerSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/webhook/events/issue-comment.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it("returns early on non-created actions before any dispatch call", () => {
+    const earlyReturn = handlerSrc.indexOf(`if (payload.action !== "created") return;`);
+    expect(earlyReturn, "early-return guard missing").toBeGreaterThan(-1);
+
+    const firstDispatch = Math.min(
+      ...["dispatchByIntent(", "dispatchCommentSurface("]
+        .map((s) => handlerSrc.indexOf(s))
+        .filter((i) => i !== -1),
+    );
+    expect(firstDispatch, "no dispatch call found").toBeGreaterThan(-1);
+    expect(
+      earlyReturn,
+      "early-return must appear BEFORE the first dispatch call site",
+    ).toBeLessThan(firstDispatch);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #129.

`src/app.ts:80` subscribed only `issue_comment.created`, so the chat-thread `comment_cache` write-through inside `handleIssueComment` (which handles all three actions: created/edited/deleted) never fired for edits or deletes. After a user edited a comment to clarify or retract content, the cache kept the original body forever; after a deletion, the soft-delete never ran. The chat-thread executor at `src/workflows/ship/scoped/chat-thread.ts` reads from `comment_cache` on every turn, so it kept reasoning against pre-edit text the user thought they had changed.

The subscription is now the array form `["issue_comment.created", ".edited", ".deleted"]`, mirroring `pull_request_review_comment.*` at `src/app.ts:112-121`. Dispatch behaviour is unchanged: the existing early-return at `src/webhook/events/issue-comment.ts:36` still gates `dispatchByIntent` / `dispatchCommentSurface` to `created`-only, so editing a previously-mentioned comment cannot re-fire the workflow (would be surprising UX and double-bill the user).

## Diagram

```mermaid
flowchart LR
  subgraph LIFE["issue_comment lifecycle"]
    direction TB

    GHE["User edits or deletes<br/>issue comment"] --> WHK["Webhook delivery"]

    WHK --> BFR["src/app.ts before<br/>'issue_comment.created' only"]:::bad
    BFR -->|"created"| BIN["handleIssueComment runs"]:::ok
    BFR -->|"edited or deleted"| BDR["delivery dropped<br/>cache stays stale"]:::bad
    BDR --> BST["chat-thread reads<br/>pre-edit body"]:::bad

    WHK --> AFR["src/app.ts after<br/>array subscription"]:::good
    AFR --> AIN["handleIssueComment runs<br/>for all three actions"]:::good
    AIN --> AGT["early-return at line 36<br/>still gates dispatch to created"]:::good
    AIN --> AWR["writeCommentCacheThrough<br/>updates comment_cache"]:::good
    AWR --> AFR2["chat-thread sees<br/>current GitHub state"]:::good
  end

  classDef bad fill:#7a1f1f,color:#ffffff,stroke:#400,stroke-width:1px
  classDef ok fill:#3d4f63,color:#ffffff,stroke:#1e2937,stroke-width:1px
  classDef good fill:#1f5d3a,color:#ffffff,stroke:#063,stroke-width:1px
```

## Changes

- `src/app.ts` — subscription extended from `"issue_comment.created"` to `["issue_comment.created", ".edited", ".deleted"]`.
- `src/webhook/events/issue-comment.ts` — exported `writeCommentCacheThrough` for testability; added a terse WHY comment above the dispatch early-return to lock in the gate ordering.
- `test/webhook/events/issue-comment-cache.test.ts` (new) — 8 tests across three suites:
  1. DB-backed behaviour for `created` / `edited` / `deleted` payloads asserting `loadConversation` reflects the post-edit body and the soft-delete hides the row.
  2. Source-level subscription invariant: scans `src/app.ts` and asserts every issue_comment action is present, with the regression shape `app.webhooks.on("issue_comment.created", ...)` explicitly forbidden.
  3. Source-level dispatch-gate ordering guard: asserts the early-return appears before any dispatch call site, so a future refactor that moves it below dispatch fails loudly.

## Related Issues

- Closes #129
- Filed #130 to audit the analogous gap on `issues.*` and `pull_request_review.*` subscriptions (out of scope here to avoid PR bloat).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on changed files (one pre-existing warning on `issue-comment.ts:158` is from commit 698694b, not introduced here)
- [x] `bun run format` clean
- [x] `bun test test/webhook/events/issue-comment-cache.test.ts` — 8/8 pass
- [x] Full `bun run test` — 121/121 files pass with `TEST_DATABASE_URL` set
- [x] Verified regression-shape detection: temporarily reverting `src/app.ts` to the single-action form trips the subscription invariant tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub webhook now processes edited and deleted issue comments in addition to newly created ones, enabling more complete comment synchronization.

* **Tests**
  * Added regression tests verifying issue comment cache behavior across creation, editing, and deletion events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/github-app-playground/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->