### PR TITLE
feat(observability): log octokit rate-limit headers via hook.after

### DIFF
--- a/docs/operate/observability.md
+++ b/docs/operate/observability.md
@@ -49,6 +49,18 @@ The crash path is covered too. `installFatalHandlers(processName)` in `src/logge
 | `pipeline.completed` | Success terminal line; carries `pipeline_wall_clock_ms` alongside the existing cost/turn fields.                                                                                                       |
 | `pipeline.failed`    | Failure terminal line; carries `pipeline_wall_clock_ms` + the redacted `err`.                                                                                                                          |
 
+## GitHub API rate-limit fields
+
+The `App` is constructed with `ObservableOctokit` (`src/utils/octokit-observability.ts`), an `Octokit.plugin` subclass shared by `app.octokit` and every installation octokit. It logs GitHub's per-installation rate-limit headers via `octokit.hook.after` / `hook.error`. The `pipeline.stage`-style strict Zod schema (`GithubApiLogFieldsSchema`) pins the field shape.
+
+Volume policy: the per-request line is `debug` (default `info` stays quiet on a fleet issuing thousands of calls/hour); a `warn` fires only when quota runs low or a rate-limit error lands. Set `LOG_LEVEL=debug` for full per-call visibility, no separate sampling knob.
+
+| `event`                         | Level | Fields                                                                                                        |
+| ------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------- |
+| `github.api.request`            | debug | `route`, `status`, `rate_limit_limit`, `rate_limit_remaining`, `rate_limit_reset_in_s`, `rate_limit_resource` |
+| `github.api.rate_limit_low`     | warn  | Same fields; emitted once `rate_limit_remaining` drops below `RATE_LIMIT_LOW_WATER` (500).                    |
+| `github.api.rate_limit_warning` | warn  | `route`, `status`, `retry_after_s`; on a 429 or 403 secondary-rate-limit response.                            |
+
 ## Ship workflow log fields
 
 The shepherding lifecycle emits structured pino lines validated against the canonical Zod schema in `src/workflows/ship/log-fields.ts`. Field names and types are pinned so emitters cannot drift.

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,7 @@ import {
 } from "./orchestrator/ws-server";
 import { createScheduler, type SchedulerHandle } from "./scheduler";
 import type { BotContext } from "./types";
+import { ObservableOctokit } from "./utils/octokit-observability";
 import { handleCheckRun } from "./webhook/events/check-run";
 import { handleCheckSuite } from "./webhook/events/check-suite";
 import { handleIssueComment } from "./webhook/events/issue-comment";
@@ -81,6 +82,9 @@ const app = new App({
   appId: config.appId,
   privateKey: config.privateKey,
   webhooks: { secret: config.webhookSecret },
+  // Log GitHub rate-limit headers on every octokit response (issue #170);
+  // covers app.octokit + all installation octokits via the shared subclass.
+  Octokit: ObservableOctokit,
 });
 
 // All three actions are subscribed so the chat-thread cache write-through

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,7 +46,7 @@ import {
 } from "./orchestrator/ws-server";
 import { createScheduler, type SchedulerHandle } from "./scheduler";
 import type { BotContext } from "./types";
-import { ObservableOctokit } from "./utils/octokit-observability";
+import { observableOctokit } from "./utils/octokit-observability";
 import { handleCheckRun } from "./webhook/events/check-run";
 import { handleCheckSuite } from "./webhook/events/check-suite";
 import { handleIssueComment } from "./webhook/events/issue-comment";
@@ -84,7 +84,7 @@ const app = new App({
   webhooks: { secret: config.webhookSecret },
   // Log GitHub rate-limit headers on every octokit response (issue #170);
   // covers app.octokit + all installation octokits via the shared subclass.
-  Octokit: ObservableOctokit,
+  Octokit: observableOctokit(),
 });
 
 // All three actions are subscribed so the chat-thread cache write-through

--- a/src/orchestrator/connection-handler.ts
+++ b/src/orchestrator/connection-handler.ts
@@ -5,6 +5,7 @@ import { config } from "../config";
 import { resolveGithubToken } from "../core/github-token";
 import { clearInFlightByJobId } from "../db/queries/scheduled-actions-store";
 import { logger } from "../logger";
+import { ObservableOctokit } from "../utils/octokit-observability";
 import { addReaction } from "../utils/reactions";
 import { findById, findInflightByOwner, type WorkflowRunRow } from "../workflows/runs-store";
 import { setState } from "../workflows/tracking-mirror";
@@ -93,7 +94,12 @@ function getOrCreateApp(): InstanceType<typeof App> {
   if (config.appId === undefined || config.privateKey === undefined) {
     throw new Error("getOrCreateApp requires GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY");
   }
-  cachedApp = new App({ appId: config.appId, privateKey: config.privateKey });
+  cachedApp = new App({
+    appId: config.appId,
+    privateKey: config.privateKey,
+    // Rate-limit observability on app.octokit + installation octokits (#170).
+    Octokit: ObservableOctokit,
+  });
   return cachedApp;
 }
 

--- a/src/orchestrator/connection-handler.ts
+++ b/src/orchestrator/connection-handler.ts
@@ -5,7 +5,7 @@ import { config } from "../config";
 import { resolveGithubToken } from "../core/github-token";
 import { clearInFlightByJobId } from "../db/queries/scheduled-actions-store";
 import { logger } from "../logger";
-import { ObservableOctokit } from "../utils/octokit-observability";
+import { observableOctokit } from "../utils/octokit-observability";
 import { addReaction } from "../utils/reactions";
 import { findById, findInflightByOwner, type WorkflowRunRow } from "../workflows/runs-store";
 import { setState } from "../workflows/tracking-mirror";
@@ -98,7 +98,7 @@ function getOrCreateApp(): InstanceType<typeof App> {
     appId: config.appId,
     privateKey: config.privateKey,
     // Rate-limit observability on app.octokit + installation octokits (#170).
-    Octokit: ObservableOctokit,
+    Octokit: observableOctokit(),
   });
   return cachedApp;
 }

--- a/src/utils/octokit-observability.ts
+++ b/src/utils/octokit-observability.ts
@@ -1,0 +1,147 @@
+/**
+ * GitHub API rate-limit observability (issue #170).
+ *
+ * GitHub returns per-installation rate-limit context on every response
+ * (`x-ratelimit-*`) and `Retry-After` on 429 / 403 secondary-limit responses.
+ * The bot dropped all of it: no `App` constructor installed an
+ * `octokit.hook.after("request", ...)` listener, so quota state was invisible.
+ *
+ * `installRateLimitHooks` wires two hooks onto an Octokit instance; passing
+ * `Octokit.plugin(installRateLimitHooks)` as the `App`'s `Octokit` option makes
+ * both `app.octokit` (JWT calls) and every `getInstallationOctokit()` inherit
+ * them (verified against octokit v5: the `Octokit` option enriches all octokits
+ * the App creates).
+ *
+ * Volume policy: the per-request line is emitted at `debug` so default `info`
+ * logging stays quiet (a busy installation issues thousands of calls/hour). A
+ * `warn` fires only when `remaining` crosses `RATE_LIMIT_LOW_WATER` or on a
+ * rate-limit error, which is the operational signal. `LOG_LEVEL=debug` turns on
+ * full per-call visibility without a separate sampling knob.
+ */
+import { Octokit } from "octokit";
+import { z } from "zod";
+
+import { logger } from "../logger";
+
+/** Emit a `rate_limit_low` warn once remaining drops below this floor. */
+export const RATE_LIMIT_LOW_WATER = 500;
+
+export const GITHUB_API_LOG_EVENTS = {
+  request: "github.api.request",
+  rateLimitLow: "github.api.rate_limit_low",
+  rateLimitWarning: "github.api.rate_limit_warning",
+} as const;
+
+/**
+ * `.strict()` shape for the GitHub-API observability lines, so an emitter that
+ * adds an unpinned field or mistypes one trips the co-located test.
+ */
+export const GithubApiLogFieldsSchema = z
+  .object({
+    event: z.enum([
+      GITHUB_API_LOG_EVENTS.request,
+      GITHUB_API_LOG_EVENTS.rateLimitLow,
+      GITHUB_API_LOG_EVENTS.rateLimitWarning,
+    ]),
+    route: z.string().min(1),
+    status: z.number().int(),
+    rate_limit_limit: z.number().int().nonnegative().optional(),
+    rate_limit_remaining: z.number().int().nonnegative().optional(),
+    rate_limit_reset_in_s: z.number().int().optional(),
+    rate_limit_resource: z.string().min(1).optional(),
+    retry_after_s: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export type GithubApiLogFields = z.infer<typeof GithubApiLogFieldsSchema>;
+
+type Headers = Record<string, string | number | undefined>;
+
+function intHeader(headers: Headers, name: string): number | undefined {
+  // octokit lowercases response header keys; values arrive as strings.
+  // eslint-disable-next-line security/detect-object-injection -- name is a hardcoded header key from this module, not user input
+  const raw = headers[name];
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}
+
+/**
+ * Build the structured rate-limit fields from a response, or null when the
+ * response carried no `x-ratelimit-remaining` header (not all endpoints do).
+ * Pure: the hook only logs what this returns, so the decision logic is unit
+ * testable without spinning up octokit.
+ */
+export function rateLimitFields(
+  status: number,
+  headers: Headers,
+  route: string,
+  nowSeconds: number,
+): GithubApiLogFields | null {
+  const remaining = intHeader(headers, "x-ratelimit-remaining");
+  if (remaining === undefined) return null;
+  const limit = intHeader(headers, "x-ratelimit-limit");
+  const reset = intHeader(headers, "x-ratelimit-reset");
+  const resource = headers["x-ratelimit-resource"];
+  return {
+    event:
+      remaining < RATE_LIMIT_LOW_WATER
+        ? GITHUB_API_LOG_EVENTS.rateLimitLow
+        : GITHUB_API_LOG_EVENTS.request,
+    route,
+    status,
+    ...(limit !== undefined ? { rate_limit_limit: limit } : {}),
+    rate_limit_remaining: remaining,
+    ...(reset !== undefined ? { rate_limit_reset_in_s: reset - nowSeconds } : {}),
+    ...(typeof resource === "string" ? { rate_limit_resource: resource } : {}),
+  };
+}
+
+/**
+ * Octokit plugin: log GitHub rate-limit context on every response and warn on
+ * rate-limit errors. Use via `Octokit.plugin(installRateLimitHooks)`.
+ */
+export function installRateLimitHooks(octokit: Pick<Octokit, "hook">): void {
+  octokit.hook.after("request", (response, options) => {
+    const route = `${options.method} ${options.url}`;
+    const fields = rateLimitFields(
+      response.status,
+      response.headers as Headers,
+      route,
+      Math.floor(Date.now() / 1000),
+    );
+    if (fields === null) return;
+    if (fields.event === GITHUB_API_LOG_EVENTS.rateLimitLow) {
+      logger.warn(fields, "GitHub API rate limit low");
+    } else {
+      logger.debug(fields, "GitHub API request completed");
+    }
+  });
+
+  octokit.hook.error("request", (error, options) => {
+    const err = error as { status?: number; response?: { headers?: Headers } };
+    const status = err.status;
+    const retryAfter = intHeader(err.response?.headers ?? {}, "retry-after");
+    // 429, or 403 secondary-rate-limit (which carries Retry-After).
+    if (status === 429 || (status === 403 && retryAfter !== undefined)) {
+      const fields: GithubApiLogFields = {
+        event: GITHUB_API_LOG_EVENTS.rateLimitWarning,
+        route: `${options.method} ${options.url}`,
+        status,
+        ...(retryAfter !== undefined ? { retry_after_s: retryAfter } : {}),
+      };
+      logger.warn(fields, "GitHub API rate limit hit");
+    }
+    // Preserve behaviour: the hook only observes, the caller still sees the error.
+    throw error;
+  });
+}
+
+/**
+ * Octokit subclass with the rate-limit hooks pre-installed. Pass as the `App`'s
+ * `Octokit` option so `app.octokit` and every `getInstallationOctokit()` inherit
+ * the observability hooks from a single shared class.
+ */
+export const ObservableOctokit = Octokit.plugin((octokit) => {
+  installRateLimitHooks(octokit);
+});

--- a/src/utils/octokit-observability.ts
+++ b/src/utils/octokit-observability.ts
@@ -137,11 +137,20 @@ export function installRateLimitHooks(octokit: Pick<Octokit, "hook">): void {
   });
 }
 
+let observableOctokitClass: typeof Octokit | undefined;
+
 /**
  * Octokit subclass with the rate-limit hooks pre-installed. Pass as the `App`'s
  * `Octokit` option so `app.octokit` and every `getInstallationOctokit()` inherit
  * the observability hooks from a single shared class.
+ *
+ * Built lazily and memoised: importing this module must have no side effect, so
+ * a consumer (e.g. connection-handler) stays importable under a test that mocks
+ * the `octokit` module. The plugin subclass is created once on first call.
  */
-export const ObservableOctokit = Octokit.plugin((octokit) => {
-  installRateLimitHooks(octokit);
-});
+export function observableOctokit(): typeof Octokit {
+  observableOctokitClass ??= Octokit.plugin((octokit) => {
+    installRateLimitHooks(octokit);
+  });
+  return observableOctokitClass;
+}

--- a/test/orchestrator/connection-handler.test.ts
+++ b/test/orchestrator/connection-handler.test.ts
@@ -125,6 +125,11 @@ void mock.module("octokit", () => ({
   // shape so the import resolves under bun's mock.module.
   Octokit: class MockOctokit {
     constructor(public options: unknown) {}
+    // Real octokit `Octokit` exposes a static `plugin`; observableOctokit()
+    // (#170) calls it. Return the class so `new App({ Octokit })` stays valid.
+    static plugin() {
+      return MockOctokit;
+    }
   },
 }));
 

--- a/test/utils/octokit-observability.test.ts
+++ b/test/utils/octokit-observability.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  GITHUB_API_LOG_EVENTS,
+  GithubApiLogFieldsSchema,
+  ObservableOctokit,
+  RATE_LIMIT_LOW_WATER,
+  rateLimitFields,
+} from "../../src/utils/octokit-observability";
+
+// A fetch stub returning a fixed status/headers/body, so the hooks run against
+// a real octokit request pipeline without network. retry+throttle are disabled
+// so a 4xx does not trigger real backoff.
+function octokitWithFetch(status: number, headers: Record<string, string>, body: unknown) {
+  const fetch = (): Promise<Response> =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json", ...headers },
+      }),
+    );
+  return new ObservableOctokit({
+    auth: "test-token",
+    retry: { enabled: false },
+    throttle: { enabled: false },
+    request: { fetch },
+  });
+}
+
+const NOW_S = 1_000_000;
+
+describe("rateLimitFields (#170)", () => {
+  it("returns a request event with parsed quota when remaining is healthy", () => {
+    const f = rateLimitFields(
+      200,
+      {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4800",
+        "x-ratelimit-reset": String(NOW_S + 1800),
+        "x-ratelimit-resource": "core",
+      },
+      "GET /repos/{owner}/{repo}/issues",
+      NOW_S,
+    );
+    expect(f).not.toBeNull();
+    expect(f?.event).toBe(GITHUB_API_LOG_EVENTS.request);
+    expect(f?.rate_limit_limit).toBe(5000);
+    expect(f?.rate_limit_remaining).toBe(4800);
+    expect(f?.rate_limit_reset_in_s).toBe(1800);
+    expect(f?.rate_limit_resource).toBe("core");
+  });
+
+  it("flips to rate_limit_low once remaining drops below the floor", () => {
+    const f = rateLimitFields(
+      200,
+      { "x-ratelimit-remaining": String(RATE_LIMIT_LOW_WATER - 1) },
+      "GET /x",
+      NOW_S,
+    );
+    expect(f?.event).toBe(GITHUB_API_LOG_EVENTS.rateLimitLow);
+    expect(f?.rate_limit_remaining).toBe(RATE_LIMIT_LOW_WATER - 1);
+  });
+
+  it("treats exactly the floor as healthy (boundary)", () => {
+    const f = rateLimitFields(
+      200,
+      { "x-ratelimit-remaining": String(RATE_LIMIT_LOW_WATER) },
+      "GET /x",
+      NOW_S,
+    );
+    expect(f?.event).toBe(GITHUB_API_LOG_EVENTS.request);
+  });
+
+  it("returns null when the response carries no rate-limit headers", () => {
+    expect(
+      rateLimitFields(200, { "content-type": "application/json" }, "GET /x", NOW_S),
+    ).toBeNull();
+  });
+
+  it("omits optional fields when their headers are absent", () => {
+    const f = rateLimitFields(200, { "x-ratelimit-remaining": "100" }, "GET /x", NOW_S);
+    expect(f).not.toBeNull();
+    expect(f?.rate_limit_limit).toBeUndefined();
+    expect(f?.rate_limit_reset_in_s).toBeUndefined();
+    expect(f?.rate_limit_resource).toBeUndefined();
+  });
+});
+
+describe("GithubApiLogFieldsSchema (#170)", () => {
+  it("accepts a request line and a rate-limit-warning line", () => {
+    expect(
+      GithubApiLogFieldsSchema.safeParse({
+        event: GITHUB_API_LOG_EVENTS.request,
+        route: "GET /x",
+        status: 200,
+        rate_limit_remaining: 4800,
+      }).success,
+    ).toBe(true);
+    expect(
+      GithubApiLogFieldsSchema.safeParse({
+        event: GITHUB_API_LOG_EVENTS.rateLimitWarning,
+        route: "POST /x",
+        status: 429,
+        retry_after_s: 60,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an unknown field (strict pins drift)", () => {
+    expect(
+      GithubApiLogFieldsSchema.safeParse({
+        event: GITHUB_API_LOG_EVENTS.request,
+        route: "GET /x",
+        status: 200,
+        ratelimit_remaining: 4800, // typo'd field name
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("installRateLimitHooks contract (#170)", () => {
+  it("after-hook preserves the response (handler return value is ignored)", async () => {
+    const octokit = octokitWithFetch(
+      200,
+      { "x-ratelimit-limit": "5000", "x-ratelimit-remaining": "4999", "x-ratelimit-reset": "0" },
+      { login: "octocat" },
+    );
+    const res = await octokit.request("GET /user");
+    // If the after-hook dropped the response, status/data would be undefined.
+    expect(res.status).toBe(200);
+    expect((res.data as { login: string }).login).toBe("octocat");
+  });
+
+  it("error-hook rethrows so the caller still sees the error", async () => {
+    const octokit = octokitWithFetch(
+      429,
+      { "retry-after": "60" },
+      { message: "API rate limit exceeded" },
+    );
+    let caught: { status?: number } | undefined;
+    try {
+      await octokit.request("GET /user");
+    } catch (e) {
+      caught = e as { status?: number };
+    }
+    // If the error-hook had returned instead of rethrowing, the error would be
+    // swallowed and `caught` would stay undefined.
+    expect(caught?.status).toBe(429);
+  });
+});

--- a/test/utils/octokit-observability.test.ts
+++ b/test/utils/octokit-observability.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   GITHUB_API_LOG_EVENTS,
   GithubApiLogFieldsSchema,
-  ObservableOctokit,
+  observableOctokit,
   RATE_LIMIT_LOW_WATER,
   rateLimitFields,
 } from "../../src/utils/octokit-observability";
@@ -19,7 +19,7 @@ function octokitWithFetch(status: number, headers: Record<string, string>, body:
         headers: { "content-type": "application/json", ...headers },
       }),
     );
-  return new ObservableOctokit({
+  return new (observableOctokit())({
     auth: "test-token",
     retry: { enabled: false },
     throttle: { enabled: false },


### PR DESCRIPTION
## What

Resolves #170. GitHub returns per-installation rate-limit context on every response (`x-ratelimit-limit/remaining/reset/used/resource`, plus `Retry-After` on 429 / 403 secondary-limit). Both `App` constructors were bare — no `octokit.hook.after` listener — so quota state and rate-limit backoff were invisible (`grep -ri x-ratelimit src/` returned nothing).

## Changes

- **`src/utils/octokit-observability.ts`**: `installRateLimitHooks(octokit)` wires `hook.after` (rate-limit context) + `hook.error` (warn on 429 / 403-with-Retry-After, **rethrows** to preserve error propagation); a pure `rateLimitFields(...)` builder; a strict Zod `GithubApiLogFieldsSchema`; and `ObservableOctokit = Octokit.plugin(installRateLimitHooks)`.
- Wired `Octokit: ObservableOctokit` into **both** App constructors (`app.ts`, `connection-handler.ts`). Per octokit v5 the `Octokit` option enriches `app.octokit` **and** every `getInstallationOctokit()` (confirmed via docs + source), so all call sites inherit the hooks from one shared subclass — no per-site install, no double-registration.
- **`test/utils/octokit-observability.test.ts`**: parser cases (healthy/low/boundary/absent/optional-omission), strict-schema drift, and **two hook-contract tests** via a stubbed `request.fetch` — one asserting the after-hook preserves the response (status/data intact), one asserting the error-hook rethrows a 429.
- Docs: `observability.md` gains a "GitHub API rate-limit fields" section.

## Judgement calls

- **No `LOG_GITHUB_API_REQUESTS` sampling env var** (deviation from the proposal). Volume is controlled by reusing `LOG_LEVEL`: the per-request line is `debug` (silent at default `info` on a fleet issuing thousands of calls/hour); a `warn` fires only when `remaining` drops below `RATE_LIMIT_LOW_WATER` (500) or on a rate-limit error. Same volume control, zero new config surface.
- `installation_id` not logged (not cleanly available in the octokit hook); `route` (method + url) gives per-repo context and the headers are themselves per-installation.

## Verification

typecheck / eslint (0 errors) / prettier / em-dash / docs-citations clean. `test/utils/octokit-observability.test.ts` 9 pass (incl. hook contracts; no network, no backoff). Senior-review gate: 2 independent passes, both clean — the two critical octokit contracts (after-hook ignores handler return value; error-hook must rethrow) were verified against `before-after-hook` source + a live probe. CodeRabbit unavailable this run (org out of credits), so senior-review is the quality gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
