### PR TITLE
fix(mcp): wrap GitHub-touching MCP servers + state-fetchers in retryWithBackoff

### DIFF
--- a/docs/use/workflows/ship.md
+++ b/docs/use/workflows/ship.md
@@ -110,6 +110,8 @@ Some merge-readiness probe verdicts cannot be recovered by ship at iteration 0, 
 
 Other non-readiness reasons (`failing_checks`, `behind_base`, `pending_checks`, etc.) are recoverable by the iteration loop and stay on the normal path. The reroute set is defined as `SHIP_REROUTE_REASONS` in `src/workflows/ship/session-runner.ts`.
 
+The `chat-thread` executor's GitHub-state tool calls (CI rollup, check output, branch protection, PR diff/files, comments) go through `dispatchGithubStateTool`, whose fetchers wrap every octokit call in `retryWithBackoff`. A transient GitHub API blip (5xx, 429, or a secondary rate limit) is retried up to three times with exponential backoff and a deliveryId-correlated retry-warning log, instead of surfacing to the model as a tool error it would have to recover from semantically (issue #199).
+
 ## Re-triggering
 
 Re-applying the `bot:ship` label or re-commenting `bot:ship` on the same PR while a session is **active** is a no-op. Re-applying after the session is **terminal** starts a fresh session: the prior `ship_intents` row is preserved for audit.

--- a/src/github/state-fetchers.ts
+++ b/src/github/state-fetchers.ts
@@ -235,38 +235,45 @@ export async function getWorkflowRun(deps: GithubStateDeps, runId: number): Prom
 }
 
 export async function getBranchProtection(deps: GithubStateDeps, branch: string): Promise<string> {
-  try {
-    const result = await retryWithBackoff(
-      () =>
-        deps.octokit.rest.repos.getBranchProtection({
+  // A 404 means the branch is unprotected, an expected outcome, not a failure.
+  // Convert it to a `null` sentinel INSIDE the retried operation so the retry
+  // helper never sees it as an error: no spurious "non-retriable" warn log and
+  // no wasted attempt. Octokit RequestError carries `status` directly; that's
+  // more reliable than matching the message string (which varies by SDK version
+  // and locale). Genuine transient failures still propagate and retry.
+  const result = await retryWithBackoff(
+    async () => {
+      try {
+        return await deps.octokit.rest.repos.getBranchProtection({
           owner: deps.owner,
           repo: deps.repo,
           branch,
-        }),
-      { log: deps.log },
-    );
-    return serialize({
-      branch,
-      protected: true,
-      required_status_checks: result.data.required_status_checks ?? null,
-      required_pull_request_reviews: result.data.required_pull_request_reviews ?? null,
-      enforce_admins: result.data.enforce_admins?.enabled ?? false,
-      restrictions: result.data.restrictions ?? null,
-    });
-  } catch (err) {
-    // 404 is expected for unprotected branches, return a structured payload, not an error.
-    // Octokit RequestError carries `status` directly; that's more reliable than
-    // matching the message string (which varies by SDK version and locale).
-    if (
-      err !== null &&
-      typeof err === "object" &&
-      "status" in err &&
-      (err as { status: unknown }).status === 404
-    ) {
-      return serialize({ branch, protected: false });
-    }
-    throw err;
+        });
+      } catch (err) {
+        if (
+          err !== null &&
+          typeof err === "object" &&
+          "status" in err &&
+          (err as { status: unknown }).status === 404
+        ) {
+          return null;
+        }
+        throw err;
+      }
+    },
+    { log: deps.log },
+  );
+  if (result === null) {
+    return serialize({ branch, protected: false });
   }
+  return serialize({
+    branch,
+    protected: true,
+    required_status_checks: result.data.required_status_checks ?? null,
+    required_pull_request_reviews: result.data.required_pull_request_reviews ?? null,
+    enforce_admins: result.data.enforce_admins?.enabled ?? false,
+    restrictions: result.data.restrictions ?? null,
+  });
 }
 
 export async function getPrDiff(deps: GithubStateDeps, prNumber: number): Promise<string> {

--- a/src/github/state-fetchers.ts
+++ b/src/github/state-fetchers.ts
@@ -13,12 +13,22 @@
 import type { Octokit } from "octokit";
 
 import type { LLMTool, LLMToolCall, LLMToolResult } from "../ai/llm-client";
+import type { Logger } from "../logger";
+import { retryWithBackoff } from "../utils/retry";
 import { PROBE_QUERY } from "./queries";
 
 export interface GithubStateDeps {
   readonly octokit: Octokit;
   readonly owner: string;
   readonly repo: string;
+  /**
+   * Optional delivery-scoped logger. When provided it is passed to
+   * retryWithBackoff so transient-failure retry warnings carry the
+   * deliveryId binding; when omitted the retry helper logs via its
+   * config-free default. `import type` keeps this module config-free for
+   * the github-state MCP subprocess. See issue #199.
+   */
+  readonly log?: Logger;
 }
 
 const MAX_TEXT_BYTES = 60_000;
@@ -101,11 +111,15 @@ export async function getPrStateCheckRollup(
   deps: GithubStateDeps,
   prNumber: number,
 ): Promise<string> {
-  const data = await deps.octokit.graphql<ProbeQueryShape>(PROBE_QUERY, {
-    owner: deps.owner,
-    repo: deps.repo,
-    number: prNumber,
-  });
+  const data = await retryWithBackoff(
+    () =>
+      deps.octokit.graphql<ProbeQueryShape>(PROBE_QUERY, {
+        owner: deps.owner,
+        repo: deps.repo,
+        number: prNumber,
+      }),
+    { log: deps.log },
+  );
   const pr = data.repository?.pullRequest;
   if (pr === null || pr === undefined) {
     return serialize({ error: `PR #${prNumber} not found` });
@@ -166,11 +180,15 @@ export async function getCheckRunOutput(
   deps: GithubStateDeps,
   checkRunId: number,
 ): Promise<string> {
-  const result = await deps.octokit.rest.checks.get({
-    owner: deps.owner,
-    repo: deps.repo,
-    check_run_id: checkRunId,
-  });
+  const result = await retryWithBackoff(
+    () =>
+      deps.octokit.rest.checks.get({
+        owner: deps.owner,
+        repo: deps.repo,
+        check_run_id: checkRunId,
+      }),
+    { log: deps.log },
+  );
   const text = result.data.output.text ?? "";
   const truncated = truncate(text, MAX_CHECK_OUTPUT_BYTES);
   return serialize({
@@ -191,11 +209,15 @@ export async function getCheckRunOutput(
 }
 
 export async function getWorkflowRun(deps: GithubStateDeps, runId: number): Promise<string> {
-  const result = await deps.octokit.rest.actions.getWorkflowRun({
-    owner: deps.owner,
-    repo: deps.repo,
-    run_id: runId,
-  });
+  const result = await retryWithBackoff(
+    () =>
+      deps.octokit.rest.actions.getWorkflowRun({
+        owner: deps.owner,
+        repo: deps.repo,
+        run_id: runId,
+      }),
+    { log: deps.log },
+  );
   return serialize({
     id: result.data.id,
     name: result.data.name,
@@ -214,11 +236,15 @@ export async function getWorkflowRun(deps: GithubStateDeps, runId: number): Prom
 
 export async function getBranchProtection(deps: GithubStateDeps, branch: string): Promise<string> {
   try {
-    const result = await deps.octokit.rest.repos.getBranchProtection({
-      owner: deps.owner,
-      repo: deps.repo,
-      branch,
-    });
+    const result = await retryWithBackoff(
+      () =>
+        deps.octokit.rest.repos.getBranchProtection({
+          owner: deps.owner,
+          repo: deps.repo,
+          branch,
+        }),
+      { log: deps.log },
+    );
     return serialize({
       branch,
       protected: true,
@@ -244,12 +270,16 @@ export async function getBranchProtection(deps: GithubStateDeps, branch: string)
 }
 
 export async function getPrDiff(deps: GithubStateDeps, prNumber: number): Promise<string> {
-  const result = await deps.octokit.rest.pulls.get({
-    owner: deps.owner,
-    repo: deps.repo,
-    pull_number: prNumber,
-    mediaType: { format: "diff" },
-  });
+  const result = await retryWithBackoff(
+    () =>
+      deps.octokit.rest.pulls.get({
+        owner: deps.owner,
+        repo: deps.repo,
+        pull_number: prNumber,
+        mediaType: { format: "diff" },
+      }),
+    { log: deps.log },
+  );
   const diff = typeof result.data === "string" ? result.data : JSON.stringify(result.data);
   const { text, truncated } = truncate(diff, MAX_DIFF_BYTES);
   return serialize(
@@ -264,12 +294,16 @@ export async function getPrDiff(deps: GithubStateDeps, prNumber: number): Promis
 }
 
 export async function getPrFiles(deps: GithubStateDeps, prNumber: number): Promise<string> {
-  const result = await deps.octokit.rest.pulls.listFiles({
-    owner: deps.owner,
-    repo: deps.repo,
-    pull_number: prNumber,
-    per_page: 100,
-  });
+  const result = await retryWithBackoff(
+    () =>
+      deps.octokit.rest.pulls.listFiles({
+        owner: deps.owner,
+        repo: deps.repo,
+        pull_number: prNumber,
+        per_page: 100,
+      }),
+    { log: deps.log },
+  );
   return serialize({
     pr_number: prNumber,
     file_count: result.data.length,
@@ -290,13 +324,17 @@ export async function listPrComments(
   prNumber: number,
   page = 1,
 ): Promise<string> {
-  const result = await deps.octokit.rest.issues.listComments({
-    owner: deps.owner,
-    repo: deps.repo,
-    issue_number: prNumber,
-    per_page: 30,
-    page,
-  });
+  const result = await retryWithBackoff(
+    () =>
+      deps.octokit.rest.issues.listComments({
+        owner: deps.owner,
+        repo: deps.repo,
+        issue_number: prNumber,
+        per_page: 30,
+        page,
+      }),
+    { log: deps.log },
+  );
   const comments = result.data.map((c) => ({
     id: c.id,
     author: c.user?.login ?? "(unknown)",

--- a/src/mcp/servers/comment.ts
+++ b/src/mcp/servers/comment.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { Octokit } from "octokit";
 import { z } from "zod";
 
+import { retryWithBackoff } from "../../utils/retry";
 import { redactSecrets, sanitizeContent } from "../../utils/sanitize";
 import { createMcpLogger } from "../mcp-logger";
 
@@ -99,13 +100,19 @@ server.tool(
       const markerPrefix = `<!-- delivery:${DELIVERY_ID} -->`;
       const bodyWithMarker = `${markerPrefix}\n${guarded.body}`;
 
-      // Always use issues API -- tracking comment is created via issues.createComment
-      const result = await octokit.rest.issues.updateComment({
-        owner: REPO_OWNER,
-        repo: REPO_NAME,
-        comment_id: commentId,
-        body: bodyWithMarker,
-      });
+      // Always use issues API -- tracking comment is created via issues.createComment.
+      // Wrapped in retryWithBackoff so a transient 5xx/429/secondary-rate-limit
+      // does not drop a status update and leave a stale "Working..." comment (#199).
+      const result = await retryWithBackoff(
+        () =>
+          octokit.rest.issues.updateComment({
+            owner: REPO_OWNER,
+            repo: REPO_NAME,
+            comment_id: commentId,
+            body: bodyWithMarker,
+          }),
+        { log },
+      );
 
       return {
         content: [

--- a/src/mcp/servers/github-state.ts
+++ b/src/mcp/servers/github-state.ts
@@ -45,7 +45,9 @@ if (
 }
 
 const octokit = new Octokit({ auth: GITHUB_TOKEN });
-const deps = { octokit, owner: REPO_OWNER, repo: REPO_NAME } as const;
+// `log` carries the deliveryId binding into retryWithBackoff warnings emitted
+// by the fetchers on transient-failure retries (issue #199).
+const deps = { octokit, owner: REPO_OWNER, repo: REPO_NAME, log } as const;
 
 const server = new McpServer({
   name: "GitHub State Server",

--- a/src/mcp/servers/inline-comment.ts
+++ b/src/mcp/servers/inline-comment.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { Octokit } from "octokit";
 import { z } from "zod";
 
+import { retryWithBackoff } from "../../utils/retry";
 import { redactSecrets, sanitizeContent } from "../../utils/sanitize";
 import { createMcpLogger } from "../mcp-logger";
 
@@ -107,11 +108,15 @@ server.tool(
       // Get latest commit SHA if not provided
       let commitSha = commit_id;
       if (commitSha === undefined || commitSha === "") {
-        const pr = await octokit.rest.pulls.get({
-          owner: REPO_OWNER,
-          repo: REPO_NAME,
-          pull_number,
-        });
+        const pr = await retryWithBackoff(
+          () =>
+            octokit.rest.pulls.get({
+              owner: REPO_OWNER,
+              repo: REPO_NAME,
+              pull_number,
+            }),
+          { log },
+        );
         commitSha = pr.data.head.sha;
       }
 
@@ -133,7 +138,9 @@ server.tool(
         params.line = line;
       }
 
-      const result = await octokit.rest.pulls.createReviewComment(params);
+      const result = await retryWithBackoff(() => octokit.rest.pulls.createReviewComment(params), {
+        log,
+      });
 
       return {
         content: [

--- a/src/mcp/servers/merge-readiness.ts
+++ b/src/mcp/servers/merge-readiness.ts
@@ -4,6 +4,7 @@ import { Octokit } from "octokit";
 import { z } from "zod";
 
 import { PROBE_QUERY } from "../../github/queries";
+import { retryWithBackoff } from "../../utils/retry";
 import { computeVerdict, type ProbeResponseShape } from "../../workflows/ship/verdict";
 import { createMcpLogger } from "../mcp-logger";
 
@@ -76,11 +77,18 @@ server.tool(
   { pr_number: z.number().int().positive().describe("The pull request number") },
   async ({ pr_number }) => {
     try {
-      const response = await octokit.graphql<ProbeResponseShape>(PROBE_QUERY, {
-        owner: REPO_OWNER,
-        repo: REPO_NAME,
-        number: pr_number,
-      });
+      // Wrapped in retryWithBackoff so a single transient blip cannot flip the
+      // deterministic auto-merge gate to "not ready" and skip the merge until
+      // the next cron tick (#199).
+      const response = await retryWithBackoff(
+        () =>
+          octokit.graphql<ProbeResponseShape>(PROBE_QUERY, {
+            owner: REPO_OWNER,
+            repo: REPO_NAME,
+            number: pr_number,
+          }),
+        { log },
+      );
       // The probe fetches the first 100 review threads only, sufficient for
       // a scheduled action's own freshly-created PR. botPushedShas is empty:
       // a scheduled action tracks no prior pushes, so head-commit authorship

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -276,6 +276,9 @@ export async function triageRequest(input: TriageInput, client: LLMClient): Prom
   const breakerResult = await breaker.execute(async () => {
     if (useTools && input.octokit !== undefined && input.prNumber !== undefined) {
       const octokit = input.octokit;
+      // Delivery-correlated logger so the fetchers' retryWithBackoff warnings
+      // carry the deliveryId binding (#199).
+      const toolLog = logger.child({ deliveryId: input.deliveryId });
       const result = await withTimeout(
         runWithTools(client, {
           model: modelId,
@@ -285,7 +288,10 @@ export async function triageRequest(input: TriageInput, client: LLMClient): Prom
           tools: GITHUB_STATE_TOOLS,
           maxIterations: TRIAGE_MAX_TOOL_ITERATIONS,
           onToolCall: (call) =>
-            dispatchGithubStateTool({ octokit, owner: input.owner, repo: input.repo }, call),
+            dispatchGithubStateTool(
+              { octokit, owner: input.owner, repo: input.repo, log: toolLog },
+              call,
+            ),
         }),
         timeoutMs,
       );

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -34,8 +34,12 @@ export interface RetryOptions {
   initialDelayMs?: number;
   maxDelayMs?: number;
   backoffFactor?: number;
-  /** Optional scoped logger. Defaults to the root logger when omitted. */
-  log?: Logger;
+  /**
+   * Optional scoped logger. Defaults to the config-free default logger when
+   * omitted or `undefined` (the destructuring default below treats both the
+   * same), so callers can forward a maybe-undefined logger without a guard.
+   */
+  log?: Logger | undefined;
 }
 
 /**
@@ -108,8 +112,20 @@ export async function retryWithBackoff<T>(
 
       // Do not retry permanent client errors (4xx except 429 Too Many Requests).
       // Octokit wraps HTTP errors with a .status property; non-HTTP errors lack it.
+      // Exception: GitHub delivers a *secondary* rate limit as HTTP 403 (not 429)
+      // with a "secondary rate limit" body. A status-only check would misclassify
+      // it as a permanent permission error, so inspect the message and let a
+      // secondary rate limit fall through to the backoff path. A plain 403
+      // (no marker) still fails fast. See issue #199.
       const status = (error as { status?: number }).status;
-      if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+      const isSecondaryRateLimit = lastError.message.toLowerCase().includes("secondary rate limit");
+      if (
+        status !== undefined &&
+        status >= 400 &&
+        status < 500 &&
+        status !== 429 &&
+        !isSecondaryRateLimit
+      ) {
         log.warn({ attempt, status, err: lastError }, "Non-retriable error, throwing immediately");
         throw lastError;
       }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -112,22 +112,25 @@ export async function retryWithBackoff<T>(
 
       // Do not retry permanent client errors (4xx except 429 Too Many Requests).
       // Octokit wraps HTTP errors with a .status property; non-HTTP errors lack it.
-      // Exception: GitHub delivers a *secondary* rate limit as HTTP 403 (not 429)
-      // with a "secondary rate limit" body. A status-only check would misclassify
-      // it as a permanent permission error, so inspect the message and let a
-      // secondary rate limit fall through to the backoff path. A plain 403
-      // (no marker) still fails fast. See issue #199.
       const status = (error as { status?: number }).status;
-      const isSecondaryRateLimit = lastError.message.toLowerCase().includes("secondary rate limit");
-      if (
-        status !== undefined &&
-        status >= 400 &&
-        status < 500 &&
-        status !== 429 &&
-        !isSecondaryRateLimit
-      ) {
-        log.warn({ attempt, status, err: lastError }, "Non-retriable error, throwing immediately");
-        throw lastError;
+      if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+        // Exception: GitHub delivers a *secondary* rate limit as HTTP 403 (not
+        // 429) with a "secondary rate limit" body. A status-only check would
+        // misclassify it as a permanent permission error, so inspect the
+        // message and let a secondary rate limit fall through to the backoff
+        // path. A plain 403 (no marker) still fails fast. The message is
+        // inspected only inside this 4xx branch, so non-4xx errors skip the
+        // string work. See issue #199.
+        const isSecondaryRateLimit = lastError.message
+          .toLowerCase()
+          .includes("secondary rate limit");
+        if (!isSecondaryRateLimit) {
+          log.warn(
+            { attempt, status, err: lastError },
+            "Non-retriable error, throwing immediately",
+          );
+          throw lastError;
+        }
       }
 
       log.warn({ attempt, maxAttempts, err: lastError }, "Operation attempt failed");

--- a/src/workflows/ship/scoped/chat-thread.ts
+++ b/src/workflows/ship/scoped/chat-thread.ts
@@ -389,7 +389,10 @@ export async function runChatThread(input: RunChatThreadInput): Promise<RunChatT
   // tool-less: the tool surface is PR-scoped.
   let raw: string;
   const toolDispatch: LLMToolHandler = (call) =>
-    dispatchGithubStateTool({ octokit: input.octokit, owner: input.owner, repo: input.repo }, call);
+    dispatchGithubStateTool(
+      { octokit: input.octokit, owner: input.owner, repo: input.repo, log },
+      call,
+    );
   const toolsActive = input.targetType === "pr" && config.chatThreadToolsEnabled;
   const llmParams = toolsActive
     ? {

--- a/test/github/state-fetchers.test.ts
+++ b/test/github/state-fetchers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Octokit } from "octokit";
 
 import { dispatchGithubStateTool, GITHUB_STATE_TOOLS } from "../../src/github/state-fetchers";
+import { makeSilentLogger } from "../factories";
 
 interface FakeOctokitOptions {
   graphql?: (query: string, vars: unknown) => Promise<unknown>;
@@ -156,6 +157,30 @@ describe("dispatchGithubStateTool: happy paths", () => {
     );
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content)).toEqual({ branch: "feat-x", protected: false });
+  });
+
+  it("get_branch_protection on a 404 does not emit a retry warn log", async () => {
+    // The expected 404 (unprotected branch) is converted to a sentinel inside
+    // the retried operation, so the retry helper never sees it as an error and
+    // never logs a spurious "non-retriable" warning (#199 review).
+    const log = makeSilentLogger();
+    const octokit = fakeOctokit({
+      rest: {
+        repos: {
+          getBranchProtection: () => {
+            const err = new Error("Not Found") as Error & { status: number };
+            err.status = 404;
+            return Promise.reject(err);
+          },
+        },
+      },
+    });
+    const result = await dispatchGithubStateTool(
+      { octokit, ...repo, log },
+      { id: "x", name: "get_branch_protection", input: { branch: "feat-x" } },
+    );
+    expect(JSON.parse(result.content)).toEqual({ branch: "feat-x", protected: false });
+    expect(log.warn).not.toHaveBeenCalled();
   });
 
   it("get_pr_files passes through the listFiles result", async () => {

--- a/test/github/state-fetchers.test.ts
+++ b/test/github/state-fetchers.test.ts
@@ -207,7 +207,16 @@ describe("dispatchGithubStateTool: happy paths", () => {
     const octokit = fakeOctokit({
       rest: {
         repos: {
-          getBranchProtection: () => Promise.reject(new Error("HTTP 500 Server Error")),
+          getBranchProtection: () => {
+            // A non-retriable status (422) surfaces immediately as is_error.
+            // The fetchers now wrap calls in retryWithBackoff (#199), so a
+            // retriable status (5xx/429/network) would be retried first; that
+            // retry behaviour is covered in test/utils/retry.test.ts. Using a
+            // non-retriable status here keeps this surfacing test fast.
+            const err = new Error("Validation Failed") as Error & { status: number };
+            err.status = 422;
+            return Promise.reject(err);
+          },
         },
       },
     });
@@ -216,6 +225,6 @@ describe("dispatchGithubStateTool: happy paths", () => {
       { id: "x", name: "get_branch_protection", input: { branch: "main" } },
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("HTTP 500");
+    expect(result.content).toContain("Validation Failed");
   });
 });

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -92,6 +92,47 @@ describe("retryWithBackoff: 429 Too Many Requests (should retry)", () => {
   });
 });
 
+describe("retryWithBackoff: secondary rate limit (403, should retry)", () => {
+  // GitHub delivers a secondary rate limit as HTTP 403 (not 429) with a
+  // "secondary rate limit" body. A status-only 4xx check misclassifies it as
+  // a permanent permission error; the helper must inspect the message and
+  // retry. See issue #199.
+  it("retries a 403 whose message indicates a secondary rate limit", async () => {
+    let calls = 0;
+    const op = mock(() => {
+      calls++;
+      if (calls === 1) {
+        const err = new Error(
+          "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+        ) as Error & { status: number };
+        err.status = 403;
+        return Promise.reject(err);
+      }
+      return Promise.resolve("after-secondary-limit");
+    });
+    const result = await retryWithBackoff(op, {
+      maxAttempts: 3,
+      initialDelayMs: 1,
+      log: silentLog,
+    });
+    expect(result).toBe("after-secondary-limit");
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  // The negative case (a plain 403 permission error stays non-retriable) is
+  // covered by "does NOT retry on 403 Forbidden" above: its message has no
+  // "secondary rate limit" marker, so the message inspection does not fire.
+
+  it("still fails fast on a 403 whose message lacks the secondary-rate-limit marker", () => {
+    // A realistic permission error (longer message, no marker) must NOT be
+    // retried, locking the substring match against a future over-broad change.
+    const err = new Error("Resource not accessible by integration") as Error & { status: number };
+    err.status = 403;
+    const op = mock(() => Promise.reject(err));
+    return expectImmedateThrow(op, "Resource not accessible by integration", 1);
+  });
+});
+
 describe("retryWithBackoff: 5xx server errors (should retry)", () => {
   it("retries on 500 Internal Server Error", async () => {
     let calls = 0;


### PR DESCRIPTION
## What

Fixes #199. PR #189 retrofitted only `resolve-review-thread.ts` with `retryWithBackoff`. The other 4 GitHub-touching MCP servers and the shared `state-fetchers.ts` issued bare octokit calls, so a transient 5xx / 429 / secondary rate limit surfaced as `isError: true` and the agent had to retry semantically (burning model turns). For `check_merge_readiness` a single transient blip flipped the deterministic auto-merge gate to "not ready".

While wrapping, I found that the retry **predicate** (`retry.ts`) threw *any* 4xx except 429 immediately — so a GitHub **secondary** rate limit (delivered as HTTP **403** with a `secondary rate limit` body) was never retried, even by the canonical wrapped server. The predicate now retries it (message-based), while a plain permission-denied 403 still fails fast.

## Changes

- **`src/utils/retry.ts`** — retry a 4xx whose message contains `secondary rate limit`; relax `RetryOptions.log` to `Logger | undefined` so callers can forward a maybe-undefined logger (the destructuring default treats `undefined` as "use default logger").
- **`src/github/state-fetchers.ts`** — add optional `log` to `GithubStateDeps`; wrap all 7 octokit calls in `retryWithBackoff(() => …, { log: deps.log })`. Both the `github-state` MCP server and the inline `dispatchGithubStateTool` (triage, chat-thread) inherit.
- **`src/mcp/servers/comment.ts`** — wrap `issues.updateComment` (every tracking-comment update).
- **`src/mcp/servers/inline-comment.ts`** — wrap `pulls.get` + `pulls.createReviewComment`.
- **`src/mcp/servers/merge-readiness.ts`** — wrap the `PROBE_QUERY` graphql call (the auto-merge gate).
- **`src/mcp/servers/github-state.ts`** — plumb `createMcpLogger("github-state")` into deps.
- **`src/orchestrator/triage.ts`** + **`src/workflows/ship/scoped/chat-thread.ts`** — plumb a deliveryId-correlated `log` into the inline dispatch deps.

## Red → green

The secondary-rate-limit 403 test (`test/utils/retry.test.ts`) threw immediately (1 call) against the old predicate and retries (2 calls) after the fix. A negative test locks the boundary: a permission 403 (`Resource not accessible by integration`) still fails fast.

## Acceptance criteria (issue #199)

1. ✅ The 4 unconverted MCP servers wrap their octokit calls in `retryWithBackoff`.
2. ✅ `state-fetchers.ts` wraps all 7 calls; `GithubStateDeps` gains optional `log`; MCP + inline dispatch inherit retry with a deliveryId-correlated logger.
3. ✅ `retryWithBackoff` retries a secondary-rate-limit 403 (message-based); plain 403 still fails fast.
4. ✅ The github-state MCP bundle stays config-free (`check:mcp-bundle` green; `retry.ts` config-free, `Logger` imported type-only).
5. ✅ Quality gates pass (typecheck, lint, format, build, full suite — 0 genuine failures, 0 slow files).

## Notes

- Issue step 4 (audit non-MCP `octokit.rest.*` callers) is explicitly out of scope.
- `triage.ts` keeps default retry delays; its tool calls run inside an existing `withTimeout` + circuit breaker that bounds latency and falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transient GitHub API failures (5xx, 429, secondary rate limits) are now automatically retried up to three times with exponential backoff, improving reliability of PR operations and preventing loss of progress updates.

* **Bug Fixes**
  * GitHub secondary rate limit errors are now properly recognized and retried instead of failing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->