### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history kept for parity with dev-release/release workflows
           # and to give semantic-release accurate diff context when this
@@ -71,12 +71,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .tool-versions
 
       - name: Cache Bun install dir
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -97,6 +97,12 @@ jobs:
 
       - name: Dockerfile base-sync guard
         run: bun run check:dockerfile-base-sync
+
+      - name: GitHub Actions SHA-pin guard
+        # Fails if any third-party `uses:` reference is on a mutable tag
+        # instead of a 40-char commit SHA. Prevents a hand-edited workflow
+        # from reintroducing the supply-chain vector closed in issue #137.
+        run: bun run check:action-pins
 
       - name: Docs-sync guard (bot workflows, FR-019)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -62,7 +62,7 @@ jobs:
       new-release-version: ${{ steps.semrel.outputs.new-release-version }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -120,17 +120,17 @@ jobs:
           done <<< "$STALE_TAGS"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .tool-versions
 
       - name: Setup Node.js for semantic-release
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
       - name: Cache Bun install dir
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,7 +103,7 @@ jobs:
             }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -138,17 +138,17 @@ jobs:
           echo "git_hash=$GIT_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -182,7 +182,7 @@ jobs:
           touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -221,24 +221,24 @@ jobs:
           echo "variant_tag=${PACKAGE_VERSION}-${VARIANT}" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -315,10 +315,10 @@ jobs:
         variant: [orchestrator, daemon]
     steps:
       - name: Checkout (for .trivyignore.yaml)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -350,7 +350,7 @@ jobs:
       #       --predicate-type https://cyclonedx.org/bom
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_PLATFORM: "linux/${{ matrix.arch }}"
         with:
@@ -367,7 +367,7 @@ jobs:
           trivyignores: .trivyignore.yaml
 
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         if: always()
         with:
           sarif_file: "trivy-results-${{ matrix.variant }}-${{ matrix.arch }}.sarif"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,11 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .tool-versions
 
@@ -43,7 +43,7 @@ jobs:
       - name: Verify docs src citations
         run: bun run scripts/check-docs-citations.ts
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           cache: pip

--- a/.github/workflows/generate-labels.yml
+++ b/.github/workflows/generate-labels.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Label PR based on title
-        uses: srvaroa/labeler@v1
+        uses: srvaroa/labeler@9c29ad1ef33d169f9ef33c52722faf47a566bcf3 # v1 (moving major; no patch-level release tag at this SHA)
         with:
           config_path: .github/labeler.yml
           use_local_config: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,23 +45,23 @@ jobs:
       new-release-version: ${{ steps.semrel.outputs.new-release-version }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .tool-versions
 
       - name: Setup Node.js for semantic-release
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
       - name: Cache Bun install dir
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -55,7 +55,7 @@ jobs:
           echo "trigger_type=$EVENT_NAME"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
       # - --disallowedTools "": WebSearch/WebFetch are denied by default (#690)
       - name: Run research with Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # For `push` events gitleaks-action scans the push range
           # (GITHUB_EVENT_BEFORE..GITHUB_SHA), which needs enough depth
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@v2.3.9
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,12 +106,13 @@ Five workflow files form the pipeline; each owns one responsibility.
 | `.github/workflows/release.yml`      | `workflow_dispatch` only (manual)                         | Calls `ci.yml` → semantic-release prod → calls `docker-build.yml`                                                                                                                                                         |
 | `.github/workflows/docker-build.yml` | `workflow_call` + `workflow_dispatch`                     | Reusable image builder: matrix split-and-merge (amd64 on `ubuntu-24.04` + arm64 on `ubuntu-24.04-arm`), SLSA v1 provenance + SBOM attestations (BuildKit + Sigstore), `gh attestation verify` regression gate, Trivy scan |
 
-- **Bun version is single-sourced** via `.tool-versions` (`bun 1.3.13`). All workflows use `oven-sh/setup-bun@v2` with `bun-version-file: .tool-versions`.
+- **Bun version is single-sourced** via `.tool-versions` (`bun 1.3.13`). All workflows use `oven-sh/setup-bun` with `bun-version-file: .tool-versions`.
 - **`audit:ci` (`scripts/audit-ci.ts`)** wraps `bun audit --json` to gate on severity: blocks on high+critical, warns on moderate+low, with an inline `IGNORED` GHSA allowlist (each entry must carry an `expires` date). Required because `bun audit` exits 1 on **any** finding regardless of `--audit-level`.
 - **Semantic release config** (`release.config.mjs`) is single-file with `SEMREL_CHANNEL=dev|prod` env switching: replaces the previous file-swap hack.
 - **Prod releases are manual.** Push to main only triggers `ci.yml` (sanity). Cut a release with `gh workflow run release.yml`.
 - Multi-arch images: amd64 builds on `ubuntu-24.04`, arm64 builds natively on `ubuntu-24.04-arm` (free for public repos). Both runners are explicitly pinned (not `ubuntu-latest`) so the rolling alias can't silently flip to a new major and break the build, see the header of `.github/workflows/docker-build.yml`. Manifest assembled by `docker buildx imagetools create`. GHA cache scoped per arch.
 - Defense-in-depth on workflow injection: every dynamic input flowing into a `run:` block is passed via `env:` first.
+- **GitHub Actions are SHA-pinned.** Every third-party `uses:` reference is pinned to a full 40-char commit SHA (with a `# vX.Y.Z` comment), not a mutable tag, so a force-moved upstream tag cannot change the bytes a runner executes. Renovate keeps the SHAs current via the `helpers:pinGitHubActionDigests` preset behind the existing 7-day `minimumReleaseAge` soak. `ci.yml` runs `bun run check:action-pins` (`scripts/check-action-pins.ts`), which fails the build if any third-party `uses:` is on a tag. Local reusable-workflow calls (`uses: ./...`) are exempt.
 
 ## Security invariants (prompt-injection hardening)
 

--- a/docs/build/conventions.md
+++ b/docs/build/conventions.md
@@ -5,7 +5,7 @@ The repo enforces conventions through tooling, not docs, every rule below is che
 ## Runtime and language
 
 - **Runtime.** Bun for the application; Node.js 20 for the Claude Code CLI subprocess. Both are installed in the Docker `base` stage.
-- **Bun version.** Pinned in `.tool-versions` (`bun 1.3.13`). All workflows use `oven-sh/setup-bun@v2` with `bun-version-file: .tool-versions`.
+- **Bun version.** Pinned in `.tool-versions` (`bun 1.3.13`). All workflows use `oven-sh/setup-bun` with `bun-version-file: .tool-versions`.
 - **TypeScript.** Strict mode plus the strictest flags: `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `useUnknownInCatchVariables`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`. Module resolution is `bundler`, imports do not need `.js` extensions.
 
 ## ESLint

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "audit:ci": "bun run scripts/audit-ci.ts",
-    "check": "bun run typecheck && bun run lint && bun run format && bun run check:no-destructive && bun run check:no-em-dashes && bun run check:docs-versions && bun run check:docs-citations && bun run test",
+    "check": "bun run typecheck && bun run lint && bun run format && bun run check:no-destructive && bun run check:no-em-dashes && bun run check:action-pins && bun run check:docs-versions && bun run check:docs-citations && bun run test",
     "check:no-destructive": "bun run scripts/check-no-destructive-actions.ts",
     "check:no-em-dashes": "bun run scripts/em-dash-sweep.ts --check",
     "dev:daemon": "bash scripts/run-daemon.sh",
@@ -77,6 +77,7 @@
     "check:docs-sync": "bun run scripts/check-docs-sync.ts",
     "check:docs-versions": "bun run scripts/check-docs-versions.ts",
     "check:docs-citations": "bun run scripts/check-docs-citations.ts",
+    "check:action-pins": "bun run scripts/check-action-pins.ts",
     "check:mcp-bundle": "bun run scripts/check-mcp-bundle.ts",
     "prepare": "husky"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommits"],
+  "extends": ["config:recommended", ":semanticCommits", "helpers:pinGitHubActionDigests"],
   "timezone": "Australia/Melbourne",
   "schedule": ["before 4am on Monday"],
   "labels": ["dependencies", "renovate"],

--- a/scripts/check-action-pins.ts
+++ b/scripts/check-action-pins.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * CI guard: every third-party GitHub Action referenced by `uses:` in
+ * .github/workflows/ is pinned to a full 40-character commit SHA, not a
+ * mutable Git tag. A tag (even `vX.Y.Z`) can be force-moved by anyone who
+ * can push to the action's repo, so the bytes a runner executes are decided
+ * at run time, not at review time (CVE-2025-30066, tj-actions/changed-files).
+ * A commit SHA is immutable. See issue #137.
+ *
+ * Local reusable-workflow calls (`uses: ./...`) are exempt: they are
+ * same-repo paths with no upstream tag an attacker could move.
+ *
+ * Scope: this scans block-style `uses:` keys (the only form in this repo's
+ * workflows). Flow-mapping steps (`- {uses: ...}`) are not parsed; if that
+ * form is ever introduced, extend `USES_RE` and add a fixture.
+ *
+ * Exit 0 when every reference is SHA-pinned, 1 otherwise with a per-line
+ * report on stderr.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `ACTION_PINS_REPO_ROOT` env override exists solely so the test suite can
+// point the gate at a fixture tree without copying the script. Production
+// invocations leave it unset and resolve `repoRoot` from the script's own
+// location.
+const repoRoot =
+  process.env["ACTION_PINS_REPO_ROOT"] ?? resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW_DIR = join(repoRoot, ".github", "workflows");
+
+// `uses:` line, capturing the action reference as the first whitespace-
+// delimited token. `\S+` stops at the first space, so a trailing
+// `# vX.Y.Z` version comment is naturally excluded from the capture.
+const USES_RE = /^\s*(?:-\s*)?uses:\s*(\S+)/;
+// A pinned ref ends with `@` then exactly 40 hex chars (the commit SHA).
+const SHA_RE = /@[0-9a-fA-F]{40}$/;
+
+interface Violation {
+  file: string;
+  line: number;
+  ref: string;
+}
+
+function workflowFiles(): string[] {
+  let entries: string[];
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- constant path
+    entries = readdirSync(WORKFLOW_DIR);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.endsWith(".yml") || e.endsWith(".yaml"))
+    .map((e) => join(WORKFLOW_DIR, e));
+}
+
+function checkFile(path: string): Violation[] {
+  const out: Violation[] = [];
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- enumerated from .github/workflows/
+  const lines = readFileSync(path, "utf-8").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    // Skip fully commented-out lines (e.g. a disabled `#   uses: foo@v1`).
+    if (line.trimStart().startsWith("#")) continue;
+    const match = USES_RE.exec(line);
+    if (match === null) continue;
+    // Strip surrounding quotes: `uses: "owner/action@<sha>"` is legal YAML
+    // and must not be reported as unpinned just for the quote characters.
+    const ref = (match[1] as string).replace(/^["']|["']$/g, "");
+    // Local reusable-workflow call: same-repo path, nothing to pin.
+    if (ref.startsWith("./") || ref.startsWith("../")) continue;
+    if (!SHA_RE.test(ref)) {
+      out.push({ file: relative(repoRoot, path), line: i + 1, ref });
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const violations = workflowFiles().flatMap(checkFile);
+  if (violations.length === 0) {
+    console.log(
+      "OK: every third-party `uses:` in .github/workflows/ is pinned to a 40-char commit SHA",
+    );
+    return;
+  }
+  console.error(`ERROR: ${String(violations.length)} GitHub Action reference(s) not SHA-pinned:\n`);
+  for (const v of violations) {
+    console.error(`  - ${v.file}:${String(v.line)} uses \`${v.ref}\``);
+  }
+  console.error(
+    "\nFix: replace the tag with the commit SHA it resolves to, e.g.\n" +
+      "  uses: owner/action@<40-char-sha> # vX.Y.Z\n" +
+      "Resolve with: gh api repos/<owner>/<repo>/commits/<tag> --jq .sha",
+  );
+  process.exit(1);
+}
+
+main();

--- a/test/scripts/check-action-pins.test.ts
+++ b/test/scripts/check-action-pins.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+const SCRIPT = resolve(import.meta.dir, "..", "..", "scripts", "check-action-pins.ts");
+
+// A representative 40-char commit SHA (actions/checkout v6.0.2).
+const SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd";
+
+function makeFixture(workflows: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "check-action-pins-"));
+  const dir = join(root, ".github", "workflows");
+  mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(workflows)) {
+    writeFileSync(join(dir, name), body);
+  }
+  return root;
+}
+
+function runScript(repoRoot: string): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(["bun", "run", SCRIPT], {
+    env: { ...process.env, ACTION_PINS_REPO_ROOT: repoRoot },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: proc.stdout.toString(),
+    stderr: proc.stderr.toString(),
+  };
+}
+
+const fixtures: string[] = [];
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const f = fixtures.pop();
+    if (f !== undefined) rmSync(f, { recursive: true, force: true });
+  }
+});
+
+describe("scripts/check-action-pins.ts", () => {
+  it("exits 0 when every uses: is SHA-pinned and ignores local workflow calls", () => {
+    const root = makeFixture({
+      "ci.yml": `jobs:\n  a:\n    steps:\n      - uses: actions/checkout@${SHA} # v6.0.2\n`,
+      "release.yml": `jobs:\n  call:\n    uses: ./.github/workflows/ci.yml\n`,
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every third-party");
+  });
+
+  it("exits 1 when a uses: is pinned to a mutable tag", () => {
+    const root = makeFixture({
+      "ci.yml": `jobs:\n  a:\n    steps:\n      - uses: actions/checkout@v6\n`,
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("ci.yml:4");
+    expect(stderr).toContain("actions/checkout@v6");
+  });
+
+  it("ignores commented-out uses: lines", () => {
+    const root = makeFixture({
+      "ci.yml": `jobs:\n  a:\n    steps:\n      # - uses: anchore/sbom-action@v0\n      - uses: actions/checkout@${SHA} # v6.0.2\n`,
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every third-party");
+  });
+
+  it("accepts a quoted SHA-pinned ref without flagging the quote characters", () => {
+    const root = makeFixture({
+      "ci.yml": `jobs:\n  a:\n    steps:\n      - uses: "actions/checkout@${SHA}" # v6.0.2\n`,
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every third-party");
+  });
+
+  it("reports every unpinned reference across multiple workflow files", () => {
+    const root = makeFixture({
+      "a.yml": `jobs:\n  j:\n    steps:\n      - uses: docker/login-action@v4\n`,
+      "b.yml": `jobs:\n  j:\n    steps:\n      - uses: oven-sh/setup-bun@v2\n`,
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("2 GitHub Action reference(s) not SHA-pinned");
+  });
+});


### PR DESCRIPTION
## Summary

Every `uses:` reference across the 8 workflow files resolved a third-party GitHub Action by a **mutable Git tag**. A tag — even `vX.Y.Z` — can be force-moved by anyone who can push to the action's repo, so the bytes a runner executes are decided at run time, not at review time. This is the `tj-actions/changed-files` compromise class (CVE-2025-30066). This PR closes that vector.

Closes #137

## Changes

**SHA-pin every third-party action** — all 33 active third-party `uses:` references across the 8 `.github/workflows/*.yml` files repinned from a tag to a full 40-char commit SHA, each with a `# vX.Y.Z` comment for human readability. Each SHA was resolved via `gh api repos/{owner}/{repo}/commits/{tag}` and independently re-verified during review. The 4 local `uses: ./.github/workflows/*.yml` reusable-workflow calls are **exempt** — same-repo paths with no upstream tag an attacker could move.

**Renovate maintenance** — added `helpers:pinGitHubActionDigests` to `renovate.json` `extends`, so Renovate keeps the SHAs current behind the existing 7-day `minimumReleaseAge` soak and `digest` automerge rule (both already configured). No update-velocity loss; the `# vX.Y.Z` comment preserves version context.

**CI guard against regression** — new `scripts/check-action-pins.ts` (+ `check:action-pins` package script) wired into `ci.yml` and the `check` aggregate. It fails the build if any third-party `uses:` is on a tag instead of a 40-char SHA, so a future hand-edited workflow cannot silently reintroduce the vector. Mirrors the repo's existing `check:*` guard pattern. Covered by `test/scripts/check-action-pins.test.ts` (5 fixture tests: SHA-pinned pass, tag fail, commented-line skip, quoted-ref accept, multi-file aggregation).

**Docs** — `CLAUDE.md` CI/CD section and `docs/build/conventions.md` updated to describe the SHA-pinning posture and drop the now-stale `@v2` suffix from `oven-sh/setup-bun` prose references.

## Verification

- `bun run check:action-pins` — passes (every third-party `uses:` is SHA-pinned).
- `bun run typecheck`, `bun run format` — clean.
- `bun test test/scripts/` — all pass.
- Full suite — 197 pre-existing failures unchanged (zero regressions; this PR touches no `src/` code).
- Senior-review gate ran to convergence; all 16 distinct SHA-to-tag pairings cross-checked against the GitHub API.

## Judgement calls

- **`srvaroa/labeler` comment.** Every pin carries a precise `# vX.Y.Z` except `srvaroa/labeler@9c29ad1… # v1`. `srvaroa/labeler@v1` resolves to a v1-branch-HEAD commit that is not any `v1.X.Y` release tag's commit, so `# v1` is the only truthful comment; the comment is annotated inline to explain the asymmetry.
- **Guard scope.** `check-action-pins.ts` parses block-style `uses:` (the only form in this repo). Flow-mapping steps (`- {uses: ...}`) are not scanned; documented as a known boundary in the script header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)