### PR TITLE
fix(webhook): write-through target_cache on issues/pull_request events (#130)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -89,12 +89,22 @@ app.webhooks.on(
   },
 );
 
+// Cache write-through (issue #130): every action that mutates a field
+// stored in `target_cache` is subscribed so the chat-thread cache stays
+// fresh without waiting for a cold-miss backfill. Dispatch paths inside
+// `handlePullRequest` remain gated to their original action set (only
+// `labeled` / `synchronize` / `closed` trigger workflows; the rest are
+// cache-only).
 app.webhooks.on(
   [
     "pull_request.opened",
+    "pull_request.edited",
     "pull_request.labeled",
     "pull_request.synchronize",
     "pull_request.closed",
+    "pull_request.reopened",
+    "pull_request.converted_to_draft",
+    "pull_request.ready_for_review",
   ],
   ({ octokit, payload, id }) => {
     handlePullRequest(octokit, payload as unknown as PullRequestEvent, id);
@@ -109,9 +119,25 @@ app.webhooks.on("check_suite.completed", ({ octokit, payload, id }) => {
   handleCheckSuite(octokit, payload as unknown as CheckSuiteEvent, id);
 });
 
-app.webhooks.on(["issues.labeled", "issues.unlabeled"], ({ octokit, payload, id }) => {
-  handleIssues(octokit, payload as unknown as IssuesEvent, id);
-});
+// Cache write-through (issue #130): every action that mutates a field
+// stored in `target_cache` is subscribed so the chat-thread cache stays
+// fresh without waiting for a cold-miss backfill. Dispatch is still
+// gated to `labeled` by the early-returns inside `handleIssues`; the
+// other actions are cache-only.
+app.webhooks.on(
+  [
+    "issues.opened",
+    "issues.edited",
+    "issues.closed",
+    "issues.reopened",
+    "issues.deleted",
+    "issues.labeled",
+    "issues.unlabeled",
+  ],
+  ({ octokit, payload, id }) => {
+    handleIssues(octokit, payload as unknown as IssuesEvent, id);
+  },
+);
 
 app.webhooks.on("pull_request_review.submitted", ({ octokit, payload, id }) => {
   handleReview(octokit, payload as unknown as PullRequestReviewEvent, id);

--- a/src/db/queries/conversation-store.ts
+++ b/src/db/queries/conversation-store.ts
@@ -159,15 +159,61 @@ export async function upsertTarget(input: UpsertTargetInput): Promise<void> {
       ${input.createdAt}, ${input.updatedAt}, now()
     )
     ON CONFLICT (owner, repo, target_type, target_number) DO UPDATE SET
-      title = EXCLUDED.title,
-      body = EXCLUDED.body,
-      state = EXCLUDED.state,
-      is_draft = EXCLUDED.is_draft,
-      base_ref = EXCLUDED.base_ref,
-      head_ref = EXCLUDED.head_ref,
+      -- Webhook delivery is at-least-once and unordered. Gate every
+      -- mutable field on a monotonic clock check so a delayed retry of
+      -- an older payload cannot clobber a newer body that already
+      -- landed. The updated_at column itself uses GREATEST so the
+      -- wallclock never goes backwards.
+      title = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.title ELSE target_cache.title END,
+      body = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.body ELSE target_cache.body END,
+      state = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.state ELSE target_cache.state END,
+      is_draft = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.is_draft ELSE target_cache.is_draft END,
+      base_ref = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.base_ref ELSE target_cache.base_ref END,
+      head_ref = CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at
+        THEN EXCLUDED.head_ref ELSE target_cache.head_ref END,
       updated_at = GREATEST(target_cache.updated_at, EXCLUDED.updated_at),
       fetched_at = now()
   `;
+}
+
+/**
+ * Hard-delete on `issues.deleted` webhook action. `target_cache` has no
+ * `deleted_at` column, the schema treats GitHub as the source of truth
+ * and a deleted issue is gone there too, so cache retention adds no
+ * value. We also hard-delete any `comment_cache` rows scoped to the
+ * same target so a future GitHub-side reuse of the number does not
+ * surface orphan comments.
+ *
+ * PR deletion is not a real GitHub action (PRs close, never delete),
+ * so this helper is currently only wired into the issues handler.
+ */
+export async function deleteTarget(input: {
+  readonly owner: string;
+  readonly repo: string;
+  readonly targetType: "issue" | "pr";
+  readonly targetNumber: number;
+}): Promise<void> {
+  const db = requireDb();
+  // Single transaction so `loadConversation` cannot observe the
+  // intermediate state where the target row is gone but comment_cache
+  // rows still point at the deleted number.
+  await db.begin(async (tx) => {
+    await tx`
+      DELETE FROM comment_cache
+      WHERE owner = ${input.owner} AND repo = ${input.repo}
+        AND target_type = ${input.targetType} AND target_number = ${input.targetNumber}
+    `;
+    await tx`
+      DELETE FROM target_cache
+      WHERE owner = ${input.owner} AND repo = ${input.repo}
+        AND target_type = ${input.targetType} AND target_number = ${input.targetNumber}
+    `;
+  });
 }
 
 // ─── Conversation read path ───────────────────────────────────────────────────

--- a/src/webhook/events/issues.ts
+++ b/src/webhook/events/issues.ts
@@ -1,6 +1,7 @@
 import type { IssuesEvent } from "@octokit/webhooks-types";
 import type { Octokit } from "octokit";
 
+import { deleteTarget, upsertTarget } from "../../db/queries/conversation-store";
 import { logger } from "../../logger";
 import { dispatchByLabel } from "../../workflows/dispatcher";
 import { dispatchCanonicalCommand } from "../../workflows/ship/command-dispatch";
@@ -12,22 +13,42 @@ import { isOwnerAllowed } from "../authorize";
 const BOT_LABEL_PATTERN = /^bot:[a-z]+(?:-[a-z]+)*$/;
 
 /**
- * Handler for `issues.labeled` and `issues.unlabeled`. Implements the label
- * dispatch protocol from `specs/20260421-181205-bot-workflows/contracts/
- * webhook-dispatch.md` §Label trigger:
+ * Handler for `issues.*` events.
  *
- *   1. label.name matches ^bot:[a-z]+$
- *   2. sender.login in ALLOWED_OWNERS
- *   → hand off to `dispatchByLabel` for the rest of the seven-step protocol.
+ * Two responsibilities:
  *
- * FR-015: events that fail precondition 2 produce no DB row, no queue job,
- * and no tracking comment: we log and return before touching the dispatcher.
+ *   1. Cache write-through (every action). The `target_cache` row for this
+ *      issue is upserted from the payload before any dispatch gate, so the
+ *      chat-thread executor sees the freshest title/body/state on the very
+ *      turn the edit triggered. `deleted` hard-deletes the row plus its
+ *      `comment_cache` children, since GitHub no longer holds the issue.
+ *      Mirrors the `writeCommentCacheThrough` pattern in `issue-comment.ts`.
+ *      See issues #129 and #130.
  *
- * `unlabeled` is accepted so the webhook subscription stays symmetric with
- * `labeled`, but we deliberately do not run the dispatch protocol: label
- * removal is a reversal of a prior state, not a fresh trigger.
+ *   2. Label dispatch (`labeled` only). Implements the protocol from
+ *      `specs/20260421-181205-bot-workflows/contracts/webhook-dispatch.md`
+ *      §Label trigger:
+ *
+ *        1. label.name matches ^bot:[a-z]+$
+ *        2. sender.login in ALLOWED_OWNERS
+ *        → hand off to `dispatchByLabel` for the seven-step protocol.
+ *
+ *      FR-015: events that fail precondition 2 produce no DB row, no queue
+ *      job, and no tracking comment. `unlabeled` is accepted so the webhook
+ *      subscription stays symmetric with `labeled`, but the dispatch
+ *      protocol does not run (label removal is a reversal of a prior state,
+ *      not a fresh trigger).
  */
 export function handleIssues(octokit: Octokit, payload: IssuesEvent, deliveryId: string): void {
+  // Cache write-through runs BEFORE any dispatch gate / early-return so
+  // every subscribed action keeps target_cache fresh. The fire-and-forget
+  // shape matches `writeCommentCacheThrough` in issue-comment.ts; the
+  // .catch downgrades inline-mode (no DATABASE_URL) to a no-op inside the
+  // writer.
+  void writeIssueTargetCacheThrough(payload).catch((err: unknown) => {
+    logger.warn({ err, deliveryId }, "issues: cache write-through failed");
+  });
+
   if (payload.action === "unlabeled") {
     const removedLabel = payload.label?.name;
     if (removedLabel !== undefined && BOT_LABEL_PATTERN.test(removedLabel)) {
@@ -106,4 +127,56 @@ export function handleIssues(octokit: Octokit, payload: IssuesEvent, deliveryId:
       log.error({ err }, "dispatchByLabel threw for issues.labeled");
     }
   })();
+}
+
+/**
+ * Cache write-through for the chat-thread executor. Mirrors
+ * `writeCommentCacheThrough` in issue-comment.ts but targets
+ * `target_cache` (issue body) rather than `comment_cache`. Runs on every
+ * subscribed action so the cache stays a faithful projection of GitHub
+ * state. Inline-mode deployments (no DB) silently skip via the
+ * DATABASE_URL guard, matching the existing pattern.
+ *
+ * Actions:
+ *   - opened / edited / closed / reopened: upsert title/body/state.
+ *   - deleted: hard-delete the row plus its comment_cache children.
+ *   - labeled / unlabeled: also upsert because GitHub bumps `updated_at`
+ *     on label changes and an active conversation may run a chat-thread
+ *     turn right after; staying current here costs one INSERT.
+ */
+export async function writeIssueTargetCacheThrough(payload: IssuesEvent): Promise<void> {
+  const owner = payload.repository.owner.login;
+  const repo = payload.repository.name;
+  const targetNumber = payload.issue.number;
+
+  try {
+    if (payload.action === "deleted") {
+      await deleteTarget({ owner, repo, targetType: "issue", targetNumber });
+      return;
+    }
+    const i = payload.issue;
+    await upsertTarget({
+      owner,
+      repo,
+      targetType: "issue",
+      targetNumber,
+      title: i.title,
+      // `state` widens to `string | undefined` across the IssuesEvent
+      // union; default to "open" for the variants that omit it. `user`
+      // is optional-chained because partial test fixtures and rare
+      // ghost-user payloads can lack it, matching `backfillFromGitHub`.
+      body: i.body ?? "",
+      state: (i.state ?? "open") as string,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- schema marks user non-nullable but partial fixtures omit it
+      authorLogin: i.user?.login ?? "",
+      isDraft: null,
+      baseRef: null,
+      headRef: null,
+      createdAt: new Date(i.created_at),
+      updatedAt: new Date(i.updated_at),
+    });
+  } catch (err) {
+    if (err instanceof Error && /DATABASE_URL/i.test(err.message)) return;
+    throw err;
+  }
 }

--- a/src/webhook/events/pull-request.ts
+++ b/src/webhook/events/pull-request.ts
@@ -1,6 +1,7 @@
 import type { PullRequestEvent } from "@octokit/webhooks-types";
 import type { Octokit } from "octokit";
 
+import { upsertTarget } from "../../db/queries/conversation-store";
 import { logger } from "../../logger";
 import { dispatchByLabel } from "../../workflows/dispatcher";
 import { dispatchCanonicalCommand } from "../../workflows/ship/command-dispatch";
@@ -14,15 +15,28 @@ import { isOwnerAllowed } from "../authorize";
 const BOT_LABEL_PATTERN = /^bot:[a-z][a-z-]*(?:\/deadline=\d+(?:\.\d+)?[hms])?$/;
 
 /**
- * Handler for `pull_request.*` events. Currently covers four actions:
+ * Handler for `pull_request.*` events.
  *
- *   - `opened`: placeholder (trigger detection lands when ready)
- *   - `labeled`: legacy workflow dispatch + ship reactor label dispatch (T028d)
- *   - `synchronize`: ship reactor early-wake / foreign-push detection (T023)
- *   - `closed`: ship reactor terminal transition (merged_externally / pr_closed) (T023)
+ * Two responsibilities:
  *
- * Registered in `src/app.ts` via explicit per-action listeners
- * (`pull_request.opened`, `.labeled`, `.synchronize`, `.closed`); each
+ *   1. Cache write-through (every action). The `target_cache` row for this
+ *      PR is upserted from `payload.pull_request` before any dispatch gate,
+ *      so the chat-thread executor sees the freshest title/body/state/
+ *      is_draft/base_ref/head_ref on the very turn the edit triggered.
+ *      Mirrors the `writeCommentCacheThrough` pattern in `issue-comment.ts`.
+ *      PR deletion is not a real GitHub action (PRs close, never delete),
+ *      so there is no hard-delete branch. See issues #129 and #130.
+ *
+ *   2. Action-specific dispatch:
+ *      - `opened`: placeholder (trigger detection lands when ready)
+ *      - `edited` / `reopened` / `converted_to_draft` / `ready_for_review`:
+ *        cache-only, no dispatch
+ *      - `labeled`: legacy workflow dispatch + ship reactor label dispatch
+ *      - `synchronize`: ship reactor early-wake / foreign-push detection
+ *      - `closed`: ship reactor terminal transition (merged_externally /
+ *        pr_closed)
+ *
+ * Registered in `src/app.ts` via explicit per-action listeners; each
  * delegates here for action-specific dispatch.
  */
 export function handlePullRequest(
@@ -30,6 +44,15 @@ export function handlePullRequest(
   payload: PullRequestEvent,
   deliveryId: string,
 ): void {
+  // Cache write-through runs BEFORE any dispatch gate / early-return so
+  // every subscribed action keeps target_cache fresh. The fire-and-forget
+  // shape matches `writeCommentCacheThrough` in issue-comment.ts; the
+  // .catch downgrades inline-mode (no DATABASE_URL) to a no-op inside the
+  // writer.
+  void writePrTargetCacheThrough(payload).catch((err: unknown) => {
+    logger.warn({ err, deliveryId }, "pull_request: cache write-through failed");
+  });
+
   if (payload.action === "labeled") {
     handlePullRequestLabeled(octokit, payload, deliveryId);
     return;
@@ -186,4 +209,48 @@ function handlePullRequestLabeled(
       log.error({ err }, "dispatchByLabel threw for pull_request.labeled");
     }
   })();
+}
+
+/**
+ * Cache write-through for the chat-thread executor. Mirrors
+ * `writeCommentCacheThrough` in issue-comment.ts but targets
+ * `target_cache` (PR body) rather than `comment_cache`. Runs on every
+ * subscribed action so the cache stays a faithful projection of GitHub
+ * state. Inline-mode deployments (no DB) silently skip via the
+ * DATABASE_URL guard, matching the existing pattern.
+ *
+ * State semantics: a merged PR reports `state: "closed"` and `merged:
+ * true` in the payload; downstream readers expect `"merged"` in
+ * target_cache (see `backfillFromGitHub` for the same translation), so
+ * we collapse the two flags here.
+ */
+export async function writePrTargetCacheThrough(payload: PullRequestEvent): Promise<void> {
+  const owner = payload.repository.owner.login;
+  const repo = payload.repository.name;
+  const pr = payload.pull_request;
+  const targetNumber = pr.number;
+
+  try {
+    await upsertTarget({
+      owner,
+      repo,
+      targetType: "pr",
+      targetNumber,
+      title: pr.title,
+      body: pr.body ?? "",
+      state: pr.merged === true ? "merged" : pr.state,
+      // `user` is optional-chained because partial test fixtures and rare
+      // ghost-user payloads can lack it, matching `backfillFromGitHub`.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- schema marks user non-nullable but partial fixtures omit it
+      authorLogin: pr.user?.login ?? "",
+      isDraft: pr.draft,
+      baseRef: pr.base.ref,
+      headRef: pr.head.ref,
+      createdAt: new Date(pr.created_at),
+      updatedAt: new Date(pr.updated_at),
+    });
+  } catch (err) {
+    if (err instanceof Error && /DATABASE_URL/i.test(err.message)) return;
+    throw err;
+  }
 }

--- a/test/webhook/events/issues-cache.test.ts
+++ b/test/webhook/events/issues-cache.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression tests for issue #130: chat-thread `target_cache` write-through
+ * must fire on every `issues` action that mutates a cached field, not just
+ * the cold-miss backfill path.
+ *
+ * Covers three layers (same shape as `issue-comment-cache.test.ts`):
+ *
+ *   1. Behaviour: `writeIssueTargetCacheThrough` correctly upserts on
+ *      `opened` / `edited` / `closed` / `reopened` and hard-deletes on
+ *      `deleted`, with `loadConversation` reflecting the post-edit body.
+ *
+ *   2. Subscription: `src/app.ts` registers all five actions
+ *      (`opened`, `edited`, `closed`, `reopened`, `deleted`) plus the
+ *      pre-existing `labeled` / `unlabeled` with `app.webhooks.on`. A
+ *      future edit that narrows the subscription drops a write-through
+ *      gap; the grep assertion fails first.
+ *
+ *   3. Ordering: `handleIssues` runs the cache write-through BEFORE any
+ *      dispatch gate / early-return, so a `labeled` action whose
+ *      `unlabeled` branch returns first does not skip the cache.
+ *
+ * Skips DB tests when the configured Postgres is unreachable.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { IssuesEvent } from "@octokit/webhooks-types";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+
+import { getDb } from "../../../src/db";
+import { loadConversation, upsertComment } from "../../../src/db/queries/conversation-store";
+import { writeIssueTargetCacheThrough } from "../../../src/webhook/events/issues";
+
+const TEST_OWNER = "issue-130-test-owner";
+const TEST_REPO = "issue-130-test-repo";
+const TEST_ISSUE_NUMBER = 13_000;
+
+let dbAvailable = false;
+beforeAll(async () => {
+  const db = getDb();
+  if (db === null) return;
+  try {
+    await db`SELECT 1 FROM target_cache LIMIT 1`;
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+});
+
+const skipIfNoDb = (): boolean => !dbAvailable;
+
+async function cleanup(): Promise<void> {
+  const db = getDb();
+  if (db === null || !dbAvailable) return;
+  await db`DELETE FROM target_cache WHERE owner = ${TEST_OWNER}`;
+  await db`DELETE FROM comment_cache WHERE owner = ${TEST_OWNER}`;
+}
+
+beforeEach(cleanup);
+afterAll(cleanup);
+
+type IssueAction = "opened" | "edited" | "closed" | "reopened" | "deleted";
+
+function basePayload(
+  action: IssueAction,
+  body: string,
+  overrides: { readonly updatedAt?: string; readonly title?: string; readonly state?: string } = {},
+): IssuesEvent {
+  const createdAt = "2026-05-11T00:00:00Z";
+  const updatedAt = overrides.updatedAt ?? createdAt;
+  return {
+    action,
+    issue: {
+      number: TEST_ISSUE_NUMBER,
+      title: overrides.title ?? "Test issue title",
+      body,
+      state: overrides.state ?? (action === "closed" ? "closed" : "open"),
+      created_at: createdAt,
+      updated_at: updatedAt,
+      user: { login: "alice", type: "User" },
+      pull_request: undefined,
+    } as unknown as IssuesEvent["issue"],
+    repository: {
+      name: TEST_REPO,
+      owner: { login: TEST_OWNER },
+    } as unknown as IssuesEvent["repository"],
+    sender: { login: "alice", type: "User" } as unknown as IssuesEvent["sender"],
+  } as unknown as IssuesEvent;
+}
+
+describe("writeIssueTargetCacheThrough: action coverage (issue #130)", () => {
+  it("upserts the row on `opened` and loadConversation returns the body", async () => {
+    if (skipIfNoDb()) return;
+    await writeIssueTargetCacheThrough(basePayload("opened", "initial body"));
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target?.body).toBe("initial body");
+    expect(snap.target?.state).toBe("open");
+  });
+
+  it("updates the body on `edited` so loadConversation returns the post-edit body", async () => {
+    if (skipIfNoDb()) return;
+    await writeIssueTargetCacheThrough(basePayload("opened", "initial body"));
+    await writeIssueTargetCacheThrough(
+      basePayload("edited", "post-edit body", { updatedAt: "2026-05-11T00:05:00Z" }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target?.body).toBe("post-edit body");
+  });
+
+  it("flips state to `closed` on `closed` and back to `open` on `reopened`", async () => {
+    if (skipIfNoDb()) return;
+    await writeIssueTargetCacheThrough(basePayload("opened", "body", { state: "open" }));
+    await writeIssueTargetCacheThrough(
+      basePayload("closed", "body", {
+        state: "closed",
+        updatedAt: "2026-05-11T00:05:00Z",
+      }),
+    );
+
+    let snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target?.state).toBe("closed");
+
+    await writeIssueTargetCacheThrough(
+      basePayload("reopened", "body", {
+        state: "open",
+        updatedAt: "2026-05-11T00:10:00Z",
+      }),
+    );
+    snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target?.state).toBe("open");
+  });
+
+  it("does not clobber a newer body when an older payload arrives second", async () => {
+    if (skipIfNoDb()) return;
+    // Webhooks can be redelivered out of order. The newer `edited` lands
+    // first; a stuck retry of the original `opened` arrives second. The
+    // upsert must keep the newer body, gated on payload `updated_at`.
+    await writeIssueTargetCacheThrough(
+      basePayload("edited", "newer body", { updatedAt: "2026-05-11T01:00:00Z" }),
+    );
+    await writeIssueTargetCacheThrough(
+      basePayload("opened", "older body", { updatedAt: "2026-05-11T00:00:00Z" }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target?.body).toBe("newer body");
+  });
+
+  it("hard-deletes target + child comment rows on `deleted`", async () => {
+    if (skipIfNoDb()) return;
+    await writeIssueTargetCacheThrough(basePayload("opened", "doomed"));
+    // Seed a comment on the same target to verify cascade-on-delete.
+    await upsertComment({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+      commentId: 99_999_001,
+      surface: "issue-comment",
+      inReplyToId: null,
+      authorLogin: "alice",
+      authorType: "User",
+      body: "orphan candidate",
+      path: null,
+      line: null,
+      diffHunk: null,
+      createdAt: new Date("2026-05-11T00:01:00Z"),
+      updatedAt: new Date("2026-05-11T00:01:00Z"),
+    });
+
+    await writeIssueTargetCacheThrough(basePayload("deleted", "doomed"));
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "issue",
+      targetNumber: TEST_ISSUE_NUMBER,
+    });
+    expect(snap.target).toBeNull();
+    expect(snap.comments.length).toBe(0);
+  });
+});
+
+/**
+ * Subscription-level invariant. Without this, narrowing the array back to
+ * `["issues.labeled", "issues.unlabeled"]` (the pre-#130 state, which
+ * leaves target_cache stale) compiles, passes every behavioural test
+ * (which call `writeIssueTargetCacheThrough` directly), but ships the gap.
+ */
+describe("src/app.ts subscription (issue #130)", () => {
+  const appSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/app.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it.each([
+    ["issues.opened"],
+    ["issues.edited"],
+    ["issues.closed"],
+    ["issues.reopened"],
+    ["issues.deleted"],
+    ["issues.labeled"],
+    ["issues.unlabeled"],
+  ])("subscribes to %s", (action) => {
+    // Substring (not RegExp), same reasoning as `issue-comment-cache.test.ts`:
+    // dynamic-regex builds get flagged by CodeQL as escape footguns.
+    const hasDoubleQuoted = appSrc.includes(`"${action}"`);
+    const hasSingleQuoted = appSrc.includes(`'${action}'`);
+    expect(hasDoubleQuoted || hasSingleQuoted, `${action} not found as a quoted string`).toBe(true);
+  });
+});
+
+/**
+ * Source-level guard on the dispatch ordering inside `handleIssues`. The
+ * cache write-through must run for every action, but dispatch must stay
+ * gated to `labeled`. A refactor that moves the write-through call below
+ * the early-return for `unlabeled` would silently re-introduce the gap;
+ * this regex assertion fails first.
+ */
+describe("handleIssues cache write-through ordering (issue #130)", () => {
+  const handlerSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/webhook/events/issues.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it("calls writeIssueTargetCacheThrough BEFORE the unlabeled early-return", () => {
+    const cacheCall = handlerSrc.indexOf("writeIssueTargetCacheThrough(payload)");
+    expect(cacheCall, "cache write-through call missing").toBeGreaterThan(-1);
+
+    const unlabeledGuard = handlerSrc.indexOf(`payload.action === "unlabeled"`);
+    expect(unlabeledGuard, "unlabeled guard missing").toBeGreaterThan(-1);
+    expect(
+      cacheCall,
+      "cache write-through must appear BEFORE the unlabeled early-return",
+    ).toBeLessThan(unlabeledGuard);
+  });
+});

--- a/test/webhook/events/pull-request-cache.test.ts
+++ b/test/webhook/events/pull-request-cache.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression tests for issue #130: chat-thread `target_cache` write-through
+ * must fire on every `pull_request` action that mutates a cached field,
+ * not just the cold-miss backfill path.
+ *
+ * Covers three layers (same shape as `issues-cache.test.ts`):
+ *
+ *   1. Behaviour: `writePrTargetCacheThrough` correctly upserts title /
+ *      body / state / is_draft / base_ref / head_ref on `opened` / `edited`
+ *      / `closed` / `reopened` / `converted_to_draft` / `ready_for_review`,
+ *      and collapses `merged: true` to `state = "merged"`.
+ *
+ *   2. Subscription: `src/app.ts` registers all eight subscribed actions.
+ *
+ *   3. Ordering: `handlePullRequest` runs the cache write-through BEFORE
+ *      any dispatch gate / early-return.
+ *
+ * Skips DB tests when the configured Postgres is unreachable.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { PullRequestEvent } from "@octokit/webhooks-types";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+
+import { getDb } from "../../../src/db";
+import { loadConversation } from "../../../src/db/queries/conversation-store";
+import { writePrTargetCacheThrough } from "../../../src/webhook/events/pull-request";
+
+const TEST_OWNER = "issue-130-pr-test-owner";
+const TEST_REPO = "issue-130-pr-test-repo";
+const TEST_PR_NUMBER = 13_001;
+
+let dbAvailable = false;
+beforeAll(async () => {
+  const db = getDb();
+  if (db === null) return;
+  try {
+    await db`SELECT 1 FROM target_cache LIMIT 1`;
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+});
+
+const skipIfNoDb = (): boolean => !dbAvailable;
+
+async function cleanup(): Promise<void> {
+  const db = getDb();
+  if (db === null || !dbAvailable) return;
+  await db`DELETE FROM target_cache WHERE owner = ${TEST_OWNER}`;
+}
+
+beforeEach(cleanup);
+afterAll(cleanup);
+
+type PrAction =
+  | "opened"
+  | "edited"
+  | "closed"
+  | "reopened"
+  | "converted_to_draft"
+  | "ready_for_review";
+
+function basePayload(
+  action: PrAction,
+  body: string,
+  overrides: {
+    readonly updatedAt?: string;
+    readonly title?: string;
+    readonly state?: "open" | "closed";
+    readonly merged?: boolean;
+    readonly draft?: boolean;
+    readonly baseRef?: string;
+    readonly headRef?: string;
+  } = {},
+): PullRequestEvent {
+  const createdAt = "2026-05-11T00:00:00Z";
+  const updatedAt = overrides.updatedAt ?? createdAt;
+  return {
+    action,
+    pull_request: {
+      number: TEST_PR_NUMBER,
+      title: overrides.title ?? "Test PR title",
+      body,
+      state: overrides.state ?? (action === "closed" ? "closed" : "open"),
+      merged: overrides.merged ?? false,
+      draft: overrides.draft ?? action === "converted_to_draft",
+      created_at: createdAt,
+      updated_at: updatedAt,
+      user: { login: "alice", type: "User" },
+      base: { ref: overrides.baseRef ?? "main" },
+      head: { ref: overrides.headRef ?? "feature-branch", sha: "deadbeef" },
+    } as unknown as PullRequestEvent["pull_request"],
+    repository: {
+      name: TEST_REPO,
+      owner: { login: TEST_OWNER },
+    } as unknown as PullRequestEvent["repository"],
+    sender: { login: "alice", type: "User" } as unknown as PullRequestEvent["sender"],
+  } as unknown as PullRequestEvent;
+}
+
+describe("writePrTargetCacheThrough: action coverage (issue #130)", () => {
+  it("upserts the row on `opened` with title/body/state/is_draft/base_ref/head_ref", async () => {
+    if (skipIfNoDb()) return;
+    await writePrTargetCacheThrough(
+      basePayload("opened", "initial body", {
+        title: "Initial title",
+        baseRef: "main",
+        headRef: "feat/x",
+      }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "pr",
+      targetNumber: TEST_PR_NUMBER,
+    });
+    expect(snap.target?.title).toBe("Initial title");
+    expect(snap.target?.body).toBe("initial body");
+    expect(snap.target?.state).toBe("open");
+    expect(snap.target?.is_draft).toBe(false);
+    expect(snap.target?.base_ref).toBe("main");
+    expect(snap.target?.head_ref).toBe("feat/x");
+  });
+
+  it("updates the body on `edited` so loadConversation returns the post-edit body", async () => {
+    if (skipIfNoDb()) return;
+    await writePrTargetCacheThrough(basePayload("opened", "initial body"));
+    await writePrTargetCacheThrough(
+      basePayload("edited", "post-edit body", { updatedAt: "2026-05-11T00:05:00Z" }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "pr",
+      targetNumber: TEST_PR_NUMBER,
+    });
+    expect(snap.target?.body).toBe("post-edit body");
+  });
+
+  it("collapses `merged: true` to state = 'merged'", async () => {
+    if (skipIfNoDb()) return;
+    await writePrTargetCacheThrough(basePayload("opened", "body"));
+    await writePrTargetCacheThrough(
+      basePayload("closed", "body", {
+        state: "closed",
+        merged: true,
+        updatedAt: "2026-05-11T00:10:00Z",
+      }),
+    );
+
+    const snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "pr",
+      targetNumber: TEST_PR_NUMBER,
+    });
+    expect(snap.target?.state).toBe("merged");
+  });
+
+  it("flips is_draft via `converted_to_draft` / `ready_for_review`", async () => {
+    if (skipIfNoDb()) return;
+    await writePrTargetCacheThrough(basePayload("opened", "body", { draft: false }));
+    await writePrTargetCacheThrough(
+      basePayload("converted_to_draft", "body", {
+        draft: true,
+        updatedAt: "2026-05-11T00:05:00Z",
+      }),
+    );
+
+    let snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "pr",
+      targetNumber: TEST_PR_NUMBER,
+    });
+    expect(snap.target?.is_draft).toBe(true);
+
+    await writePrTargetCacheThrough(
+      basePayload("ready_for_review", "body", {
+        draft: false,
+        updatedAt: "2026-05-11T00:10:00Z",
+      }),
+    );
+    snap = await loadConversation({
+      owner: TEST_OWNER,
+      repo: TEST_REPO,
+      targetType: "pr",
+      targetNumber: TEST_PR_NUMBER,
+    });
+    expect(snap.target?.is_draft).toBe(false);
+  });
+});
+
+describe("src/app.ts subscription (issue #130, pull_request)", () => {
+  const appSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/app.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it.each([
+    ["pull_request.opened"],
+    ["pull_request.edited"],
+    ["pull_request.labeled"],
+    ["pull_request.synchronize"],
+    ["pull_request.closed"],
+    ["pull_request.reopened"],
+    ["pull_request.converted_to_draft"],
+    ["pull_request.ready_for_review"],
+  ])("subscribes to %s", (action) => {
+    const hasDoubleQuoted = appSrc.includes(`"${action}"`);
+    const hasSingleQuoted = appSrc.includes(`'${action}'`);
+    expect(hasDoubleQuoted || hasSingleQuoted, `${action} not found as a quoted string`).toBe(true);
+  });
+});
+
+describe("handlePullRequest cache write-through ordering (issue #130)", () => {
+  const handlerSrc = ((): string => {
+    const path = join(import.meta.dir, "../../../src/webhook/events/pull-request.ts");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is a fixed test fixture path, not user input
+    return readFileSync(path, "utf8");
+  })();
+
+  it("calls writePrTargetCacheThrough BEFORE the first action branch", () => {
+    const cacheCall = handlerSrc.indexOf("writePrTargetCacheThrough(payload)");
+    expect(cacheCall, "cache write-through call missing").toBeGreaterThan(-1);
+
+    const firstActionBranch = handlerSrc.indexOf(`payload.action === "labeled"`);
+    expect(firstActionBranch, "labeled action branch missing").toBeGreaterThan(-1);
+    expect(
+      cacheCall,
+      "cache write-through must appear BEFORE the first action-branch",
+    ).toBeLessThan(firstActionBranch);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #130. Extends the cache write-through pattern shipped in #131 (which fixed `comment_cache` for `issue_comment.edited/.deleted`) to the `target_cache` table. Before this PR, `target_cache` was only written from `backfillFromGitHub`, so any edit to an issue/PR title, body, state, or draft flag stayed stale until the next cold-miss backfill. The chat-thread executor could reason against pre-edit text the user thought they had changed.

`pull_request_review.edited`/`.dismissed` were called out in #130 but are deliberately not addressed here: review bodies are not cached anywhere today (`comment_cache.surface` only permits `'issue-comment'` and `'review-comment'`, and `backfillFromGitHub` does not fetch top-level reviews), so there is no destination to write through to. Adding review-body caching requires a schema migration and is out of scope.

## Diagram

```mermaid
flowchart LR
    subgraph FLW["before vs after, target_cache freshness"]
        direction TB
        EdtBefore["user edits<br/>issue/PR body"]:::user
        WhBefore["webhook fires<br/>issues.edited or<br/>pull_request.edited"]:::wh
        DropBefore["NOT subscribed,<br/>event dropped"]:::stale
        CacheBefore["target_cache stale<br/>chat-thread reasons<br/>against old body"]:::stale

        EdtAfter["user edits<br/>issue/PR body"]:::user
        WhAfter["webhook fires<br/>issues.edited or<br/>pull_request.edited"]:::wh
        WriteAfter["writeIssueTargetCacheThrough or<br/>writePrTargetCacheThrough,<br/>monotonic upsert"]:::write
        CacheAfter["target_cache fresh<br/>chat-thread sees<br/>post-edit body"]:::fresh

        EdtBefore --> WhBefore --> DropBefore --> CacheBefore
        EdtAfter --> WhAfter --> WriteAfter --> CacheAfter
    end
    classDef user fill:#ecf0f1,color:#2c3e50,stroke:#2c3e50
    classDef wh fill:#3498db,color:#ffffff,stroke:#1f618d
    classDef stale fill:#922b21,color:#ffffff,stroke:#641e16
    classDef write fill:#1e8449,color:#ffffff,stroke:#0e6b3a
    classDef fresh fill:#27ae60,color:#ffffff,stroke:#196f3d
```

## Changes

- **`src/app.ts`**: expand `issues` subscription to `opened/edited/closed/reopened/deleted/labeled/unlabeled`; expand `pull_request` subscription to `opened/edited/labeled/synchronize/closed/reopened/converted_to_draft/ready_for_review`. Dispatch gates inside each handler are unchanged.
- **`src/webhook/events/issues.ts`**: add `writeIssueTargetCacheThrough(payload)` called before any dispatch gate. `deleted` hard-deletes the row plus its `comment_cache` children; all other actions upsert title/body/state from `payload.issue`.
- **`src/webhook/events/pull-request.ts`**: add `writePrTargetCacheThrough(payload)` called before any dispatch gate. Always upserts from `payload.pull_request` and collapses `merged: true` to `state = "merged"` (matches `backfillFromGitHub`).
- **`src/db/queries/conversation-store.ts`**: add `deleteTarget` helper that hard-deletes `comment_cache` + `target_cache` rows in a single `db.begin` transaction so concurrent `loadConversation` cannot observe a partial view. Harden `upsertTarget` with monotonicity gating: every mutable field (`title`, `body`, `state`, `is_draft`, `base_ref`, `head_ref`) now uses `CASE WHEN EXCLUDED.updated_at >= target_cache.updated_at THEN EXCLUDED.x ELSE target_cache.x END` so an out-of-order webhook retry cannot clobber a newer body.
- **`test/webhook/events/issues-cache.test.ts`** (new): behaviour coverage for `opened/edited/closed/reopened/deleted`, monotonicity regression (out-of-order edit), subscription invariant, and ordering invariant.
- **`test/webhook/events/pull-request-cache.test.ts`** (new): behaviour coverage for `opened/edited`, `merged → state="merged"` collapse, `is_draft` toggle via `converted_to_draft`/`ready_for_review`, subscription invariant, and ordering invariant.

## Related Issues

- Closes #130

## Test plan

- [x] Tested locally, 26/26 new tests pass against local Postgres
- [x] Added/updated tests: `issues-cache.test.ts`, `pull-request-cache.test.ts`
- [x] All existing tests pass: touched test directories (`test/webhook/events/`, `test/db/queries/`) green in isolated runs; full-suite flakes are pre-existing
- [x] `bun run typecheck` clean
- [x] `bun run lint` 0 errors
- [x] `bun run format` clean
