### PR TITLE
ci(docs-gates): scan root-level Markdown for version and citation drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Five workflow files form the pipeline; each owns one responsibility.
 | `.github/workflows/release.yml`      | `workflow_dispatch` only (manual)                         | Calls `ci.yml` → semantic-release prod → calls `docker-build.yml`                                                                                                                                                         |
 | `.github/workflows/docker-build.yml` | `workflow_call` + `workflow_dispatch`                     | Reusable image builder: matrix split-and-merge (amd64 on `ubuntu-24.04` + arm64 on `ubuntu-24.04-arm`), SLSA v1 provenance + SBOM attestations (BuildKit + Sigstore), `gh attestation verify` regression gate, Trivy scan |
 
-- **Bun version is single-sourced** via `.tool-versions` (`bun 1.3.12`). All workflows use `oven-sh/setup-bun@v2` with `bun-version-file: .tool-versions`.
+- **Bun version is single-sourced** via `.tool-versions` (`bun 1.3.13`). All workflows use `oven-sh/setup-bun@v2` with `bun-version-file: .tool-versions`.
 - **`audit:ci` (`scripts/audit-ci.ts`)** wraps `bun audit --json` to gate on severity: blocks on high+critical, warns on moderate+low, with an inline `IGNORED` GHSA allowlist (each entry must carry an `expires` date). Required because `bun audit` exits 1 on **any** finding regardless of `--audit-level`.
 - **Semantic release config** (`release.config.mjs`) is single-file with `SEMREL_CHANNEL=dev|prod` env switching: replaces the previous file-swap hack.
 - **Prod releases are manual.** Push to main only triggers `ci.yml` (sanity). Cut a release with `gh workflow run release.yml`.
@@ -153,8 +153,8 @@ Validate locally with `bun run docs:build` before pushing. If no matching doc ex
 
 **CI-enforced doc gates.** Two project-specific checks run in `.github/workflows/docs.yml` ahead of `mkdocs build --strict` (which only validates internal links and snippet targets, not prose-vs-source agreement):
 
-- Bun version strings in `docs/` are pinned to `.tool-versions` via `bun run scripts/check-docs-versions.ts` (also asserts `package.json` `engines.bun` / `packageManager` and the two `Dockerfile.*` `FROM oven/bun:<ver>` lines agree).
-- `src/<file>:<line>` citations in `docs/` are anchor-verified via `bun run scripts/check-docs-citations.ts` (file must exist; cited line / range must be in bounds).
+- Bun version strings in `docs/` **and root-level `README.md` / `CONTRIBUTING.md` / `CLAUDE.md`** are pinned to `.tool-versions` via `bun run scripts/check-docs-versions.ts` (also asserts `package.json` `engines.bun` / `packageManager` and the two `Dockerfile.*` `FROM oven/bun:<ver>` lines agree).
+- `src/<file>:<line>` citations in `docs/` **and the same three root-level files** are anchor-verified via `bun run scripts/check-docs-citations.ts` (file must exist; cited line / range must be in bounds).
 
 The `docs.yml` `pull_request:` trigger has no `paths:` filter, so these gates run on every PR, code-side bumps that invalidate doc facts (Renovate Bun bump, refactor that shifts cited line numbers) trip the build the same way doc edits do. `Deploy to GitHub Pages` is still gated on `push` / `workflow_dispatch`, so PRs validate but never publish.
 
@@ -166,14 +166,14 @@ The `docs.yml` `pull_request:` trigger has no `paths:` filter, so these gates ru
 - TypeScript 5.9.3 strict mode on Bun ≥1.3.13 + `octokit` (webhook + GraphQL/REST), `@anthropic-ai/claude-agent-sdk` (multi-turn handlers), `@anthropic-ai/bedrock-sdk` (single-turn intent classification via `src/ai/llm-client.ts`), `@modelcontextprotocol/sdk`, `pino`, `zod`. No new npm dependencies. (20260421-181205-bot-workflows)
 - PostgreSQL 17 via `Bun.sql` singleton: adds one migration (`005_workflow_runs.sql`). Valkey 8 via Bun built-in `RedisClient`, existing job queue reused unchanged. (20260421-181205-bot-workflows)
 
-- TypeScript 5.9.3 (strict mode with `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `useUnknownInCatchVariables`) on Bun ≥1.3.12 (see `package.json` `packageManager` pin). Deps: `octokit`, `@anthropic-ai/claude-agent-sdk`, `@anthropic-ai/bedrock-sdk` (Bedrock single-turn adaptor in `src/ai/llm-client.ts`), `@modelcontextprotocol/sdk`, `@kubernetes/client-node` (ephemeral-daemon Pod spawning in `src/k8s/ephemeral-daemon-spawner.ts`), `pino`, `zod`, Bun built-in `WebSocket` + `RedisClient`. `@anthropic-ai/sdk` is a transitive dep of `claude-agent-sdk`.
+- TypeScript 5.9.3 (strict mode with `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `useUnknownInCatchVariables`) on Bun ≥1.3.13 (see `package.json` `packageManager` pin). Deps: `octokit`, `@anthropic-ai/claude-agent-sdk`, `@anthropic-ai/bedrock-sdk` (Bedrock single-turn adaptor in `src/ai/llm-client.ts`), `@modelcontextprotocol/sdk`, `@kubernetes/client-node` (ephemeral-daemon Pod spawning in `src/k8s/ephemeral-daemon-spawner.ts`), `pino`, `zod`, Bun built-in `WebSocket` + `RedisClient`. `@anthropic-ai/sdk` is a transitive dep of `claude-agent-sdk`.
 - **Dispatch taxonomy (post-collapse)**: `DispatchTarget` = `daemon` (singleton, kept as a field for DB/log stability); `DispatchReason` = `persistent-daemon` | `ephemeral-daemon-triage` | `ephemeral-daemon-overflow` | `ephemeral-spawn-failed`. Canonical source: `src/shared/dispatch-types.ts`. (20260419-collapse-dispatch-to-daemon)
 - PostgreSQL 17 via `Bun.sql` singleton (`executions` + `triage_results` tables from migrations `001_initial.sql` → `004_collapse_dispatch_to_daemon.sql`); Valkey 8 (Redis-compatible) via Bun built-in `RedisClient` for the daemon job queue. Operator aggregates in `src/db/queries/dispatch-stats.ts`.
 
-- TypeScript 5.9.3 strict mode on Bun >=1.3.8 + `octokit`, `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, `pino`, `zod` (all existing). New: Bun built-in `WebSocket` + `RedisClient` (zero new npm dependencies). (20260413-191249-daemon-orchestrator-core)
+- TypeScript 5.9.3 strict mode on Bun >=1.3.13 + `octokit`, `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, `pino`, `zod` (all existing). New: Bun built-in `WebSocket` + `RedisClient` (zero new npm dependencies). (20260413-191249-daemon-orchestrator-core)
 - PostgreSQL 17 (pgvector-ready, existing `executions` + `daemons` tables from `001_initial.sql`) + Valkey 8 (Redis 7.2-compatible, via Bun built-in `RedisClient`) (20260413-191249-daemon-orchestrator-core)
 
-- TypeScript (strict mode) on Bun >=1.3.8 + `octokit`, `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, `pino`, `zod`
+- TypeScript (strict mode) on Bun >=1.3.13 + `octokit`, `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, `pino`, `zod`
 
 <!-- SPECKIT START -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ the development workflow, and the conventions enforced by the tooling.
 
 ## Prerequisites
 
-| Tool                          | Version | Purpose                                    |
-| ----------------------------- | ------- | ------------------------------------------ |
-| [Bun](https://bun.sh)         | ≥ 1.3.8 | Runtime and package manager                |
-| [Git](https://git-scm.com)    | any     | Version control                            |
-| [Node.js](https://nodejs.org) | ≥ 20    | Required by the Claude Code CLI subprocess |
+| Tool                          | Version  | Purpose                                    |
+| ----------------------------- | -------- | ------------------------------------------ |
+| [Bun](https://bun.sh)         | ≥ 1.3.13 | Runtime and package manager                |
+| [Git](https://git-scm.com)    | any      | Version control                            |
+| [Node.js](https://nodejs.org) | ≥ 20     | Required by the Claude Code CLI subprocess |
 
 ---
 
@@ -27,7 +27,7 @@ bun install
 
 # 3. Copy and fill in the environment file
 cp .env.example .env
-# Edit .env: see docs/SETUP.md for the full variable reference
+# Edit .env: see docs/operate/setup.md for the full variable reference
 ```
 
 ---
@@ -252,6 +252,6 @@ chore: upgrade @anthropic-ai/claude-agent-sdk to 0.3.0
 
 ## Project Structure
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full directory layout and
-request flow. See [docs/EXTENDING.md](docs/EXTENDING.md) for how to add new webhook
+See [docs/build/architecture.md](docs/build/architecture.md) for the full directory layout and
+request flow. See [docs/build/extending.md](docs/build/extending.md) for how to add new webhook
 event handlers and MCP servers.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flowchart LR
     classDef done fill:#2da44e,stroke:#0b4a1e,color:#ffffff
 ```
 
-See [Architecture](https://chrisleekr.github.io/github-app-playground/ARCHITECTURE/) for the full flow, including idempotency, triage, and the pipeline stages.
+See [Architecture](https://chrisleekr.github.io/github-app-playground/build/architecture/) for the full flow, including idempotency, triage, and the pipeline stages.
 
 ## Quick start
 

--- a/scripts/check-docs-citations.ts
+++ b/scripts/check-docs-citations.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 /**
  * CI guard: every `src/<path>:<line>` (or `:<start>-<end>`) citation in
- * docs/ points at a file that exists and a line range that is in bounds.
+ * docs/, plus root-level README.md, CONTRIBUTING.md and CLAUDE.md,
+ * points at a file that exists and a line range that is in bounds.
  *
  * Catches the silent-rot case where a refactor shifts line numbers but
  * the doc keeps citing the old offset. We only flag citations that
@@ -11,7 +12,7 @@
  *
  * Exit 0 on clean, 1 on any broken citation.
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +23,8 @@ import { fileURLToPath } from "node:url";
 const repoRoot =
   process.env["DOCS_CHECK_REPO_ROOT"] ?? resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DOCS_ROOT = join(repoRoot, "docs");
+// Root-level Markdown that ships outside docs/ but cites src/ all the same.
+const ROOT_DOCS = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"];
 
 // Match `src/<path>.<ext>:<line>` or `:<start>-<end>`. Path may include
 // `[A-Za-z0-9_./-]`; extension is one of the source-code extensions we
@@ -51,6 +54,19 @@ function walkMarkdown(dir: string): string[] {
   return out;
 }
 
+// Markdown files in scope: everything under docs/ plus the root-level docs
+// listed in `ROOT_DOCS` that actually exist (a missing one is skipped so the
+// gate stays portable if a file is later removed).
+function collectMarkdownFiles(): string[] {
+  const out = walkMarkdown(DOCS_ROOT);
+  for (const name of ROOT_DOCS) {
+    const full = join(repoRoot, name);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- constant repo-root names
+    if (existsSync(full)) out.push(full);
+  }
+  return out;
+}
+
 function fileLineCount(absPath: string): number {
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- absPath is constructed from a regex-matched repo-relative path; existence is checked by caller
   const buf = readFileSync(absPath);
@@ -72,8 +88,8 @@ function fileExists(absPath: string): boolean {
 
 function check(): BrokenCitation[] {
   const broken: BrokenCitation[] = [];
-  for (const md of walkMarkdown(DOCS_ROOT)) {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- enumerated from docs/
+  for (const md of collectMarkdownFiles()) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- enumerated from docs/ and ROOT_DOCS
     const contents = readFileSync(md, "utf-8");
     const lines = contents.split("\n");
     for (let i = 0; i < lines.length; i++) {
@@ -138,10 +154,10 @@ function check(): BrokenCitation[] {
 function main(): void {
   const broken = check();
   if (broken.length === 0) {
-    console.log("OK: every src/<path>:<line> citation in docs/ points at an in-range location");
+    console.log("OK: every src/<path>:<line> citation points at an in-range location");
     return;
   }
-  console.error(`ERROR: ${String(broken.length)} stale src citation(s) in docs/:\n`);
+  console.error(`ERROR: ${String(broken.length)} stale src citation(s):\n`);
   for (const b of broken) {
     console.error(`  - ${b.docFile}:${String(b.docLine)} cites \`${b.citation}\`, ${b.reason}`);
   }

--- a/scripts/check-docs-versions.ts
+++ b/scripts/check-docs-versions.ts
@@ -5,16 +5,23 @@
  * packageManager) and the two Dockerfiles agree, so the canonical pin is
  * authoritative across the repo.
  *
- * Detected forms in docs/**:
- *   - bare semver "1.3.13" inside a Bun context (preceding text contains
- *     the word `bun`, case-insensitive, anywhere in the same Markdown
- *     line; covers tables, prose, code fences). The `bun` requirement
- *     avoids false matches on unrelated semvers (e.g. Node 20.x, openssl pins).
+ * Scope: every Markdown file under docs/ plus the root-level README.md,
+ * CONTRIBUTING.md and CLAUDE.md. Those three are read by humans on every
+ * repo visit and by the bot on every agent run, so a stale Bun pin there
+ * is as damaging as one inside docs/.
+ *
+ * Detected forms:
+ *   - bare semver "1.3.13" inside a Bun context: the line mentions `bun`
+ *     (case-insensitive) and the semver is not immediately preceded by a
+ *     recognised non-Bun token (e.g. `TypeScript 5.9.3`, `Node 20.x`). An
+ *     unrecognised preceding word leaves the semver in scope on purpose,
+ *     so a line that names both a Bun version and another version is
+ *     handled without silently skipping an unexpected phrasing.
  *   - `oven/bun:<ver>` references.
  *
  * Exit 0 on match, 1 on any mismatch with a per-file diff on stderr.
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,6 +38,8 @@ const DOCKERFILES = [
   join(repoRoot, "Dockerfile.daemon"),
 ];
 const DOCS_ROOT = join(repoRoot, "docs");
+// Root-level Markdown that ships outside docs/ but is just as load-bearing.
+const ROOT_DOCS = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"];
 
 const SEMVER = /\d+\.\d+\.\d+/;
 
@@ -156,11 +165,58 @@ function walkMarkdown(dir: string): string[] {
   return out;
 }
 
+// Markdown files in scope: everything under docs/ plus the root-level docs
+// listed in `ROOT_DOCS` that actually exist (a missing one is skipped so the
+// gate stays portable if a file is later removed).
+function collectMarkdownFiles(): string[] {
+  const out = walkMarkdown(DOCS_ROOT);
+  for (const name of ROOT_DOCS) {
+    const full = join(repoRoot, name);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- constant repo-root names
+    if (existsSync(full)) out.push(full);
+  }
+  return out;
+}
+
 const OVEN_RE = /oven\/bun:(\d+\.\d+\.\d+)/g;
 const BUN_SEMVER_RE = /(?<![\w.-])(\d+\.\d+\.\d+)(?![\w.-])/g;
 
+// Tokens that own a non-Bun version on a line that also mentions Bun. A
+// semver immediately preceded by one of these is not a Bun version. This is
+// a denylist on purpose: an unknown preceding word leaves the semver in
+// scope, so the gate fails loud on an unflagged stale pin rather than
+// silently skipping a phrasing it did not anticipate.
+const NON_BUN_OWNERS = new Set([
+  "typescript",
+  "node",
+  "nodejs",
+  "postgres",
+  "postgresql",
+  "redis",
+  "valkey",
+  "openssl",
+]);
+
+// The word, if any, that immediately precedes a semver at `idx`. Only
+// version-range decoration (whitespace, `≥ ≤ > < = * ~ ^`) is skipped on the
+// way back; any other non-letter char (`|`, backtick, `(`, `:` …) is treated
+// as a hard boundary and yields "". Used to reject semvers owned by a
+// non-Bun token on a line that also mentions Bun: the line-level `/bun/i`
+// test alone is too loose for prose-dense files like CLAUDE.md where a
+// TypeScript version and a Bun version share one line.
+function precedingWord(line: string, idx: number): string {
+  let j = idx - 1;
+  while (j >= 0 && /[\s≥≤><=*~^]/.test(line[j] ?? "")) j--;
+  let word = "";
+  while (j >= 0 && /[A-Za-z]/.test(line[j] ?? "")) {
+    word = (line[j] ?? "") + word;
+    j--;
+  }
+  return word;
+}
+
 function checkDocFile(path: string, canonical: string): Mismatch[] {
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- enumerated from docs/
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- enumerated from docs/ and ROOT_DOCS
   const contents = readFileSync(path, "utf-8");
   const lines = contents.split("\n");
   const out: Mismatch[] = [];
@@ -186,6 +242,12 @@ function checkDocFile(path: string, canonical: string): Mismatch[] {
       const before = line.slice(Math.max(0, idx - 12), idx);
       // Skip the `oven/bun:<ver>` matches we already handled above.
       if (/oven\/bun:$/.test(before)) continue;
+      // Skip a semver owned by a recognised non-Bun token (e.g. `TypeScript
+      // 5.9.3`). An empty or unrecognised preceding word leaves the semver
+      // in scope: the gate must fail loud on a stale pin, not skip wording
+      // it did not anticipate.
+      const owner = precedingWord(line, idx).toLowerCase();
+      if (NON_BUN_OWNERS.has(owner)) continue;
       const found = semverMatch[1] as string;
       if (found !== canonical) {
         out.push({
@@ -205,7 +267,7 @@ function main(): void {
   const mismatches: Mismatch[] = [];
   mismatches.push(...checkPackageJson(canonical));
   for (const df of DOCKERFILES) mismatches.push(...checkDockerfile(df, canonical));
-  for (const md of walkMarkdown(DOCS_ROOT)) mismatches.push(...checkDocFile(md, canonical));
+  for (const md of collectMarkdownFiles()) mismatches.push(...checkDocFile(md, canonical));
 
   if (mismatches.length === 0) {
     console.log(

--- a/scripts/check-docs-versions.ts
+++ b/scripts/check-docs-versions.ts
@@ -199,20 +199,23 @@ const NON_BUN_OWNERS = new Set([
 
 // The word, if any, that immediately precedes a semver at `idx`. Only
 // version-range decoration (whitespace, `≥ ≤ > < = * ~ ^`) is skipped on the
-// way back; any other non-letter char (`|`, backtick, `(`, `:` …) is treated
-// as a hard boundary and yields "". Used to reject semvers owned by a
-// non-Bun token on a line that also mentions Bun: the line-level `/bun/i`
-// test alone is too loose for prose-dense files like CLAUDE.md where a
-// TypeScript version and a Bun version share one line.
+// way back; any other non-word char (`|`, backtick, `(`, `:` …) is treated
+// as a hard boundary and yields "". The word run accepts `.` and `-` so a
+// dotted token like `Node.js` is captured whole, then those separators are
+// stripped before return so the result matches a flat `NON_BUN_OWNERS` entry
+// (`nodejs`). Used to reject semvers owned by a non-Bun token on a line that
+// also mentions Bun: the line-level `/bun/i` test alone is too loose for
+// prose-dense files like CLAUDE.md where a TypeScript version and a Bun
+// version share one line.
 function precedingWord(line: string, idx: number): string {
   let j = idx - 1;
   while (j >= 0 && /[\s≥≤><=*~^]/.test(line[j] ?? "")) j--;
   let word = "";
-  while (j >= 0 && /[A-Za-z]/.test(line[j] ?? "")) {
+  while (j >= 0 && /[A-Za-z.-]/.test(line[j] ?? "")) {
     word = (line[j] ?? "") + word;
     j--;
   }
-  return word;
+  return word.replace(/[.-]/g, "");
 }
 
 function checkDocFile(path: string, canonical: string): Mismatch[] {

--- a/test/scripts/check-docs-citations.test.ts
+++ b/test/scripts/check-docs-citations.test.ts
@@ -9,6 +9,8 @@ const SCRIPT = resolve(import.meta.dir, "..", "..", "scripts", "check-docs-citat
 interface Layout {
   src?: Record<string, string>;
   docs?: Record<string, string>;
+  // Root-level Markdown (README.md / CONTRIBUTING.md / CLAUDE.md), keyed by filename.
+  rootDocs?: Record<string, string>;
 }
 
 function makeFixture(layout: Layout): string {
@@ -24,6 +26,9 @@ function makeFixture(layout: Layout): string {
     const abs = join(root, "docs", rel);
     mkdirSync(resolve(abs, ".."), { recursive: true });
     writeFileSync(abs, body);
+  }
+  for (const [name, body] of Object.entries(layout.rootDocs ?? {})) {
+    writeFileSync(join(root, name), body);
   }
   return root;
 }
@@ -103,6 +108,28 @@ describe("scripts/check-docs-citations.ts", () => {
     const { exitCode, stdout } = runScript(root);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("OK: every src/<path>:<line> citation");
+  });
+
+  it("passes a valid citation in a root-level doc (issue #136)", () => {
+    const root = makeFixture({
+      src: { "app.ts": "a\nb\nc\nd\n" },
+      rootDocs: { "README.md": "See `src/app.ts:2` for the entrypoint.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every src/<path>:<line> citation");
+  });
+
+  it("scans root-level CONTRIBUTING.md and flags a broken citation there (issue #136)", () => {
+    const root = makeFixture({
+      rootDocs: { "CONTRIBUTING.md": "See `src/gone.ts:1` for details.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("CONTRIBUTING.md:1");
+    expect(stderr).toContain("file does not exist");
   });
 
   it("flags an end-line that exceeds the file length in a range citation", () => {

--- a/test/scripts/check-docs-versions.test.ts
+++ b/test/scripts/check-docs-versions.test.ts
@@ -26,6 +26,8 @@ interface Layout {
   dockerfileOrch?: string;
   dockerfileDaemon?: string;
   docs?: Record<string, string>;
+  // Root-level Markdown (README.md / CONTRIBUTING.md / CLAUDE.md), keyed by filename.
+  rootDocs?: Record<string, string>;
 }
 
 function makeFixture(layout: Layout): string {
@@ -39,6 +41,9 @@ function makeFixture(layout: Layout): string {
     const abs = join(root, "docs", rel);
     mkdirSync(resolve(abs, ".."), { recursive: true });
     writeFileSync(abs, body);
+  }
+  for (const [name, body] of Object.entries(layout.rootDocs ?? {})) {
+    writeFileSync(join(root, name), body);
   }
   return root;
 }
@@ -109,6 +114,55 @@ describe("scripts/check-docs-versions.ts", () => {
     const { exitCode, stdout } = runScript(root);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("OK: every Bun version reference matches");
+  });
+
+  it("scans root-level README.md and flags a stale Bun version there (issue #136)", () => {
+    const root = makeFixture({
+      toolVersion: "1.3.13",
+      rootDocs: { "README.md": "Bun 1.3.8 is required to build.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("README.md:1");
+    expect(stderr).toContain("found `1.3.8`");
+  });
+
+  it("flags a stale Bun version in a CONTRIBUTING.md table cell (issue #136)", () => {
+    const root = makeFixture({
+      toolVersion: "1.3.13",
+      rootDocs: {
+        "CONTRIBUTING.md": "| [Bun](https://bun.sh) | ≥ 1.3.8 | Runtime |\n",
+      },
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("CONTRIBUTING.md:1");
+    expect(stderr).toContain("found `1.3.8`");
+  });
+
+  it("does not false-positive a non-Bun semver sharing a line with a Bun version (issue #136)", () => {
+    const root = makeFixture({
+      toolVersion: "1.3.13",
+      rootDocs: { "CLAUDE.md": "TypeScript 5.9.3 strict mode on Bun ≥1.3.13.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every Bun version reference matches");
+  });
+
+  it("still flags a stale Bun pin behind an unrecognised word (issue #136)", () => {
+    const root = makeFixture({
+      toolVersion: "1.3.13",
+      rootDocs: { "README.md": "Bun is required; install version 1.3.8 first.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("README.md:1");
+    expect(stderr).toContain("found `1.3.8`");
   });
 
   it("flags package.json `engines.bun` disagreement with the canonical pin", () => {

--- a/test/scripts/check-docs-versions.test.ts
+++ b/test/scripts/check-docs-versions.test.ts
@@ -165,6 +165,17 @@ describe("scripts/check-docs-versions.ts", () => {
     expect(stderr).toContain("found `1.3.8`");
   });
 
+  it("does not false-positive a dotted non-Bun owner like `Node.js` (issue #136, PR #138 review)", () => {
+    const root = makeFixture({
+      toolVersion: "1.3.13",
+      rootDocs: { "CLAUDE.md": "Node.js 20.18.0 runs alongside Bun ≥1.3.13.\n" },
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every Bun version reference matches");
+  });
+
   it("flags package.json `engines.bun` disagreement with the canonical pin", () => {
     const root = makeFixture({
       toolVersion: "1.3.13",


### PR DESCRIPTION
## Summary

The `check-docs-versions` and `check-docs-citations` CI gates scanned only `docs/`, so the three highest-visibility Markdown files in the repo — `README.md`, `CONTRIBUTING.md`, `CLAUDE.md` — shipped stale Bun pins and broken doc paths uncaught. This widens both gates to also scan those root-level files and fixes the drift the wider scan exposes.

Closes #136

## Changes

**Gate scripts**
- Add a `collectMarkdownFiles()` helper to both scripts: walks `docs/` and appends root-level `README.md` / `CONTRIBUTING.md` / `CLAUDE.md` (existence-guarded, so a removed file is skipped, not a crash).
- `check-docs-versions.ts`: widening the version scan surfaced a false positive — a non-Bun semver (e.g. `TypeScript 5.9.3`) on a line that also mentions Bun. Added a `precedingWord()` helper plus a `NON_BUN_OWNERS` **denylist**: a semver is skipped only when a *recognised* non-Bun token immediately precedes it. An empty or unrecognised preceding word leaves the semver in scope, so the gate fails loud on a stale pin rather than silently skipping an unanticipated phrasing.

**Drift fixed (exposed by the wider scan)**
- `CONTRIBUTING.md`: Bun `≥ 1.3.8` → `≥ 1.3.13`; `docs/SETUP.md` → `docs/operate/setup.md`; `docs/ARCHITECTURE.md` → `docs/build/architecture.md`; `docs/EXTENDING.md` → `docs/build/extending.md`.
- `CLAUDE.md`: four stale Bun version strings (`1.3.12`, `>=1.3.8`) → `1.3.13`; `CI-enforced doc gates` paragraph updated to state the new scope.
- `README.md`: published architecture URL `/ARCHITECTURE/` (HTTP 404) → `/build/architecture/`.

**Tests** — 6 new fixture tests across both `test/scripts/*.test.ts` files: root-doc version/citation scanning, the `TypeScript`-on-a-Bun-line false-positive guard, the CONTRIBUTING table-cell form, and the fail-loud case (stale Bun pin behind an unrecognised word).

## Verification

- `bun run check:docs-versions` and `check:docs-citations` — both pass.
- `bun run typecheck`, `bun run format` — clean.
- `bun test test/scripts/` — 17 pass, 0 fail.
- Senior-review gate ran to convergence (no material findings remaining).

## Judgement call

The issue lists only `CLAUDE.md:109` and `:169`, but once `CLAUDE.md` is in scope *every* Bun semver in it must equal the canonical pin or CI fails. The wider scan also flags the auto-generated Active Technologies snapshot lines (`Bun >=1.3.8`), so all four Bun-version lines are normalized to `1.3.13`; the feature-ID tags on those snapshot lines are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Bun runtime version requirement to 1.3.13
  * Clarified documentation structure references and setup paths

* **Tests**
  * Extended validation test coverage to include root-level documentation files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/github-app-playground/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->