### PR TITLE
fix(security): set strictMcpConfig to block cloned-PR .mcp.json auto-load

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -276,6 +276,18 @@ export async function executeAgent({
     // Any new SDK option must not flip this back to a permissive value. See #191.
     settingSources: [],
     mcpServers,
+    // settingSources:[] gates settings.json / CLAUDE.md / hooks, but NOT a
+    // project `.mcp.json`: the CLI auto-discovers MCP servers by default (it is
+    // a distinct item from settings/memory in the `--bare` discovery list), so
+    // a hostile `.mcp.json` committed in the cloned PR tree at `cwd` would
+    // register a stdio MCP server whose `command` runs on connect under
+    // bypassPermissions, the same RCE primitive class as #191. The SDK maps
+    // this option to the CLI `--strict-mcp-config` flag, which restricts MCP
+    // loading to the `--mcp-config` set (our `mcpServers`), ignoring project
+    // `.mcp.json`. Verified against the agent-sdk arg construction + the CLI
+    // reference. See #196. The TS `strictMcpConfig` docstring only mentions
+    // validation strictness, but the flag it emits also suppresses discovery.
+    strictMcpConfig: true,
     systemPrompt:
       useCacheableLayout && promptParts !== undefined
         ? {

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -23,6 +23,10 @@ interface QueryCall {
     abortController?: AbortController;
     stderr?: (chunk: string) => void;
     systemPrompt?: unknown;
+    // Security pins asserted by the #196 / #191 regression tests.
+    strictMcpConfig?: boolean;
+    settingSources?: unknown[];
+    mcpServers?: unknown;
   };
 }
 

--- a/test/core/executor.test.ts
+++ b/test/core/executor.test.ts
@@ -105,6 +105,29 @@ function awaitAbortIterator(
   } as AsyncIterableIterator<unknown>;
 }
 
+describe("executeAgent: MCP config hardening (#196)", () => {
+  beforeEach(() => {
+    lastQueryCall = undefined;
+    nextIterator = emptyIterator;
+  });
+
+  it("sets strictMcpConfig so a cloned-PR .mcp.json is not auto-loaded, keeping the injected mcpServers", async () => {
+    // settingSources:[] does NOT gate project `.mcp.json` MCP discovery; the
+    // SDK maps strictMcpConfig -> the CLI `--strict-mcp-config` flag, which
+    // restricts MCP loading to the explicit `mcpServers` (--mcp-config) set.
+    const mcpServers = {
+      fake: { type: "stdio", command: "node", args: [] },
+    } as unknown as McpServerConfig;
+    await executeAgent(baseParams({ mcpServers }));
+
+    expect(lastQueryCall?.options.strictMcpConfig).toBe(true);
+    // The legitimately-injected servers must still be forwarded (criterion 2).
+    expect(lastQueryCall?.options.mcpServers).toBe(mcpServers);
+    // The #191 sibling pin stays in place.
+    expect(lastQueryCall?.options.settingSources).toEqual([]);
+  });
+});
+
 describe("executeAgent: cancellation", () => {
   beforeEach(() => {
     lastQueryCall = undefined;


### PR DESCRIPTION
## What

Closes #196. Follow-up to #191 / PR #195. That PR pinned `settingSources: []` to close the `.claude/settings.json` SessionStart-hook RCE in the cloned PR working tree. This closes the **sibling vector**: a hostile `.mcp.json` committed in the same tree.

## Determination (verified, not assumed)

`settingSources: []` does **not** gate project `.mcp.json` discovery:

1. The agent-sdk arg builder (`node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs`) maps `strictMcpConfig` → the CLI `--strict-mcp-config` flag, `mcpServers` → `--mcp-config`, and `settingSources` → `--setting-sources`.
2. The Claude Code CLI reference `--bare` flag ("skip auto-discovery of hooks, skills, plugins, **MCP servers**, auto memory, and CLAUDE.md") shows MCP servers are auto-discovered by default and are a **distinct** item from settings/memory (what `settingSources` controls).
3. `--strict-mcp-config` restricts MCP loading to the `--mcp-config` set, ignoring all other configuration including project `.mcp.json`.

So with `cwd` = the cloned PR tree + `permissionMode: bypassPermissions`, a hostile `.mcp.json` was auto-discovered and loaded — registering a stdio MCP server whose `command` runs on connect, the same RCE primitive class as #191.

## Fix

- **`src/core/executor.ts`** — add `strictMcpConfig: true` to `queryOptions`, next to the `settingSources: []` pin, with an inline comment recording the determination (the TS docstring only mentions validation, but the flag it emits also suppresses discovery).
- **`test/core/executor.test.ts`** — regression test: `options.strictMcpConfig === true`, the injected `mcpServers` are still forwarded (no-loss), and `settingSources` stays `[]`.

**No-loss**: the bot supplies all its MCP servers explicitly via `mcpServers`; it never relies on a project `.mcp.json`, so this keeps every legitimate server and blocks only the attacker-controlled file.

## Acceptance criteria

1. ✅ Determined: project `.mcp.json` at `cwd` IS auto-loaded independent of `settingSources: []`.
2. ✅ `strictMcpConfig: true` added with a regression test; injected `mcpServers` preserved.

## Out of scope (residual, operator-controlled, not cloned-tree)

`~/.claude.json`, plugin-provided, and MCPB-bundled MCP servers live in operator-controlled locations, not the attacker-controllable PR tree. Both cloned-tree attacker config classes (`settings.json`, `.mcp.json`) are now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server configuration controls to prevent unintended auto-registration from project files, ensuring only explicitly specified servers load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->