### PR TITLE
fix(agent-sdk): pass settingSources [] so SDK ignores cloned PR .claude/settings.json

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -266,6 +266,15 @@ export async function executeAgent({
     // single fat tracking-comment dump. Block it so the model uses the eager
     // tool list delivered in the SDK init message instead.
     disallowedTools: ["ToolSearch"],
+    // cwd is the cloned PR head (checkout.ts), which can carry an attacker's
+    // .claude/settings.json. Omitting settingSources makes the SDK load
+    // user/project/local filesystem settings by default (v0.3.x), so a
+    // SessionStart shell hook there would fire in this subprocess with the
+    // installation token in env, before any tool gate. Pin to [] to skip all
+    // three filesystem tiers (the managed-settings policy tier, which is
+    // operator-controlled and outside the cloned tree, is unaffected).
+    // Any new SDK option must not flip this back to a permissive value. See #191.
+    settingSources: [],
     mcpServers,
     systemPrompt:
       useCacheableLayout && promptParts !== undefined

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -446,3 +446,26 @@ describe("executeAgent: cacheable prompt layout", () => {
     expect(sp.append).toBeUndefined();
   });
 });
+
+// ─── filesystem settings isolation: settingSources [] (issue #191) ──────────
+// cwd is the cloned PR head (checkout.ts), which can carry an attacker's
+// .claude/settings.json. Omitting settingSources makes the SDK load
+// user/project/local filesystem settings by default, so a SessionStart shell
+// hook there would fire in this subprocess with the installation token in env,
+// before any tool gate. Deep equality (not just "defined") catches both removal
+// and a quiet flip to a permissive value like ["user"].
+
+describe("executeAgent: filesystem settings isolation", () => {
+  beforeEach(() => {
+    lastQueryCall = undefined;
+    nextIterator = emptyIterator;
+  });
+
+  it("passes settingSources [] so SDK ignores cwd .claude/settings.json", async () => {
+    await executeAgent(baseParams());
+
+    expect(lastQueryCall).toBeDefined();
+    const opts = lastQueryCall?.options as { settingSources?: string[] };
+    expect(opts.settingSources).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #191.

The Claude Agent SDK `query()` runs with `cwd` set to the **cloned PR working tree** (`src/core/checkout.ts` clones the PR head into `workDir`, and `src/core/executor.ts` passes `cwd: workDir`) but never passed `settingSources`. Per the SDK contract (`SettingSource = 'user' | 'project' | 'local'`, `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts`), omitting it loads **all three filesystem tiers by default**.

### Attack path closed
A fork PR from any GitHub user can ship a hostile `.claude/settings.json` with a `SessionStart` shell hook. The webhook router (`src/webhook/router.ts`) gates on `ALLOWED_OWNERS`, not PR author, so any maintainer comment triggers the bot on that PR. The hook fires in the CLI subprocess — which carries `GH_TOKEN`/`GITHUB_TOKEN` (App installation token) and `ANTHROPIC_*` creds in env — **before any tool gate**, bypassing every existing prompt-injection defense. This is a credential-exfil / RCE path against the daemon.

### Fix
Pin `settingSources: []` in the `queryOptions` object (`src/core/executor.ts`, beside the existing `disallowedTools: ["ToolSearch"]` idiom). This disables the user/project/local filesystem tiers, so a hostile `.claude/settings.json` is never loaded. The managed-settings policy tier (operator-controlled, outside the cloned tree) is unaffected.

## Changes
- `src/core/executor.ts` — add `settingSources: []` + comment documenting the attack path and a regression warning.
- `test/core/executor.test.ts` — new `executeAgent: filesystem settings isolation` test asserting `options.settingSources` deep-equals `[]` (catches both removal and a flip to a permissive value like `["user"]`).

## Verification
- New test is red without the fix (`Expected: [] / Received: undefined`), green with it.
- Executor suite: 18 pass / 0 fail (via `scripts/test-isolated.sh` harness). Typecheck clean; prettier clean; no em-dash.

## Deferred (defense-in-depth follow-ups, out of scope here)
Per the issue's suggested next steps 2/4/5: a CLAUDE.md security-invariant bullet, removing `.claude/` from `workDir` after checkout, and a periodic SDK call-site audit. These reduce the broader "untrusted tree at cwd" surface but are not required to close #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent subprocess configuration handling updated to explicitly exclude user-level, project-level, and local filesystem settings sources during query execution, while preserving existing behavior for prompt selection, tool configuration, environment handling, and timeout management.

* **Tests**
  * Added new test suite to verify that agent subprocess properly isolates configuration sources and correctly excludes local filesystem configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->