### PR TITLE
fix: patch three HIGH CVEs blocking orchestrator Trivy scan

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -6,8 +6,8 @@
 # Wired into CI via the `trivyignores:` input on aquasecurity/trivy-action
 # (see .github/workflows/docker-build.yml). The action does NOT auto-discover
 # this file: it is only read when passed explicitly. See:
-#   https://github.com/aquasecurity/trivy-action/blob/v0.35.0/action.yaml
-#   https://github.com/aquasecurity/trivy-action/blob/v0.35.0/entrypoint.sh
+#   https://github.com/aquasecurity/trivy-action/blob/v0.36.0/action.yaml
+#   https://github.com/aquasecurity/trivy-action/blob/v0.36.0/entrypoint.sh
 #
 # POLICY: every entry MUST have a `statement` explaining reachability and an
 # `expired_at` forcing a re-review. No permanent ignores. Scope each entry
@@ -16,92 +16,20 @@
 # Claude Code CLI later ships its own vulnerable copy).
 
 vulnerabilities:
-  # HIGH: picomatch ReDoS via crafted extglob patterns (`+(...)` / `*(...)`).
-  # Present at: /usr/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch@4.0.3
-  # Shipped by npm's bundled tinyglobby@0.2.15 dep. Fix floor: picomatch@4.0.4.
-  # npm@11 latest (11.12.1 as of 2026-04-12) has NOT yet released a version
-  # that rebundles tinyglobby with the patched picomatch: verified by
-  # inspecting the npm-11.12.1.tgz tarball on 2026-04-12.
+  # No active ignores.
   #
-  # Reachability: the npm CLI is not invoked by the runtime ENTRYPOINT
-  # (`bun run dist/app.js`). It runs only during image build under
-  # developer-controlled inputs (e.g. `npm install -g @anthropic-ai/claude-code`).
-  # The Claude Code CLI subprocess spawned at runtime loads its own bundled
-  # JavaScript directly via node and does not re-enter the npm CLI; if it
-  # needs picomatch it resolves to a different path outside `usr/lib/node_modules/npm/`,
-  # so this path-scoped ignore does not mask that copy.
+  # Retired 2026-06-30 (all expired AND fixed upstream, per each entry's own
+  # "delete when fixed" instruction):
+  #   - CVE-2026-33671 (picomatch ReDoS): npm@11.18.0 now bundles
+  #     tinyglobby@0.2.17 -> picomatch@4.0.4. The orchestrator image no longer
+  #     ships the vulnerable 4.0.3.
+  #   - CVE-2026-33810 / CVE-2026-32282 / CVE-2026-32280 (Go stdlib in the
+  #     static `docker` client copied from docker:29-cli): docker:29-cli now
+  #     ships Go 1.26.4 (>= the 1.26.2 fix floor).
   #
-  # Action: re-evaluate on 2026-05-12. If npm@11 has released an unbundled
-  # tinyglobby by then, delete this entry and let the CI gate reassert.
-  - id: CVE-2026-33671
-    paths:
-      - "usr/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch/package.json"
-    statement: >-
-      npm-bundled picomatch@4.0.3. npm@11.12.1 has not yet re-released
-      tinyglobby with the 4.0.4 fix. Not reachable from the runtime entrypoint;
-      npm CLI only runs at image build time under trusted inputs.
-    expired_at: 2026-05-12
-
-  # HIGH: Go stdlib CVEs in the static `docker` client binary copied from
-  # `docker:29.4.0-cli` (see Dockerfile:106, src/k8s/job-spawner.ts). Upstream
-  # Go has released 1.25.9 / 1.26.2 with the fixes, but the docker image has
-  # not yet been rebuilt: docker:29.4.0-cli pushed 2026-04-16 still ships
-  # Go 1.26.1. Verified via
-  # `docker run --rm docker:29.4.0-cli docker version --format '{{.Client.GoVersion}}'`.
-  #
-  # Short 2-week expiry because Docker typically rebuilds within ~1–2 weeks
-  # of a Go security release. When docker:29-cli has picked up Go 1.26.2+,
-  # delete these three entries and let the CI gate reassert.
-  #
-  # Reachability rationale applies to all three entries below:
-  # - The `docker` CLI in the runtime image is invoked **only inside
-  #   isolated-job pods** by the Claude agent against a dind sidecar at
-  #   `tcp://localhost:2375` (plain TCP, no TLS) for `docker build` /
-  #   `docker compose`. CVEs in crypto/x509 chain validation are not
-  #   exercised on that code path.
-  # - The only TLS code path is `docker login` against trusted public
-  #   registries (Docker Hub / GHCR) whose certificate chains are signed
-  #   by well-known public CAs we configure: no attacker-supplied
-  #   intermediates or wildcard SANs reach the CLI.
-  # - `os.Root.Chmod` (CVE-2026-32282) is not called by the docker CLI on
-  #   any agent-triggered flow; the isolated-job pod filesystem is not
-  #   writable by any external actor who could race a symlink replacement.
-
-  - id: CVE-2026-33810
-    paths:
-      - "usr/local/bin/docker"
-    statement: >-
-      Go 1.26.1 stdlib in docker:29.4.0-cli (crypto/x509 wildcard SAN case
-      bypass on excluded DNS constraints). Fix requires Go 1.26.2, docker
-      image lag. CLI's only TLS path is `docker login` against trusted public
-      registries, not attacker-supplied cert chains.
-    expired_at: 2026-05-23
-
-  - id: CVE-2026-32282
-    paths:
-      - "usr/local/bin/docker"
-    statement: >-
-      Go 1.26.1 stdlib in docker:29.4.0-cli (os.Root.Chmod symlink TOCTOU on
-      Linux). Fix in Go 1.25.9 / 1.26.2, docker image lag. docker CLI does
-      not invoke Root.Chmod on any agent-triggered flow; isolated-job pod
-      filesystem is not writable by any external attacker who could race a
-      symlink replacement.
-    expired_at: 2026-05-23
-
-  - id: CVE-2026-32280
-    paths:
-      - "usr/local/bin/docker"
-    statement: >-
-      Go 1.26.1 stdlib in docker:29.4.0-cli (crypto/x509 chain-building DoS
-      via unbounded intermediates). Fix in Go 1.25.9 / 1.26.2, docker image
-      lag. Only TLS path is `docker login` against trusted public
-      registries; no attacker-supplied intermediate certificate chains
-      reach x509 chain-building.
-    expired_at: 2026-05-23
-
   # NOTE: prior entries for CVE-2026-33672 (MEDIUM picomatch) and
   # CVE-2026-33750 (MEDIUM brace-expansion) were removed when
   # `limit-severities-for-sarif: true` was added in docker-build.yml. With
-  # that flag set the trivy-action now honors `severity: CRITICAL,HIGH` at
-  # the exit-code stage, so MEDIUMs are no longer blocking and the ignores
-  # were dead entries. If the severity filter is ever dropped, re-add them.
+  # that flag set the trivy-action honors `severity: CRITICAL,HIGH` at the
+  # exit-code stage, so MEDIUMs are no longer blocking. If the severity filter
+  # is ever dropped, re-add them.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -15,8 +15,9 @@
 # future occurrences of the same CVE in a different location (e.g. if the
 # Claude Code CLI later ships its own vulnerable copy).
 
-vulnerabilities:
-  # No active ignores.
+vulnerabilities: []
+  # No active ignores. Explicit empty list (not bare `vulnerabilities:`, which
+  # parses as null) so the key unambiguously represents "no ignores".
   #
   # Retired 2026-06-30 (all expired AND fixed upstream, per each entry's own
   # "delete when fixed" instruction):

--- a/bun.lock
+++ b/bun.lock
@@ -45,9 +45,12 @@
     "fast-uri": "3.1.2",
     "fast-xml-builder": "1.2.0",
     "flatted": "3.4.2",
+    "form-data": "4.0.6",
     "hono": "4.12.25",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
+    "protobufjs": "7.6.1",
+    "ws": "8.21.0",
     "yaml": "2.9.0",
   },
   "packages": {
@@ -341,7 +344,7 @@
 
     "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
 
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
 
     "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
 
@@ -721,7 +724,7 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -757,7 +760,7 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
@@ -961,7 +964,7 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
-    "protobufjs": ["protobufjs@7.6.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ=="],
+    "protobufjs": ["protobufjs@7.6.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -1125,7 +1128,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
@@ -1559,7 +1562,11 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "es-set-tostringtag/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 

--- a/package.json
+++ b/package.json
@@ -131,9 +131,12 @@
     "fast-uri": "3.1.2",
     "fast-xml-builder": "1.2.0",
     "flatted": "3.4.2",
+    "form-data": "4.0.6",
     "hono": "4.12.25",
     "path-to-regexp": "8.4.2",
     "picomatch": "4.0.4",
+    "protobufjs": "7.6.1",
+    "ws": "8.21.0",
     "yaml": "2.9.0"
   }
 }


### PR DESCRIPTION
## Summary

The release workflow's orchestrator Trivy scan (blocking, exit-code 1) failed on three newly published HIGH CVEs in transitive npm dependencies shipped inside `app/node_modules`. This PR pins all three to their patched versions via `package.json` `overrides`, deduplicates `bun.lock` to single fixed versions, and retires the four `.trivyignore.yaml` entries whose upstream fixes have now shipped, exactly as each entry's own "delete when fixed" comment instructed.

The daemon Trivy scan is non-blocking (`exit-code 0`) by design, so only the orchestrator leg failed.

## Diagram

```mermaid
flowchart TB
    classDef vuln fill:#922b21,color:#ffffff
    classDef safe fill:#1e8449,color:#ffffff
    classDef gate fill:#e67e22,color:#ffffff
    classDef clean fill:#1a5276,color:#ffffff
    classDef ovr fill:#ecf0f1,color:#2c3e50

    fd_b["form-data 4.0.5<br/>CVE-2026-12143 HIGH"]:::vuln
    pb_b["protobufjs 7.6.0<br/>CVE-2026-48712 HIGH"]:::vuln
    ws_b["ws 8.20.0<br/>CVE-2026-48779 HIGH"]:::vuln
    blk["Trivy orchestrator scan<br/>exit-code 1 - release BLOCKED"]:::gate

    ovrn["package.json overrides<br/>bun.lock deduped"]:::ovr
    fd_a["form-data 4.0.6"]:::safe
    pb_a["protobufjs 7.6.1"]:::safe
    ws_a["ws 8.21.0"]:::safe
    clr["Trivy orchestrator scan<br/>exit-code 0 - CLEAN"]:::clean

    fd_b --> blk
    pb_b --> blk
    ws_b --> blk
    fd_b -.->|pin via overrides| fd_a
    pb_b -.->|pin via overrides| pb_a
    ws_b -.->|pin via overrides| ws_a
    fd_a --> ovrn
    pb_a --> ovrn
    ws_a --> ovrn
    ovrn --> clr
```

## Changes

- **`package.json` overrides** — pin three transitive deps to patched versions:
  - `form-data`: 4.0.5 → 4.0.6 (fixes CVE-2026-12143)
  - `protobufjs`: 7.6.0 → 7.6.1 (fixes CVE-2026-48712). Stays on 7.x because its only consumer (`onnxruntime-web`) declares `^7.2.4`; 7.6.1 is the backported security fix on that branch.
  - `ws`: 8.20.0 → 8.21.0 (fixes CVE-2026-48779)
- **`bun.lock`** — deduped to single fixed versions for all three packages; `hasown` and `@protobufjs/eventemitter` minor bumps pulled in transitively.
- **`.trivyignore.yaml`** — retired all four expired entries (all past their `expired_at` date and fixed upstream):
  - CVE-2026-33671 (picomatch ReDoS): `npm@11.18.0` now bundles `tinyglobby@0.2.17` → `picomatch@4.0.4`; the vulnerable 4.0.3 is no longer in the orchestrator image.
  - CVE-2026-33810 / CVE-2026-32282 / CVE-2026-32280 (Go stdlib in the static `docker` client): `docker:29-cli` now ships Go 1.26.4, meeting the 1.26.2 fix floor for all three.
- **`.trivyignore.yaml` comment** — updated reference URLs from `trivy-action@v0.35.0` to `v0.36.0` to match the current pinned version in `docker-build.yml`.

## Test plan

- [x] Rebuilt orchestrator image locally; `docker:scan:orchestrator` exits 0 (clean, no HIGH/CRITICAL findings).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean (warnings only, pre-existing).
- [x] `bun run audit:ci` — clean (no high/critical findings).
- [x] `bun run check:no-em-dashes` — clean.
- [x] `bun run check:docs-sync` — clean (no source/doc drift introduced).
- [x] `bun test` — pass/fail counts identical to clean-main baseline (failures are pre-existing/environmental).
- [x] Daemon image scan (non-blocking, exit-code 0) — unaffected.
