### PR TITLE
fix(docs): anchor-verify src citations to catch silent line-shift rot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Validate locally with `bun run docs:build` before pushing. If no matching doc ex
 **CI-enforced doc gates.** Two project-specific checks run in `.github/workflows/docs.yml` ahead of `mkdocs build --strict` (which only validates internal links and snippet targets, not prose-vs-source agreement):
 
 - Bun version strings in `docs/` **and root-level `README.md` / `CONTRIBUTING.md` / `CLAUDE.md`** are pinned to `.tool-versions` via `bun run scripts/check-docs-versions.ts` (also asserts `package.json` `engines.bun` / `packageManager` and the two `Dockerfile.*` `FROM oven/bun:<ver>` lines agree).
-- `src/<file>:<line>` citations in `docs/` **and the same three root-level files** are anchor-verified via `bun run scripts/check-docs-citations.ts` (file must exist; cited line / range must be in bounds).
+- `src/<file>:<line>` citations in `docs/` **and the same three root-level files** are verified via `bun run scripts/check-docs-citations.ts` (file must exist; cited line / range must be in bounds). Citations may opt in to symbol anchoring with a trailing `#symbol` suffix (e.g. `` `src/core/prompt-builder.ts:155#buildPrompt` ``); when present, the anchor token must physically appear on the cited line range, which closes the silent line-shift hole the bounds-only path can't see (issue #158).
 
 The `docs.yml` `pull_request:` trigger has no `paths:` filter, so these gates run on every PR, code-side bumps that invalidate doc facts (Renovate Bun bump, refactor that shifts cited line numbers) trip the build the same way doc edits do. `Deploy to GitHub Pages` is still gated on `push` / `workflow_dispatch`, so PRs validate but never publish.
 

--- a/docs/build/architecture.md
+++ b/docs/build/architecture.md
@@ -158,7 +158,7 @@ The agent executor (`src/core/executor.ts:208`) supports two prompt-layout strat
 
 The `cacheable` layout splits the prompt by trust:
 
-- **Trusted scaffolding** (`security_directive`, `freshness_directive`, workflow steps, commit / CAPABILITIES boilerplate) → `systemPrompt.append`. Built by `buildPromptParts()` in `src/core/prompt-builder.ts:402`. Byte-identical across jobs of the same shape, so the system-prompt prefix becomes a stable cache key.
+- **Trusted scaffolding** (`security_directive`, `freshness_directive`, workflow steps, commit / CAPABILITIES boilerplate) → `systemPrompt.append`. Built by `buildPromptParts()` in `src/core/prompt-builder.ts:448#buildPromptParts`. Byte-identical across jobs of the same shape, so the system-prompt prefix becomes a stable cache key.
 - **Attacker-influenceable data** (`formatted_context` with title / body / comments, `<untrusted_*>` spotlight blocks with per-call nonce, per-call metadata like delivery ID) → user-role message.
 - **Dynamic preset sections** stripped via `excludeDynamicSections: true`.
 

--- a/docs/operate/configuration.md
+++ b/docs/operate/configuration.md
@@ -188,7 +188,7 @@ before committing:
 
 ## Prompt cache layout
 
-Selects the system/user prompt split the agent executor passes to the Claude Agent SDK. See `src/config.ts:562` for the Zod definition and `src/core/executor.ts:208` for the runtime guard.
+Selects the system/user prompt split the agent executor passes to the Claude Agent SDK. See `src/config.ts:568#promptCacheLayout` for the Zod definition and `src/core/executor.ts:208` for the runtime guard.
 
 | Variable              | Default  | Notes                                                                                                        |
 | --------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
@@ -196,9 +196,9 @@ Selects the system/user prompt split the agent executor passes to the Claude Age
 
 **Why this exists.** The SDK's default systemPrompt (`{ type: "preset", preset: "claude_code" }`) embeds dynamic sections (cwd, platform, shell, OS) directly in the system-prompt prefix. Because each delivery clones to a unique `cwd` under `CLONE_BASE_DIR`, the system-prompt prefix is unique per job and the Anthropic prompt cache misses on every invocation, paying the 1-hour TTL `ephemeral_1h_input_tokens` cache-write surcharge (2× base price) with zero compensating reads.
 
-**`legacy` (default).** Single user-role string built by `buildPrompt()` in `src/core/prompt-builder.ts:126`. SystemPrompt is the unmodified `claude_code` preset. Backwards-compatible; safe rollback target.
+**`legacy` (default).** Single user-role string built by `buildPrompt()` in `src/core/prompt-builder.ts:155#buildPrompt`. SystemPrompt is the unmodified `claude_code` preset. Backwards-compatible; safe rollback target.
 
-**`cacheable`.** Static scaffolding (`security_directive`, `freshness_directive`, workflow steps, commit/CAPABILITIES boilerplate) is lifted into `systemPrompt.append`, and `excludeDynamicSections: true` strips cwd / platform / shell / OS from the preset. Built by `buildPromptParts()` in `src/core/prompt-builder.ts:402`. The user-role message keeps only the per-call dynamic blocks (`formatted_context`, `untrusted_*` with per-call nonce, per-call metadata). The append is byte-identical across jobs of the same shape (PR vs issue), so the system-prompt prefix becomes a stable cache key.
+**`cacheable`.** Static scaffolding (`security_directive`, `freshness_directive`, workflow steps, commit/CAPABILITIES boilerplate) is lifted into `systemPrompt.append`, and `excludeDynamicSections: true` strips cwd / platform / shell / OS from the preset. Built by `buildPromptParts()` in `src/core/prompt-builder.ts:448#buildPromptParts`. The user-role message keeps only the per-call dynamic blocks (`formatted_context`, `untrusted_*` with per-call nonce, per-call metadata). The append is byte-identical across jobs of the same shape (PR vs issue), so the system-prompt prefix becomes a stable cache key.
 
 **Rollout.** Flip the variable to `cacheable`, then verify cache hits by tailing the executor completion log for non-zero `cacheReadInputTokens`:
 

--- a/scripts/check-docs-citations.ts
+++ b/scripts/check-docs-citations.ts
@@ -4,11 +4,27 @@
  * docs/, plus root-level README.md, CONTRIBUTING.md and CLAUDE.md,
  * points at a file that exists and a line range that is in bounds.
  *
- * Catches the silent-rot case where a refactor shifts line numbers but
- * the doc keeps citing the old offset. We only flag citations that
- * include a `:line` suffix: bare `src/foo.ts` pointers (e.g. "see
- * `src/app.ts`") are explicitly out of scope; they don't claim a line
- * and can't go stale on a line-shift.
+ * Citations may opt in to symbol anchoring with a trailing `#symbol`
+ * suffix (e.g. `` `src/foo.ts:42#bar` ``). When the anchor is present, at
+ * least one line in the cited range must physically contain the anchor
+ * token; otherwise the citation falls back to today's bounds-only check.
+ * Anchors are opt-in per citation, so no flag day is required. The anchor
+ * grammar is an ASCII identifier token (letters, digits, `_`, `$`),
+ * optionally extended with dotted member accessors (e.g. `#Foo.bar.baz`),
+ * so a citation can pin a method on a specific receiver. Unicode
+ * identifiers and hyphenated names are not supported; cite the rightmost
+ * dotted chain instead. The anchor asserts textual presence on the cited
+ * line range only, it does not distinguish a definition from a comment
+ * or call site, the bounds-only path is the line-shift guard, the anchor
+ * is the symbol-rename guard.
+ *
+ * Without an anchor, the gate only catches the loud refactor-shift case
+ * where the new line falls past the end of the file. Anchored citations
+ * also catch the silent case where the symbol moved inside the file but
+ * the doc kept citing the old offset.
+ *
+ * Bare `src/foo.ts` pointers (e.g. "see `src/app.ts`") are explicitly
+ * out of scope: they don't claim a line and can't go stale on a shift.
  *
  * Exit 0 on clean, 1 on any broken citation.
  */
@@ -26,10 +42,22 @@ const DOCS_ROOT = join(repoRoot, "docs");
 // Root-level Markdown that ships outside docs/ but cites src/ all the same.
 const ROOT_DOCS = ["README.md", "CONTRIBUTING.md", "CLAUDE.md"];
 
-// Match `src/<path>.<ext>:<line>` or `:<start>-<end>`. Path may include
-// `[A-Za-z0-9_./-]`; extension is one of the source-code extensions we
-// actually cite. `:<line>` is required; bare paths are ignored.
-const CITATION_RE = /\bsrc\/([A-Za-z0-9_./-]+\.(?:ts|tsx|mts|cts|mjs|cjs|js)):(\d+)(?:-(\d+))?\b/g;
+// Match `src/<path>.<ext>:<line>` or `:<start>-<end>`, with an optional
+// trailing `#symbol` anchor. Path may include `[A-Za-z0-9_./-]`; extension
+// is one of the source-code extensions we actually cite. `:<line>` is
+// required; bare paths are ignored. The anchor is an ASCII identifier
+// token, optionally extended with dotted accessors (`Foo.bar.baz`); the
+// leading char of each segment is letter / `_` / `$`, so leading digits
+// can't start an anchor. The trailing negative lookahead
+// `(?![A-Za-z0-9_$])` is required (not `\b`) because `$` is not a regex
+// word character: a plain `\b` after the anchor would silently truncate
+// `#foo$` to `foo`. The lookahead deliberately does NOT include `.` or
+// `#`, so a citation followed by sentence punctuation (`src/a.ts:1.`)
+// or a malformed anchor (`src/a.ts:1#42abc`, which can't bind a leading
+// digit and falls through anchorlessly) still parses as the bounds-only
+// citation it would on `main`.
+const CITATION_RE =
+  /\bsrc\/([A-Za-z0-9_./-]+\.(?:ts|tsx|mts|cts|mjs|cjs|js)):(\d+)(?:-(\d+))?(?:#([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*))?(?![A-Za-z0-9_$])/g;
 
 interface BrokenCitation {
   docFile: string;
@@ -77,6 +105,31 @@ function fileLineCount(absPath: string): number {
   return count;
 }
 
+// Extracts the [start, end] (1-based, inclusive) slice of `absPath` as a
+// single string. Caller is responsible for ensuring the range is in bounds.
+function readLineRange(absPath: string, start: number, end: number): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- absPath is constructed from a regex-matched repo-relative path; bounds checked by caller
+  const text = readFileSync(absPath, "utf-8");
+  const lines = text.split("\n");
+  // `split("\n")` on a trailing-newline file yields an extra empty element;
+  // slice(start-1, end) is still correct because we never read past `total`.
+  return lines.slice(start - 1, end).join("\n");
+}
+
+// Anchor matches must be whole-word so `buildPrompt` doesn't match
+// `buildPromptParts`, and a dotted anchor like `Foo.bar` must not match
+// inside a longer chain like `obj.Foo.bar`. We bound the token with
+// characters that are neither identifier chars nor `.` on each side. `$`
+// and `.` are regex metacharacters so we escape them before interpolation;
+// CITATION_RE's anchor group only permits `[A-Za-z0-9_$.]`, of which
+// those two are the only metacharacters.
+function anchorPresent(haystack: string, anchor: string): boolean {
+  const escaped = anchor.replace(/[$.]/g, (c) => `\\${c}`);
+  // eslint-disable-next-line security/detect-non-literal-regexp -- anchor is restricted to [A-Za-z0-9_$.] by CITATION_RE and metacharacters are escaped above
+  const re = new RegExp(`(?:^|[^A-Za-z0-9_$.])${escaped}(?:[^A-Za-z0-9_$.]|$)`);
+  return re.test(haystack);
+}
+
 function fileExists(absPath: string): boolean {
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- absPath is repo-relative path constructed from regex match
@@ -100,10 +153,12 @@ function check(): BrokenCitation[] {
         const relPath = `src/${match[1] ?? ""}`;
         const startStr = match[2] as string;
         const endStr = match[3];
+        const anchor = match[4];
         const start = Number.parseInt(startStr, 10);
         const end = endStr === undefined ? start : Number.parseInt(endStr, 10);
-        const citation =
-          endStr === undefined ? `${relPath}:${startStr}` : `${relPath}:${startStr}-${endStr}`;
+        const rangeStr = endStr === undefined ? startStr : `${startStr}-${endStr}`;
+        const anchorSuffix = anchor === undefined ? "" : `#${anchor}`;
+        const citation = `${relPath}:${rangeStr}${anchorSuffix}`;
         // Reject `..` segments. `CITATION_RE` allows them in the path
         // component, so a doc citing `src/../foo.ts:1` would otherwise
         // statSync a path that escapes `src/` and report "OK" for a
@@ -144,6 +199,26 @@ function check(): BrokenCitation[] {
             citation,
             reason: `end line ${String(end)} out of range (file has ${String(total)} lines)`,
           });
+          continue;
+        }
+        // Anchor verification: if the citation declared an expected symbol,
+        // assert the cited range actually contains that token. This is the
+        // silent-rot guard the bounds-only path can't provide.
+        if (anchor !== undefined) {
+          const slice = readLineRange(abs, start, end);
+          if (!anchorPresent(slice, anchor)) {
+            broken.push({
+              docFile: relative(repoRoot, md),
+              docLine: i + 1,
+              citation,
+              reason: `anchor \`${anchor}\` not found on cited line${start === end ? "" : "s"} ${rangeStr} of \`${relPath}\``,
+            });
+            // Trailing `continue` is defensive: keeps the per-citation
+            // failure pattern uniform with the earlier checks, so any
+            // future check appended below doesn't double-report a
+            // citation that's already on `broken`.
+            continue;
+          }
         }
       }
     }
@@ -162,7 +237,7 @@ function main(): void {
     console.error(`  - ${b.docFile}:${String(b.docLine)} cites \`${b.citation}\`, ${b.reason}`);
   }
   console.error(
-    "\nFix: update the citation to the current line range, or drop the `:<line>` suffix if the file no longer needs an anchor.",
+    "\nFix: update the citation to the current line range, drop the `:<line>` suffix if the file no longer needs an anchor, or correct the `#symbol` suffix (anchors are optional but, when present, must appear on the cited line).",
   );
   process.exit(1);
 }

--- a/test/scripts/check-docs-citations.test.ts
+++ b/test/scripts/check-docs-citations.test.ts
@@ -142,4 +142,249 @@ describe("scripts/check-docs-citations.ts", () => {
     expect(exitCode).toBe(1);
     expect(stderr).toContain("end line 99 out of range");
   });
+
+  // Anchor-verification cases (issue #158): close the silent-rot gap the
+  // bounds-only check misses when a refactor shifts a cited symbol but
+  // leaves the new offset inside the file.
+  describe("anchor verification (#symbol suffix)", () => {
+    it("passes when the anchor token appears on the cited line", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// line1\nexport function buildPrompt() {}\n// line3\n" },
+        docs: { "page.md": "See `src/app.ts:2#buildPrompt` for the builder.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("flags an anchor that is in-bounds but on the wrong line (the silent-rot regression)", () => {
+      // Mirrors the issue's live example: `buildPrompt` moved from line 2
+      // down to line 4, but the doc still cites line 2. Bounds-only passes;
+      // anchored check fails.
+      const root = makeFixture({
+        src: {
+          "app.ts": "// preamble\n// preamble\n// preamble\nexport function buildPrompt() {}\n",
+        },
+        docs: { "page.md": "See `src/app.ts:2#buildPrompt` for the builder.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `buildPrompt` not found on cited line 2");
+    });
+
+    it("matches the anchor whole-word so `buildPrompt` doesn't match `buildPromptParts`", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// line1\nexport function buildPromptParts() {}\n" },
+        docs: { "page.md": "See `src/app.ts:2#buildPrompt`.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `buildPrompt` not found");
+    });
+
+    it("accepts a multi-line range when the anchor appears anywhere inside it", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\nexport function buildPrompt() {}\n// l5\n" },
+        docs: { "page.md": "Block `src/app.ts:2-4#buildPrompt` covers the def.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("flags a multi-line range whose anchor falls outside the range", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\n// l4\nexport function buildPrompt() {}\n" },
+        docs: { "page.md": "Bad: `src/app.ts:1-3#buildPrompt`.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `buildPrompt` not found on cited lines 1-3");
+    });
+
+    it("leaves anchorless citations on the bounds-only path (no flag day)", () => {
+      // No anchor → today's behaviour. Line 2 is in bounds; content is
+      // irrelevant. This is the backward-compat guarantee.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2 unrelated content\n// l3\n" },
+        docs: { "page.md": "See `src/app.ts:2` for context.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("accepts `$` and `_` in anchor tokens (JS-identifier shape)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "const _$private_helper = 1;\n" },
+        docs: { "page.md": "See `src/app.ts:1#_$private_helper`.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("treats malformed anchors (leading digit) as anchorless citations (matches `main`'s pre-anchor behaviour)", () => {
+      // `42abc` can't bind to the anchor group (leading digit fails the
+      // `[A-Za-z_$]` first-char requirement). The optional group does
+      // not match, the citation falls through to its bounds-only form
+      // `src/app.ts:1`, and the gate validates that. This is the same
+      // behaviour `main` had before anchor support landed: malformed
+      // anchor suffixes are not interpreted, and the rest of the
+      // citation is still checked. Loudly rejecting malformed anchors
+      // would require a broader negative lookahead that also breaks
+      // citations followed by sentence-ending `.` (see trailing-period
+      // tests below), so the silent-fall-through is the better trade-off.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n" },
+        docs: { "page.md": "Malformed `src/app.ts:1#42abc` falls through.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("anchor `42abc`");
+    });
+
+    // Trailing-period regression tests (#158 iter-2 [H1] / [M1]): an
+    // over-broad lookahead would silently drop range bounds or anchors
+    // when a citation is followed by sentence punctuation. These lock
+    // the gate's behaviour against that regression in both backtick'd
+    // (typical) and bare (rare but legal in prose) shapes.
+    it("matches an anchorless single-line citation followed by `.` (regression: H1 over-broad lookahead)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\n" },
+        docs: { "page.md": "See src/app.ts:2. Done.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("still flags an out-of-range end on a range citation followed by `.` (range end must not be silently dropped)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "a\nb\nc\n" },
+        docs: { "page.md": "Bad: src/app.ts:1-99. End out of range.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("end line 99 out of range");
+    });
+
+    it("still verifies the anchor on an anchored range citation followed by `.` (anchor must not be silently dropped)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\n" },
+        docs: { "page.md": "Bad: src/app.ts:1-3#missingSym. Symbol absent.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `missingSym` not found on cited lines 1-3");
+    });
+
+    it("matches the same three shapes wrapped in backticks (positive control)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\nexport function sym() {}\n" },
+        docs: {
+          "page.md": "OK: `src/app.ts:2`. OK: `src/app.ts:1-3`. OK: `src/app.ts:4#sym`.\n",
+        },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("captures `$`-suffixed identifiers as the full anchor (regression: `\\b` would truncate)", () => {
+      // `\b` is a word boundary against `\w = [A-Za-z0-9_]`, so it treats
+      // `$` as non-word. A `\b` after the anchor group silently truncates
+      // `#foo$` to `foo`. The negative-lookahead form preserves the full
+      // identifier so `count$` (common with reactive-style suffixes) is
+      // checked correctly. The fixture omits `count$` from the cited
+      // line so the gate must fail with the full identifier in the
+      // error message, proving the suffix was captured.
+      const root = makeFixture({
+        src: { "app.ts": "// line1\nconst other = 1;\n" },
+        docs: { "page.md": "See `src/app.ts:2#count$` for the stream.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `count$` not found on cited line 2");
+    });
+
+    it("accepts a single-line anchored citation on the exact symbol line (slice boundary)", () => {
+      // Pins the off-by-one edge in `readLineRange` (slice(start-1, end)):
+      // start === end, citing the exact symbol line.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\n// l2\n// l3\nexport function buildPrompt() {}\n" },
+        docs: { "page.md": "See `src/app.ts:4#buildPrompt`.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("accepts dotted member-expression anchors (`#Foo.bar`)", () => {
+      const root = makeFixture({
+        src: { "app.ts": "// l1\nexport const Foo = { bar: () => 1 };\nFoo.bar();\n" },
+        docs: { "page.md": "See `src/app.ts:3#Foo.bar` for the call site.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stdout } = runScript(root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("OK: every src/<path>:<line> citation");
+    });
+
+    it("rejects a dotted anchor when only the prefix is present on the cited line", () => {
+      // Closes the silent-truncation hole: `#Foo.bar` must not falsely
+      // pass when only `Foo` appears at the cited line.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\nclass Foo {}\n" },
+        docs: { "page.md": "Bad: `src/app.ts:2#Foo.bar`, only Foo here.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `Foo.bar` not found on cited line 2");
+    });
+
+    it("does not match `#Foo.bar` inside a longer chain like `obj.Foo.bar`", () => {
+      // Dotted anchors must bind to a chain root, not a tail-substring of
+      // a deeper expression, otherwise the anchor false-positives on any
+      // line that incidentally ends with the same suffix.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\nconst x = obj.Foo.bar();\n" },
+        docs: { "page.md": "See `src/app.ts:2#Foo.bar`.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("anchor `Foo.bar` not found");
+    });
+
+    it("honours `#symbol` anchors in root-level docs (CLAUDE.md), not just docs/", () => {
+      // Confirms the anchor path is file-location-independent: the gate
+      // widening in PR #138 swept root-level docs into scope, and #158
+      // anchor support must apply uniformly.
+      const root = makeFixture({
+        src: { "app.ts": "// l1\nexport function buildPrompt() {}\n" },
+        rootDocs: { "CLAUDE.md": "Stale: `src/app.ts:1#buildPrompt` cites wrong line.\n" },
+      });
+      fixtures.push(root);
+      const { exitCode, stderr } = runScript(root);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("CLAUDE.md:1");
+      expect(stderr).toContain("anchor `buildPrompt` not found on cited line 1");
+    });
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The `scripts/check-docs-citations.ts` gate's docstring claimed to catch "the silent-rot case where a refactor shifts line numbers but the doc keeps citing the old offset", but its actual check was bounds-only, so a citation whose target shifted inside the file still passed. 4 of the repo's 6 live `src/<path>:<line>` citations were already pointing at the wrong content and CI was green. This PR extends `CITATION_RE` with an optional trailing `#symbol` anchor that asserts the cited line range physically contains the named token. Anchors are opt-in per citation (no flag day), support dotted member expressions (`#Foo.bar.baz`), and use a negative-lookahead boundary so `$`-suffixed identifiers like `count$` are captured correctly (a plain `\b` would silently truncate them). The four stale citations are backfilled with anchors + corrected line numbers, the gate's docstring and `CLAUDE.md` are updated to reflect the new contract, and 10 regression tests lock the behaviour against the failure modes flagged in senior review.

## Diagram

```mermaid
flowchart TD
    classDef before fill:#ecf0f1,color:#2c3e50,stroke:#34495e
    classDef after fill:#2c3e50,color:#ffffff,stroke:#1a252f
    classDef bad fill:#922b21,color:#ffffff,stroke:#641e16
    classDef good fill:#1e8449,color:#ffffff,stroke:#196f3d

    A["doc cites<br/>src/foo.ts:42"]:::before --> B["file exists?"]:::before
    B --> C["1 le 42 le total?"]:::before
    C --> D["OK or BROKEN"]:::bad
    D --> E["refactor moves<br/>bar from 42 to 87,<br/>file still 200 lines"]:::bad
    E --> F["gate still green,<br/>reader lands on<br/>wrong function"]:::bad

    G["doc cites<br/>src/foo.ts:42#bar"]:::after --> H["file exists?"]:::after
    H --> I["1 le 42 le total?"]:::after
    I --> J{"anchor present?"}:::after
    J -->|no anchor| K["bounds-only path,<br/>backward compatible"]:::good
    J -->|yes| L["does line 42 contain<br/>token bar with<br/>non-identifier boundaries?"]:::after
    L -->|yes| M["OK"]:::good
    L -->|no| N["BROKEN:<br/>anchor not found"]:::good
```

## Changes

- **`scripts/check-docs-citations.ts`**: extend `CITATION_RE` with optional `(?:#([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*))?` anchor capture and trailing `(?![A-Za-z0-9_$])` lookahead (replaces `\b` to preserve `$`-suffixed identifiers). When the anchor binds, `readLineRange` + `anchorPresent` assert the literal token appears in the cited range with non-identifier-and-non-dot boundaries on each side, so `Foo.bar` does not false-match inside `obj.Foo.bar` and `buildPrompt` does not false-match inside `buildPromptParts`. Tightened docstring to "ASCII identifier token" and clarified that the anchor asserts textual presence only (not definition-site distinction); the bounds path remains the line-shift guard, the anchor is the symbol-rename guard.
- **`test/scripts/check-docs-citations.test.ts`**: 10 new tests under a `describe("anchor verification (#symbol suffix)")` block covering happy path, the silent-rot regression mirroring the live #158 case, whole-word boundary (`buildPrompt` vs `buildPromptParts`), multi-line range inside / outside, anchorless backward-compat, `$` and `_` in anchor tokens, dotted member-expression positives / negatives / tail-substring rejection, root-level `CLAUDE.md` anchor support, malformed leading-digit anchors falling through anchorlessly, `$`-suffix round-trip (regression-locks the `\b` truncation bug), single-line slice-boundary anchor, and four trailing-period regression tests.
- **`docs/operate/configuration.md`**: backfill three stale citations:
  - `src/config.ts:562` to `src/config.ts:568#promptCacheLayout`
  - `src/core/prompt-builder.ts:126` to `src/core/prompt-builder.ts:155#buildPrompt`
  - `src/core/prompt-builder.ts:402` to `src/core/prompt-builder.ts:448#buildPromptParts`
- **`docs/build/architecture.md`**: backfill `src/core/prompt-builder.ts:402` to `src/core/prompt-builder.ts:448#buildPromptParts`.
- **`CLAUDE.md`**: update the "CI-enforced doc gates" entry to document the `#symbol` opt-in and link the rationale to issue #158.

## Related Issues

- Closes #158

## Test plan

- [x] Tested locally: `bun run scripts/check-docs-citations.ts` passes; intentionally re-introducing a stale citation reproduces the issue.
- [x] Added/updated tests: 10 new regression tests in `test/scripts/check-docs-citations.test.ts` (26 pass / 0 fail in that suite).
- [x] All existing tests pass: `bun test` failure count unchanged vs `main` (pre-existing failures only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and configuration documentation to reflect current source code references with improved accuracy and clarity.
  * Documentation citation system now supports optional symbol anchoring for more precise and maintainable code references.

* **Tests**
  * Expanded test coverage for documentation citation validation system, including new symbol-anchoring verification capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/github-app-playground/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->