### PR TITLE
feat(observability): redact crash logs via uncaughtException/unhandledRejection handlers

### DIFF
--- a/docs/operate/observability.md
+++ b/docs/operate/observability.md
@@ -14,6 +14,8 @@ The serializer operates on a copy, so the original Error instance is never mutat
 
 If you add a new secret-bearing config field to `src/config.ts`, add its property name to `REDACT_PATHS` in the same PR. The point helpers `redactGitHubTokens` and `redactValkeyUrl` remain in place for their non-log call sites (prompt sanitisation and the Valkey startup info log respectively); the logger config is the system-wide default.
 
+The crash path is covered too. `installFatalHandlers(processName)` in `src/logger.ts` registers `uncaughtException` and `unhandledRejection` handlers at both entrypoints (`src/app.ts`, `src/daemon/main.ts`) that log via `logger.fatal({ err })` and then `process.exit(1)`. Without them the runtime's default handler would print a plain `stderr` stack that bypasses `errSerializer`, so a token echoed inside an octokit error would reach the log shipper in cleartext. The default destination flushes synchronously on the process `exit` event, so the fatal line is written before exit; `pino.final` is intentionally not used because it throws when the logger is built with the dev-only `pino-pretty` transport. Crash lines carry `level: 60` (fatal) and a `processName` of `orchestrator` or `daemon`, so an alert on sustained `level:60` flags a crash-looping process.
+
 ## Common log fields
 
 | Field                                | Meaning                                                                                                                                                                                                                                                                                                                                                                      |

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,7 @@ import { App, Octokit } from "octokit";
 import { config } from "./config";
 import { closeDb, getDb } from "./db";
 import { runMigrations } from "./db/migrate";
-import { logger } from "./logger";
+import { installFatalHandlers, logger } from "./logger";
 import { recoverStaleExecutions } from "./orchestrator/history";
 import { getInstanceId } from "./orchestrator/instance-id";
 import { startInstanceHeartbeat, stopInstanceHeartbeat } from "./orchestrator/instance-liveness";
@@ -677,6 +677,10 @@ function shutdown(signal: string): void {
     process.exit(1);
   }, 290_000); // 10s below K8s default terminationGracePeriodSeconds (300s)
 }
+
+// Route crashes through the redacting pino chokepoint instead of the
+// runtime's default plaintext stderr stack (issue #164).
+installFatalHandlers("orchestrator");
 
 process.on("SIGTERM", () => {
   shutdown("SIGTERM");

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -1,7 +1,7 @@
 import { platform } from "node:os";
 
 import { config } from "../config";
-import { logger } from "../logger";
+import { installFatalHandlers, logger } from "../logger";
 import type { DaemonCapabilities } from "../shared/daemon-types";
 import {
   createMessageEnvelope,
@@ -345,6 +345,11 @@ function startEphemeralIdleLoop(): void {
 
 async function main(): Promise<void> {
   logger.info({ daemonId }, "Daemon starting");
+
+  // Route crashes through the redacting pino chokepoint instead of the
+  // runtime's default plaintext stderr stack (issue #164). Registered before
+  // the async startup work below so a throw during discovery is captured too.
+  installFatalHandlers("daemon");
 
   // Surface silent exits: if the event loop ever drains while we're not
   // explicitly shutting down, log it so future regressions of the "daemon

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -234,4 +234,64 @@ export function createChildLogger(
   return logger.child(fields);
 }
 
+/**
+ * Register process-level crash handlers that route `uncaughtException` and
+ * `unhandledRejection` through this pino logger before exiting non-zero.
+ *
+ * Without these, the runtime's default handler prints a plain stderr stack
+ * that never passes through `errSerializer`, so a credential echoed in an
+ * octokit error message or stack (e.g. a `ghs_…` token) reaches the log
+ * shipper in cleartext. Logging via `logger.fatal({ err })` applies the same
+ * `REDACT_PATHS` + `errSerializer` scrubbing every other line gets.
+ *
+ * `processName` distinguishes orchestrator vs daemon crash lines in the shared
+ * aggregator. Register once per process, alongside the signal handlers.
+ *
+ * Flushing: the default (production) destination is a SonicBoom stream that
+ * flushes synchronously on the process `exit` event, so the fatal line is
+ * written before `process.exit(1)` takes effect (verified empirically under
+ * Bun). `pino.final` is deliberately NOT used despite being the textbook
+ * exit-logging helper: it throws when the logger is built with a `transport`
+ * (the dev-only `pino-pretty` config here), and the on-exit flush already
+ * guarantees delivery on the production path.
+ */
+export function installFatalHandlers(processName: "orchestrator" | "daemon"): void {
+  const onFatal =
+    (kind: "uncaughtException" | "unhandledRejection") =>
+    (reason: unknown): void => {
+      // `unhandledRejection` can deliver a non-Error reason (a bare string or
+      // object, e.g. `Promise.reject("...ghs_token...")`). `errSerializer`
+      // only scrubs Error objects, so coerce first: that puts the reason into
+      // an Error message/stack where the secret-strip pass runs on it. Without
+      // this, a token in a string/object rejection reaches the log shipper in
+      // cleartext, the exact leak #164 set out to close.
+      logger.fatal({ err: toFatalError(reason), processName }, kind);
+      process.exit(1);
+    };
+  process.on("uncaughtException", onFatal("uncaughtException"));
+  process.on("unhandledRejection", onFatal("unhandledRejection"));
+}
+
+/**
+ * Coerce an arbitrary crash reason into an Error so `errSerializer` scrubs it.
+ * Strings and JSON-serialisable objects are stringified into the message (the
+ * token regex still matches there); a value that cannot be stringified (e.g.
+ * a circular object) falls back to `String(...)`, which drops detail but never
+ * leaks a token.
+ */
+function toFatalError(reason: unknown): Error {
+  if (reason instanceof Error) return reason;
+  if (typeof reason === "string") return new Error(reason);
+  try {
+    // Scrub by field name before flattening: once the object becomes a JSON
+    // string the structure is gone, so an opaque secret in a sensitive key
+    // (authorization/token/...) could only be caught by the message regex,
+    // which misses non-pattern secrets. scrubStructured censors those keys
+    // up front; the message-level regex still runs at log time as a backstop.
+    return new Error(JSON.stringify(scrubStructured(reason)));
+  } catch {
+    return new Error(String(reason));
+  }
+}
+
 export type Logger = pino.Logger;

--- a/test/fixtures/fatal-handler-fixture.ts
+++ b/test/fixtures/fatal-handler-fixture.ts
@@ -1,0 +1,35 @@
+// Spawned as a child process by test/utils/fatal-handlers.test.ts to exercise
+// the real process-level crash handlers installed by installFatalHandlers.
+// Run it in isolation (not via the test runner) so the uncaughtException /
+// unhandledRejection -> process.exit(1) path does not tear down bun:test.
+//
+// argv[2]: "uncaught" -> throw asynchronously; "unhandled" -> reject with an
+// Error; "unhandled-string" -> reject with a bare string (the non-Error path
+// that must still be redacted).
+import { installFatalHandlers } from "../../src/logger";
+
+installFatalHandlers("daemon");
+
+// Correctly-formatted GitHub installation token (ghs_ + 36 chars) so the
+// errSerializer redaction regex matches; a wrong length would not be scrubbed.
+const token = `ghs_${"A".repeat(36)}`;
+
+if (process.argv[2] === "unhandled") {
+  void Promise.reject(new Error(`rejected with ${token}`));
+} else if (process.argv[2] === "unhandled-string") {
+  // Non-Error rejection reason: errSerializer scrubs it only after coercion.
+  // Rejecting with a non-Error is the exact case under test, so the lint rule
+  // guarding against it is disabled here intentionally.
+  // eslint-disable-next-line prefer-promise-reject-errors, @typescript-eslint/prefer-promise-reject-errors
+  void Promise.reject(`rejected with string ${token}`);
+} else if (process.argv[2] === "unhandled-object") {
+  // Bare object with an opaque (non-ghs) secret under a sensitive key name:
+  // only scrubStructured (by field name) censors it, since the message regex
+  // does not match a non-pattern secret.
+  // eslint-disable-next-line prefer-promise-reject-errors, @typescript-eslint/prefer-promise-reject-errors
+  void Promise.reject({ headers: { authorization: "Bearer opaque-non-ghs-secret-XYZ" } });
+} else {
+  setImmediate(() => {
+    throw new Error(`boom with ${token}`);
+  });
+}

--- a/test/utils/fatal-handlers.test.ts
+++ b/test/utils/fatal-handlers.test.ts
@@ -1,0 +1,82 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const FIXTURE = resolve(import.meta.dir, "..", "fixtures", "fatal-handler-fixture.ts");
+
+// The fixture imports src/logger -> src/config, which validates env at import.
+// cwd is set to a directory without a .env so Bun does not autoload the repo's
+// local .env (which may set CLAUDE_PROVIDER=bedrock etc.); all required config
+// vars are passed explicitly. NODE_ENV is not "development", so the logger uses
+// the default destination (JSON to stdout), not the pino-pretty transport.
+type FixtureMode = "uncaught" | "unhandled" | "unhandled-string" | "unhandled-object";
+
+function runFixture(mode: FixtureMode): { exitCode: number; stdout: string } {
+  const proc = Bun.spawnSync(["bun", "run", FIXTURE, mode], {
+    cwd: "/tmp",
+    env: {
+      PATH: process.env["PATH"] ?? "",
+      NODE_ENV: "test",
+      CLAUDE_PROVIDER: "anthropic",
+      ANTHROPIC_API_KEY: "test-anthropic-key",
+      GITHUB_APP_ID: "test-app-id",
+      GITHUB_APP_PRIVATE_KEY: "test-private-key",
+      GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
+      DAEMON_AUTH_TOKEN: "test-daemon-token",
+      DATABASE_URL: "postgres://bot:bot@localhost:5432/x",
+      VALKEY_URL: "redis://localhost:6379",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: proc.exitCode ?? -1, stdout: proc.stdout.toString() };
+}
+
+function findFatalLine(stdout: string, kind: string): Record<string, unknown> | undefined {
+  for (const raw of stdout.trim().split("\n")) {
+    try {
+      const obj = JSON.parse(raw) as Record<string, unknown>;
+      if (obj["msg"] === kind) return obj;
+    } catch {
+      // non-JSON line (e.g. a config warning); skip.
+    }
+  }
+  return undefined;
+}
+
+describe("installFatalHandlers (#164)", () => {
+  const cases: readonly (readonly [FixtureMode, string])[] = [
+    ["uncaught", "uncaughtException"],
+    ["unhandled", "unhandledRejection"],
+    // Non-Error rejection reason: must still be redacted after coercion (#164).
+    ["unhandled-string", "unhandledRejection"],
+  ];
+
+  for (const [mode, kind] of cases) {
+    it(`emits a redacted fatal line and exits 1 on ${kind} (${mode})`, () => {
+      const { exitCode, stdout } = runFixture(mode);
+      expect(exitCode).toBe(1);
+
+      const line = findFatalLine(stdout, kind);
+      expect(line).toBeDefined();
+      // fatal level is 60, operators can alert on level:60 over a window.
+      expect(line?.["level"]).toBe(60);
+      expect(line?.["processName"]).toBe("daemon");
+
+      // The ghs_ token in the Error message must be scrubbed by errSerializer
+      // before it reaches stdout, the whole point of the crash handler.
+      expect(stdout).not.toContain(`ghs_${"A".repeat(36)}`);
+      expect(JSON.stringify(line)).toContain("[REDACTED_GITHUB_TOKEN]");
+    });
+  }
+
+  it("censors an opaque secret under a sensitive key in a bare-object rejection", () => {
+    const { exitCode, stdout } = runFixture("unhandled-object");
+    expect(exitCode).toBe(1);
+    const line = findFatalLine(stdout, "unhandledRejection");
+    expect(line).toBeDefined();
+    // scrubStructured censors the `authorization` value by field name before
+    // the object is flattened into the Error message.
+    expect(stdout).not.toContain("opaque-non-ghs-secret-XYZ");
+  });
+});


### PR DESCRIPTION
## What

Resolves #164. The pino logger (`src/logger.ts`) is the canonical secret-scrubbing chokepoint, but **neither entrypoint registered crash handlers**. An `uncaughtException` or `unhandledRejection` therefore fell to the runtime default handler — a plain `stderr` stack that bypasses `errSerializer`, so a `ghs_` token echoed inside an octokit error reached the log shipper in cleartext.

## Changes

- **`installFatalHandlers(processName)`** in `src/logger.ts`: registers `uncaughtException` + `unhandledRejection` handlers that log via `logger.fatal({ err, processName }, kind)` (applying `REDACT_PATHS` + `errSerializer`) then `process.exit(1)` with `level: 60`.
- **`toFatalError(reason)`**: coerces non-Error rejection reasons to an Error so the scrub runs, calling `scrubStructured` first so an opaque secret under a sensitive key (or a token in a string/object reason) is censored before it lands in the message. Falls back to `String()` for non-serialisable reasons.
- Wired into `src/app.ts` (orchestrator) and `src/daemon/main.ts` (daemon, early in `main()` so startup throws are caught).
- **Subprocess test** (`test/utils/fatal-handlers.test.ts` + fixture): covers `uncaughtException`, and Error / bare-string / bare-object rejections — asserts `level:60`, `processName`, redaction (`[REDACTED_GITHUB_TOKEN]` / censored field), and exit code 1.
- Docs: `observability.md` Log-redaction section now documents the crash path.

## Judgement call: did NOT use `pino.final` (deviation from the issue's proposal)

The proposed fix was `pino.destination({ sync: false })` + `pino.final`. I deviated, with empirical evidence verified under Bun:

1. **`pino.final` throws when the logger has a `transport`** — this repo sets `transport: pino-pretty` in development, so wrapping with it would crash the dev process at registration. The plain-`logger.fatal` version runs cleanly in dev (exit 1, line still redacted via pino-pretty).
2. **`pino.final` is unnecessary for flush**: plain `logger.fatal({err}) + process.exit(1)` flushes the JSON line to stdout before exit, because the default SonicBoom destination flushes synchronously on the process `exit` event (verified 8/8 runs).
3. So I also did **not** switch to `sync: false` — an orthogonal perf/reliability change (async logs can drop on SIGKILL) not needed for this security fix.

Net: crash logs pass through the redaction chokepoint in **both** production and development modes, without `pino.final`'s transport footgun.

## Verification

- `typecheck`, `eslint .` (0 errors), `prettier --check`, `check:no-em-dashes`, `check:docs-citations` → clean.
- `bun test test/utils/fatal-handlers.test.ts` → 4 pass; `logger.test.ts` → 16 pass (no regression).
- Senior-review gate: 3 iterations (found + fixed a HIGH non-Error-rejection leak and a LOW object-rejection gap), converged clean. CodeRabbit unavailable this run (org out of credits), so senior-review is the quality gate.

## Follow-up (out of scope)

`src/mcp/servers/*.ts` use `console.error` (subprocesses without the daemon config), a different fix shape — left as a separate follow-up, as the research note itself flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
