### PR TITLE
fix(infrastructure): patch krb5 HIGH CVE-2026-40356 in shared Docker base

### DIFF
--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Apply Debian security updates for OS packages baked into the oven/bun base
 # image. The orchestrator stage never reinstalls them otherwise, so it shipped
-# stale python3.13 / libsystemd0 / libnghttp2 / libcap2 with HIGH CVEs flagged
+# stale python3.13 / libsystemd0 / libnghttp2 / libcap2 / krb5 libs with HIGH CVEs flagged
 # by the Trivy gate. This block lives in the shared base so both images carry
 # the patched versions. Targeted --only-upgrade (not a blanket apt-get upgrade)
 # keeps the build reproducible and avoids hadolint DL3005.
@@ -39,7 +39,8 @@ RUN apt-get update && \
   apt-get install --only-upgrade -y --no-install-recommends \
   openssl libssl3 \
   python3.13 python3.13-minimal libpython3.13-stdlib libpython3.13-minimal \
-  libsystemd0 libudev1 libnghttp2-14 libcap2 && \
+  libsystemd0 libudev1 libnghttp2-14 libcap2 \
+  libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 && \
   rm -rf /var/lib/apt/lists/*
 
 # Tracks 11.x major (unlike the exact pins elsewhere).

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Apply Debian security updates for OS packages baked into the oven/bun base
 # image. The orchestrator stage never reinstalls them otherwise, so it shipped
-# stale python3.13 / libsystemd0 / libnghttp2 / libcap2 with HIGH CVEs flagged
+# stale python3.13 / libsystemd0 / libnghttp2 / libcap2 / krb5 libs with HIGH CVEs flagged
 # by the Trivy gate. This block lives in the shared base so both images carry
 # the patched versions. Targeted --only-upgrade (not a blanket apt-get upgrade)
 # keeps the build reproducible and avoids hadolint DL3005.
@@ -38,7 +38,8 @@ RUN apt-get update && \
   apt-get install --only-upgrade -y --no-install-recommends \
   openssl libssl3 \
   python3.13 python3.13-minimal libpython3.13-stdlib libpython3.13-minimal \
-  libsystemd0 libudev1 libnghttp2-14 libcap2 && \
+  libsystemd0 libudev1 libnghttp2-14 libcap2 \
+  libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 && \
   rm -rf /var/lib/apt/lists/*
 
 # Tracks 11.x major (unlike the exact pins elsewhere).


### PR DESCRIPTION
## What

Resolves #179. The `Docker / Trivy scan (orchestrator / arm64)` CI gate (`docker-build.yml`, `--exit-code 1` on CRITICAL,HIGH for the orchestrator variant) failed **deterministically** (confirmed across two re-runs) on a single finding:

- **CVE-2026-40356** (HIGH) in the Debian Kerberos runtime libs `libgssapi-krb5-2`, `libk5crypto3`, `libkrb5-3`, `libkrb5support0` — installed `1.21.3-5`, fixed `1.21.3-5+deb13u1` — shipped by the `oven/bun:1.3.14` (Debian 13) base and pulled in transitively by the `curl git … nodejs` install in the shared base stage.

amd64 already passed; the existing `apt-get install --only-upgrade` security-patch block pinned openssl/python3.13/libsystemd0/etc. but not krb5.

## Fix

Add the four krb5 runtime packages to that `--only-upgrade` block. The block lives between the `SHARED-BASE-BEGIN/END` markers and must stay byte-identical across both images (`scripts/check-dockerfile-base-sync.ts`), so the same edit lands in `Dockerfile.orchestrator` and `Dockerfile.daemon`.

## Verification (local, linux/arm64 — the failing arch)

- Built `Dockerfile.orchestrator`; confirmed all four krb5 packages upgrade to `1.21.3-5+deb13u1`, all moving together (no version skew), and the base ships no other krb5 package.
- Ran Trivy v0.70.0 (same as CI) with CI's exact flags `--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore.yaml --exit-code 1` → **exit 0, zero gating findings**.
- `bun run check:dockerfile-base-sync` → OK. `--only-upgrade` confirmed non-no-op (packages present transitively before the upgrade RUN). No image bloat; no new hadolint warnings.

## Context

Surfaced by the bulk-implement run while shipping #175 (PR #178). #175 is pure TypeScript and did not introduce this CVE — it is a pre-existing base-image CVE that gated `main` itself. This PR unblocks #178 (which will be rebased on the patched base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)