### PR TITLE
fix(testing): run colocated src/**/*.test.ts in CI + add drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
         # workflow from reintroducing the drift closed in issue #173.
         run: bun run check:runner-pins
 
+      - name: Test-glob drift guard
+        # Fails if any `*.test.ts` file is not reachable by the runner glob in
+        # scripts/test-isolated.sh, so a colocated test outside the globbed
+        # roots cannot go dark while CI stays green. See issue #201.
+        run: bun run check:test-globs
+
       - name: Docs-sync guard (bot workflows, FR-019)
         if: github.event_name == 'pull_request'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ GitHub-side auth defaults to the App installation token minted on demand from `G
 - Strict TypeScript: `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `useUnknownInCatchVariables`, etc.
 - Pre-commit hooks via Husky + lint-staged (auto-format + lint on staged files).
 - Conventional commits enforced via commitlint.
+- Test files live under `test/<mirror>/foo.test.ts` or colocated as `src/.../foo.test.ts`; both are CI-gated. The runner (`scripts/test-isolated.sh`) globs `test/**/*.test.ts src/**/*.test.ts`, and `bun run check:test-globs` (`scripts/check-test-globs.ts`) fails CI if any `*.test.ts` is not reachable by that glob set, so a colocated test cannot go dark while CI stays green (issue #201).
 
 ## CI/CD Pipeline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,10 @@ bun run test:watch        # re-run on file changes
 bun run test:coverage     # explicit coverage report (output in coverage/)
 ```
 
-Test files live in `test/` and mirror the `src/` directory structure.
+Test files live under `test/` mirroring the `src/` directory structure, or
+colocated as `src/.../foo.test.ts`. Both are CI-gated: the runner globs
+`test/**/*.test.ts src/**/*.test.ts`, and `bun run check:test-globs` fails CI
+if any `*.test.ts` is unreachable by that glob set.
 
 **Coverage threshold**: `bunfig.toml` enforces a per-file minimum of **90%
 lines and 90% functions** via Bun's native `coverageThreshold`. Any PR that

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "audit:ci": "bun run scripts/audit-ci.ts",
-    "check": "bun run typecheck && bun run lint && bun run format && bun run check:no-destructive && bun run check:no-em-dashes && bun run check:action-pins && bun run check:runner-pins && bun run check:docs-versions && bun run check:docs-citations && bun run test",
+    "check": "bun run typecheck && bun run lint && bun run format && bun run check:no-destructive && bun run check:no-em-dashes && bun run check:action-pins && bun run check:runner-pins && bun run check:test-globs && bun run check:docs-versions && bun run check:docs-citations && bun run test",
     "check:no-destructive": "bun run scripts/check-no-destructive-actions.ts",
     "check:no-em-dashes": "bun run scripts/em-dash-sweep.ts --check",
     "dev:daemon": "bash scripts/run-daemon.sh",
@@ -79,6 +79,7 @@
     "check:docs-citations": "bun run scripts/check-docs-citations.ts",
     "check:action-pins": "bun run scripts/check-action-pins.ts",
     "check:runner-pins": "bun run scripts/check-runner-pins.ts",
+    "check:test-globs": "bun run scripts/check-test-globs.ts",
     "check:mcp-bundle": "bun run scripts/check-mcp-bundle.ts",
     "prepare": "husky"
   },

--- a/scripts/check-test-globs.ts
+++ b/scripts/check-test-globs.ts
@@ -31,9 +31,11 @@ const repoRoot =
   process.env["TEST_GLOBS_REPO_ROOT"] ?? resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const RUNNER_SCRIPT = join(repoRoot, "scripts", "test-isolated.sh");
 
-// Directories that never hold first-party test suites. `node_modules` and
-// `dist` would otherwise flood the scan with vendored / built `.test.ts`.
-const EXCLUDED_DIRS = ["node_modules", "dist", ".git", "coverage"];
+// Non-dot directories that never hold first-party test suites. `node_modules`
+// and `dist` would otherwise flood the scan with vendored / built `.test.ts`.
+// Dot-directories (`.git`, etc.) are pruned separately by the leading-dot rule
+// in collectTestFiles, mirroring bash's no-`dotglob` traversal.
+const EXCLUDED_DIRS = ["node_modules", "dist", "coverage"];
 
 // Extract the glob patterns from the runner's `tests=( ... )` array literal.
 // The runner is the source of truth for what CI actually executes. The match
@@ -50,10 +52,16 @@ function runnerGlobs(scriptPath: string): string[] {
         "Update this guard if the runner moved or duplicated its glob source of truth.",
     );
   }
-  return (matches[0]?.[1] ?? "")
-    .split(/\s+/)
-    .map((s) => s.trim().replace(/^["']|["']$/g, ""))
-    .filter((s) => s.length > 0 && !s.startsWith("#"));
+  const globs: string[] = [];
+  for (const raw of (matches[0]?.[1] ?? "").split(/\s+/)) {
+    const tok = raw.trim().replace(/^["']|["']$/g, "");
+    // Bash recognises an inline `#` comment inside the array literal; once one
+    // starts, the rest of the line is comment, not globs. Stop, do not just
+    // drop the `#` token (which would keep the comment words as bogus globs).
+    if (tok.startsWith("#")) break;
+    if (tok.length > 0) globs.push(tok);
+  }
+  return globs;
 }
 
 // Convert a shell glob (`**`, `*`, literal segments) to an anchored RegExp
@@ -91,6 +99,11 @@ function collectTestFiles(absDir: string, relDir: string): string[] {
   const out: string[] = [];
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- repoRoot is the script's own tree or a test fixture
   for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    // Bash runs the glob without `dotglob`, so the runner never matches a
+    // leading-dot path component (dir or file). Mirror that: a `.test.ts` under
+    // a dot-path is not runner-reachable and is out of scope for this guard.
+    // This also covers `.git` without listing it in EXCLUDED_DIRS.
+    if (entry.name.startsWith(".")) continue;
     const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
     if (entry.isDirectory()) {
       if (EXCLUDED_DIRS.includes(entry.name)) continue;

--- a/scripts/check-test-globs.ts
+++ b/scripts/check-test-globs.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+/**
+ * CI guard: every `*.test.ts` file in the repo is reachable by the test
+ * runner's glob set. `bun run test` shells out to `scripts/test-isolated.sh`,
+ * which runs each match of a hard-coded glob in its own Bun process (per-file
+ * isolation is required because `mock.module()` is process-global and bleeds
+ * across files). A test file that lives outside the globbed roots is never
+ * executed, yet CI stays green because the runner only inspects files it
+ * already matched. The scheduler PR (#159) widened that dark spot from 1 to 4
+ * colocated test files under src/ without anyone noticing. See issue #201.
+ *
+ * This guard derives the glob set from `scripts/test-isolated.sh` itself (the
+ * single source of truth), enumerates every `*.test.ts` under the repo, and
+ * fails if any file is not matched by at least one runner glob. Tying the
+ * check to the actual runner line means narrowing the runner glob, or adding a
+ * test file under a new root, both trip the guard instead of silently going
+ * dark. Same defensive shape as `check-action-pins.ts` / `check-runner-pins.ts`.
+ *
+ * Exit 0 when every test file is covered, 1 otherwise with a per-file report
+ * on stderr.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `TEST_GLOBS_REPO_ROOT` env override exists solely so the test suite can
+// point the gate at a fixture tree without copying the script. Production
+// invocations leave it unset and resolve `repoRoot` from the script's own
+// location.
+const repoRoot =
+  process.env["TEST_GLOBS_REPO_ROOT"] ?? resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const RUNNER_SCRIPT = join(repoRoot, "scripts", "test-isolated.sh");
+
+// Directories that never hold first-party test suites. `node_modules` and
+// `dist` would otherwise flood the scan with vendored / built `.test.ts`.
+const EXCLUDED_DIRS = ["node_modules", "dist", ".git", "coverage"];
+
+// Extract the glob patterns from the runner's `tests=( ... )` array literal.
+// The runner is the source of truth for what CI actually executes. The match
+// is anchored to a line-start assignment and required to be unique, so a
+// commented-out or documented `tests=( ... )` example cannot shadow the live
+// line and silently become the source of truth.
+function runnerGlobs(scriptPath: string): string[] {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- constant path under repoRoot
+  const src = readFileSync(scriptPath, "utf-8");
+  const matches = [...src.matchAll(/^[ \t]*tests=\(([^)]*)\)/gm)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one top-level \`tests=( ... )\` glob array in ${scriptPath}, found ${String(matches.length)}. ` +
+        "Update this guard if the runner moved or duplicated its glob source of truth.",
+    );
+  }
+  return (matches[0]?.[1] ?? "")
+    .split(/\s+/)
+    .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+    .filter((s) => s.length > 0 && !s.startsWith("#"));
+}
+
+// Convert a shell glob (`**`, `*`, literal segments) to an anchored RegExp
+// matching a POSIX-style relative path. `**/` matches zero or more directories;
+// a lone `*` stays within a single path segment.
+function globToRegExp(glob: string): RegExp {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i] ?? "";
+    if (c === "*") {
+      if ((glob[i + 1] ?? "") === "*") {
+        i++;
+        if ((glob[i + 1] ?? "") === "/") {
+          i++;
+          re += "(?:.*/)?";
+        } else {
+          re += ".*";
+        }
+      } else {
+        re += "[^/]*";
+      }
+    } else if ("/.+?()[]{}^$|\\".includes(c)) {
+      re += "\\" + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp("^" + re + "$");
+}
+
+// Enumerate every `*.test.ts` under the repo as forward-slash paths relative to
+// `root`, pruning vendored / built directories before descending so the scan
+// never materialises the whole of node_modules.
+function collectTestFiles(absDir: string, relDir: string): string[] {
+  const out: string[] = [];
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- repoRoot is the script's own tree or a test fixture
+  for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+    const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.includes(entry.name)) continue;
+      out.push(...collectTestFiles(join(absDir, entry.name), rel));
+    } else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const matchers = runnerGlobs(RUNNER_SCRIPT).map(globToRegExp);
+  const uncovered = collectTestFiles(repoRoot, "").filter(
+    (f) => !matchers.some((re) => re.test(f)),
+  );
+
+  if (uncovered.length === 0) {
+    console.log("OK: every `*.test.ts` file is reachable by the test-runner glob set");
+    return;
+  }
+
+  console.error(
+    `ERROR: ${String(uncovered.length)} test file(s) not matched by any glob in scripts/test-isolated.sh:\n`,
+  );
+  for (const f of uncovered) {
+    console.error(`  - ${f}`);
+  }
+  console.error(
+    "\nThese files never run in CI. Fix: widen the `tests=( ... )` glob in\n" +
+      "scripts/test-isolated.sh to cover their root, e.g. add `src/**/*.test.ts`.",
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/test-isolated.sh
+++ b/scripts/test-isolated.sh
@@ -9,9 +9,9 @@ passed=0
 failed=0
 failures=()
 
-tests=(test/**/*.test.ts)
+tests=(test/**/*.test.ts src/**/*.test.ts)
 if (( ${#tests[@]} == 0 )); then
-  echo "No test files matched test/**/*.test.ts" >&2
+  echo "No test files matched test/**/*.test.ts or src/**/*.test.ts" >&2
   exit 1
 fi
 

--- a/test/scripts/check-test-globs.test.ts
+++ b/test/scripts/check-test-globs.test.ts
@@ -176,4 +176,35 @@ describe("scripts/check-test-globs.ts", () => {
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain("found 2");
   });
+
+  it("ignores a bash inline comment inside the tests=( ... ) array", () => {
+    // `tests=( ... # note)` is a comment in bash; the words after `#` must not
+    // become bogus globs that mark every file uncovered.
+    const root = mkdtempSync(join(tmpdir(), "check-test-globs-"));
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    mkdirSync(join(root, "test"), { recursive: true });
+    writeFileSync(
+      join(root, "scripts", "test-isolated.sh"),
+      "#!/usr/bin/env bash\ntests=(test/**/*.test.ts # widened for #201)\n",
+    );
+    writeFileSync(join(root, "test", "foo.test.ts"), "");
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
+
+  it("does not flag test files under dot-paths the runner cannot reach", () => {
+    // Bash globs run without dotglob, so a `.test.ts` under a dot-dir or a
+    // dot-prefixed filename is never runner-reachable; the guard mirrors that
+    // and leaves them out of scope rather than falsely reporting coverage.
+    const root = makeFixture({
+      runnerGlobs: "test/**/*.test.ts",
+      testFiles: ["test/foo.test.ts", "test/.hidden/x.test.ts", "test/.dotfile.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
 });

--- a/test/scripts/check-test-globs.test.ts
+++ b/test/scripts/check-test-globs.test.ts
@@ -1,0 +1,179 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+const SCRIPT = resolve(import.meta.dir, "..", "..", "scripts", "check-test-globs.ts");
+
+interface Fixture {
+  runnerGlobs: string;
+  testFiles: string[];
+}
+
+// Build a throwaway repo tree: a `scripts/test-isolated.sh` carrying the given
+// `tests=( ... )` glob line, plus empty `*.test.ts` files at the given paths.
+function makeFixture({ runnerGlobs, testFiles }: Fixture): string {
+  const root = mkdtempSync(join(tmpdir(), "check-test-globs-"));
+  const scriptsDir = join(root, "scripts");
+  mkdirSync(scriptsDir, { recursive: true });
+  writeFileSync(
+    join(scriptsDir, "test-isolated.sh"),
+    `#!/usr/bin/env bash\ntests=(${runnerGlobs})\n`,
+  );
+  for (const rel of testFiles) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, "");
+  }
+  return root;
+}
+
+function runScript(repoRoot: string): { exitCode: number; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(["bun", "run", SCRIPT], {
+    env: { ...process.env, TEST_GLOBS_REPO_ROOT: repoRoot },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: proc.stdout.toString(),
+    stderr: proc.stderr.toString(),
+  };
+}
+
+const fixtures: string[] = [];
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const f = fixtures.pop();
+    if (f !== undefined) rmSync(f, { recursive: true, force: true });
+  }
+});
+
+describe("scripts/check-test-globs.ts", () => {
+  it("exits 0 when every test file is covered by the runner globs", () => {
+    const root = makeFixture({
+      runnerGlobs: "test/**/*.test.ts src/**/*.test.ts",
+      testFiles: ["test/foo.test.ts", "test/nested/bar.test.ts", "src/scheduler/baz.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
+
+  it("exits 1 and names a test file living outside the globbed roots", () => {
+    // This is the issue #201 shape: runner globs only `test/`, a colocated
+    // `src/**/*.test.ts` is silently dark.
+    const root = makeFixture({
+      runnerGlobs: "test/**/*.test.ts",
+      testFiles: ["test/foo.test.ts", "src/scheduler/due-evaluator.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("1 test file(s) not matched");
+    expect(stderr).toContain("src/scheduler/due-evaluator.test.ts");
+    // A covered file must not be reported.
+    expect(stderr).not.toContain("test/foo.test.ts");
+  });
+
+  it("ignores test files under excluded dirs at top level and nested", () => {
+    const root = makeFixture({
+      runnerGlobs: "test/**/*.test.ts",
+      testFiles: [
+        "test/foo.test.ts",
+        // top-level excluded dirs (startsWith branch)
+        "node_modules/some-dep/index.test.ts",
+        "dist/build-output.test.ts",
+        ".git/hooks/x.test.ts",
+        "coverage/lcov-report/y.test.ts",
+        // nested excluded dir (monorepo-style), pruned at the boundary
+        "packages/x/node_modules/dep/z.test.ts",
+      ],
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
+
+  it("reports every uncovered file and the plural count", () => {
+    const root = makeFixture({
+      runnerGlobs: "test/**/*.test.ts",
+      testFiles: ["test/foo.test.ts", "src/a.test.ts", "src/scheduler/b.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("2 test file(s) not matched");
+    expect(stderr).toContain("src/a.test.ts");
+    expect(stderr).toContain("src/scheduler/b.test.ts");
+  });
+
+  it("a lone * does not cross directory boundaries", () => {
+    // `test/*.test.ts` must cover only flat files, not nested ones. This locks
+    // the `[^/]*` single-segment semantics the guard relies on.
+    const root = makeFixture({
+      runnerGlobs: "test/*.test.ts",
+      testFiles: ["test/flat.test.ts", "test/nested/deep.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("test/nested/deep.test.ts");
+    expect(stderr).not.toContain("test/flat.test.ts");
+  });
+
+  it("a bare ** (no trailing slash) spans directories", () => {
+    // Exercises the `**` -> `.*` branch (vs `**/` -> `(?:.*/)?`).
+    const root = makeFixture({
+      runnerGlobs: "src/**",
+      testFiles: ["src/scheduler/due-evaluator.test.ts"],
+    });
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
+
+  it("errors when the runner script has no tests=( ... ) glob array", () => {
+    const root = mkdtempSync(join(tmpdir(), "check-test-globs-"));
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    writeFileSync(join(root, "scripts", "test-isolated.sh"), "#!/usr/bin/env bash\necho noop\n");
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("found 0");
+  });
+
+  it("skips a commented-out example and parses the live glob line", () => {
+    // The live line covers src/, a commented narrow example must not win.
+    const root = mkdtempSync(join(tmpdir(), "check-test-globs-"));
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    mkdirSync(join(root, "src", "scheduler"), { recursive: true });
+    writeFileSync(
+      join(root, "scripts", "test-isolated.sh"),
+      "#!/usr/bin/env bash\n# tests=(test/**/*.test.ts)\ntests=(test/**/*.test.ts src/**/*.test.ts)\n",
+    );
+    writeFileSync(join(root, "src", "scheduler", "c.test.ts"), "");
+    fixtures.push(root);
+    const { exitCode, stdout } = runScript(root);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK: every `*.test.ts` file is reachable");
+  });
+
+  it("errors when more than one tests=( ... ) array is present", () => {
+    // A commented/duplicated example must not silently shadow the live line.
+    const root = mkdtempSync(join(tmpdir(), "check-test-globs-"));
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    writeFileSync(
+      join(root, "scripts", "test-isolated.sh"),
+      "#!/usr/bin/env bash\ntests=(test/**/*.test.ts)\ntests=(src/**/*.test.ts)\n",
+    );
+    fixtures.push(root);
+    const { exitCode, stderr } = runScript(root);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("found 2");
+  });
+});


### PR DESCRIPTION
## What

Fixes #201. The CI test runner `scripts/test-isolated.sh` globbed only
`test/**/*.test.ts`, so 4 colocated `src/**/*.test.ts` files never ran in CI
while `bun run test` stayed green (the runner only inspects files it already
matched). The dark files cover security-sensitive surfaces: scheduler config
schema, cron due-evaluator, prompt resolver, and the orchestrator/daemon
WebSocket message schemas.

## Changes

- **`scripts/test-isolated.sh`** — widen the glob to
  `test/**/*.test.ts src/**/*.test.ts`; update the empty-match error message.
- **`scripts/check-test-globs.ts`** (new) — drift guard. Parses the
  `tests=( ... )` array from `test-isolated.sh` (single source of truth),
  enumerates every `*.test.ts` in the repo (pruning `node_modules`/`dist`/
  `.git`/`coverage` before descending), and exits non-zero listing any file
  not covered by the runner glob set. The `tests=(...)` parse is anchored to a
  line-start assignment and required to be unique, so a commented-out or
  duplicated example cannot shadow the live line.
- **`test/scripts/check-test-globs.test.ts`** (new) — 9 cases via the
  `TEST_GLOBS_REPO_ROOT` env-override + tmp-fixture pattern (mirrors
  `check-runner-pins.test.ts`): covered-pass, uncovered-fail, multi-uncovered
  count, top-level + nested exclusion (`.git`/`coverage` included), lone-`*`
  single-segment boundary, bare-`**` spanning, commented-example skip, and
  duplicate-array error.
- **`package.json`** — add `check:test-globs`; insert it into the `check`
  aggregate before `check:docs-versions`.
- **`.github/workflows/ci.yml`** — new "Test-glob drift guard" step after the
  runner-pin guard.
- **`CLAUDE.md` / `CONTRIBUTING.md`** — document the dual `test/`-or-colocated-
  `src/` layout, both CI-gated.

## Red → green

- `bun run check:test-globs` against the unfixed runner exited **1**, listing
  the 4 dark `src` files; after widening the glob it exits **0**.
- The 4 previously-dark `src` tests now execute and pass in the full isolated
  suite (`0 fail` each).

## Acceptance criteria (issue #201)

1. ✅ Runner executes all 4 colocated `src/**/*.test.ts` files.
2. ✅ Guard fails on any uncovered repo `*.test.ts`, derived from the runner
   (not hard-coded).
3. ✅ Guard wired into both `bun run check` and CI as its own step.
4. ✅ Guard has unit coverage proving fail-on-uncovered + pass-on-covered.
5. ✅ Dual layout documented (CLAUDE.md + CONTRIBUTING.md).

## Notes

- A pre-existing, unrelated dead guard (`check-no-destructive-actions.ts`
  crashes on a stale `SCAN_FILES` entry; not wired into CI) was found during
  this work and filed separately as #203 — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI validation step to ensure all test files are discoverable by the test runner, preventing tests from going unexecuted.

* **Documentation**
  * Updated testing guidelines with clarified test file locations and CI validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->